### PR TITLE
Find straights by shifting and masking

### DIFF
--- a/src/core/rank.rs
+++ b/src/core/rank.rs
@@ -388,6 +388,22 @@ mod tests {
         let h = Hand::new_from_str("2d3d4d5d6h7cAd").unwrap();
         assert_eq!(Rank::StraightFlush(0), h.rank_seven());
     }
+    #[test]
+    fn test_rank_seven_straights() {
+        let straights = ["2h3c4s5d6dTsKh",
+                         "3c4s5d6d7hTsKh",
+                         "4s5d6d7h8cTsKh",
+                         "5c6c7h8h9dAhAd",
+                         "6c7c8h9hTsKc6s",
+                         "7c8h9hTsKc6sJh",
+                         "8h9hTsQc6sJhAs",
+                         "9hTsQc6sJhKsKc",
+                         "TsQc6sJhKsAc5h"];
+        for (idx, s) in straights.iter().enumerate() {
+            assert_eq!(Rank::Straight(idx as u32 + 1),
+                       Hand::new_from_str(s).unwrap().rank_seven());
+        }
+    }
 
     #[test]
     fn test_rank_seven_four_kind() {

--- a/src/core/rank.rs
+++ b/src/core/rank.rs
@@ -36,42 +36,41 @@ const WHEEL: u32 = 0b1000000001111;
 /// Returns None if the hand ranks represented don't correspond
 /// to a straight.
 fn rank_straight(value_set: u32) -> Option<u32> {
-    // Check to see if this is the wheel. It's pretty unlikely.
-    if value_set & WHEEL == WHEEL {
+    // Example of something with a straight:
+    //       0000111111100
+    //       0001111111000
+    //       0011111110000
+    //       0111111100000
+    //       1111111000000
+    //       -------------
+    //       0000111000000
+    //
+    // So there were seven ones in a row
+    // we removed the bottom 4.
+    //
+    // Now an example of an almost straight:
+    //
+    //       0001110111100
+    //       0011101111000
+    //       0111011110000
+    //       1110111100000
+    //       1101111000000
+    //       -------------
+    //       0000000000000
+    let left = value_set & (value_set << 1) & (value_set << 2) & (value_set << 3) &
+               (value_set << 4);
+    //
+    // Now count the leading 0's
+    let idx = left.leading_zeros();
+    // If this isn't all zeros then we found a straight
+    if idx < 32 {
+        return Some(32 - 4 - idx);
+    } else if value_set & WHEEL == WHEEL {
+        // Check to see if this is the wheel. It's pretty unlikely.
         return Some(0);
     } else {
-        // Example of something with a straight:
-        //       0000111111100
-        //       0001111111000
-        //       0011111110000
-        //       0111111100000
-        //       1111111000000
-        //       -------------
-        //       0000111000000
-        //
-        // So there were seven ones in a row
-        // we removed the bottom 4.
-        //
-        // Now an example of an almost straight:
-        //
-        //       0001110111100
-        //       0011101111000
-        //       0111011110000
-        //       1110111100000
-        //       1101111000000
-        //       -------------
-        //       0000000000000
-        let left = value_set & (value_set << 1) & (value_set << 2) & (value_set << 3) &
-                   (value_set << 4);
-        //
-        // Now count the leading 0's
-        let idx = left.leading_zeros();
-        // If this isn't all zeros then we found a straight
-        if idx < 32 {
-            return Some(32 - 4 - idx);
-        }
+        None
     }
-    None
 }
 /// Keep only the most signifigant bit.
 fn keep_highest(rank: u32) -> u32 {
@@ -403,6 +402,13 @@ mod tests {
             assert_eq!(Rank::Straight(idx as u32 + 1),
                        Hand::new_from_str(s).unwrap().rank_seven());
         }
+    }
+
+
+    #[test]
+    fn test_rank_seven_find_best_with_wheel() {
+        let h = Hand::new_from_str("6dKdAd2d5d4d3d").unwrap();
+        assert_eq!(Rank::StraightFlush(1), h.rank_seven());
     }
 
     #[test]


### PR DESCRIPTION
Rather than finding the straights by shifting a mask. Shift the values to see if there are 5 ones in a row. Then if there were 5 ones in a row, find out if where they are by finding the location of the leading one.