### PR TITLE
Use fixed bitset to report winning hand in monte carlo games.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 rand = "0.7.3"
-fixedbitset = "0.3.1"
+fixedbitset = "0.4.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/game.rs
+++ b/benches/game.rs
@@ -16,7 +16,7 @@ fn simulate_one_game(c: &mut Criterion) {
 
     c.bench_function("Simulate AdAh vs 2c2s", move |b| {
         b.iter(|| {
-            let r = g.simulate().expect("There should be one best rank.");
+            let r = g.simulate();
             g.reset();
             r
         })

--- a/examples/game_simulate.rs
+++ b/examples/game_simulate.rs
@@ -25,9 +25,9 @@ fn main() {
         MonteCarloGame::new_with_hands(hands, board).expect("Should be able to create a game.");
     let mut wins: [u64; 2] = [0, 0];
     for _ in 0..2_000_000 {
-        let r = g.simulate().expect("There should be one best rank.");
+        let r = g.simulate();
         g.reset();
-        wins[r.0] += 1
+        wins[r.0.ones().next().unwrap()] += 1
     }
     println!("Wins = {:?}", wins);
 }


### PR DESCRIPTION
This should fix #19

Report a bitset for which index won.