### PR TITLE
perf: dont use heap alocated bitsets for player active sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,18 +483,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8.4"
-fixedbitset = "0.4.0"
-thiserror = "1.0"
-serde = { version = "1.0", optional = true, features = ["derive"] }
+rand = "0.8.5"
+fixedbitset = "0.4.2"
+thiserror = "1.0.40"
+serde = { version = "1.0.162", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1682392122,
-        "narHash": "sha256-czFFXzZ88LP1cBAk9nNo6Y3tefxbW+Zg18co5yWlN9Y=",
+        "lastModified": 1683272394,
+        "narHash": "sha256-4XQZbSZ8XYAeASpr0Er8mNPnjbYLJwvaB+VyH+bt6DE=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "d72795ee51634b8c5bcf6b3bc98d08ec5888d191",
+        "rev": "50bed3ba4066e6255dab434dc845e7f655812ce1",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1681680516,
-        "narHash": "sha256-EB8Adaeg4zgcYDJn9sR6UMjN/OHdIiMMK19+3LmmXQY=",
+        "lastModified": 1683134812,
+        "narHash": "sha256-yUiArtneEBCTYt7rOg/tLr1iv4AmjFu5tdGa0OVpjbo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "54b63c8eae4c50172cb50b612946ff1d2bc1c75c",
+        "rev": "8708b19627b2dfc2d1ac332b74383b8abdd429f0",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1682490133,
-        "narHash": "sha256-tR2Qx0uuk97WySpSSk4rGS/oH7xb5LykbjATcw1vw1I=",
+        "lastModified": 1683354017,
+        "narHash": "sha256-r0BrHDaljUKyQS5FgA4P9xgK+dGa8L0XDL0vBdriEM8=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "4e9412753ab75ef0e038a5fe54a062fb44c27c6a",
+        "rev": "65fdcbdc0bf35510a013d8a0883b0fa7a4ecd2a8",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682109806,
-        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
+        "lastModified": 1683392273,
+        "narHash": "sha256-pZTuxvcuDeBG+vvE1zczNyEUzlPbzXVh8Ed45Fzo+tQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
+        "rev": "16b3b0c53b1ee8936739f8c588544e7fcec3fc60",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680488274,
-        "narHash": "sha256-0vYMrZDdokVmPQQXtFpnqA2wEgCCUXf5a3dDuDVshn0=",
+        "lastModified": 1683080331,
+        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7ec2ff598a172c6e8584457167575b3a1a5d80d8",
+        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
         "type": "github"
       },
       "original": {

--- a/src/holdem/monte_carlo_game.rs
+++ b/src/holdem/monte_carlo_game.rs
@@ -1,6 +1,4 @@
-use fixedbitset::FixedBitSet;
-
-use crate::core::*;
+use crate::{core::*, utils::PlayerBitSet};
 
 /// Current state of a game.
 #[derive(Debug)]
@@ -60,7 +58,7 @@ impl MonteCarloGame {
     ///
     /// This will fill out the board and then return the tuple
     /// of which hand had the best rank in end.
-    pub fn simulate(&mut self) -> (FixedBitSet, Rank) {
+    pub fn simulate(&mut self) -> (PlayerBitSet, Rank) {
         self.shuffle_if_needed();
 
         let community_start_idx = self.current_offset;
@@ -76,22 +74,19 @@ impl MonteCarloGame {
 
         // Now get the best rank of all the possible hands.
         self.hands.iter().map(|h| h.rank()).enumerate().fold(
-            (
-                FixedBitSet::with_capacity(self.hands.len()),
-                Rank::HighCard(0),
-            ),
+            (PlayerBitSet::default(), Rank::HighCard(0)),
             |(mut found, max_rank), (idx, rank)| {
                 match rank.cmp(&max_rank) {
                     std::cmp::Ordering::Equal => {
                         // If this is a tie then add the index.
-                        found.set(idx, true);
+                        found.enable(idx);
                         (found, rank)
                     }
                     std::cmp::Ordering::Greater => {
-                        // If this is the higest then reset all the bitset that's 1's
+                        // If this is the higest then reset all the bitset
                         // Then set only the current hand's index as true
-                        found.clear();
-                        found.set(idx, true);
+                        found = PlayerBitSet::default();
+                        found.enable(idx);
                         (found, rank)
                     }
                     // Otherwise keep what we've already found.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ pub mod core;
 /// The holdem specific code. This contains range
 /// parsing, game state, and starting hand code.
 pub mod holdem;
+/// A module with structs tuned for fast poker simulation.
+/// These are not general use structs, as bit sizes are assumed
+/// be good for poker.
+pub mod utils;
 
 /// Given a tournament calculate the implied
 /// equity in the total tournament.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,2 @@
+mod player_bit_set;
+pub use player_bit_set::{ActivePlayerBitSetIter, PlayerBitSet};

--- a/src/utils/player_bit_set.rs
+++ b/src/utils/player_bit_set.rs
@@ -1,0 +1,146 @@
+use std::ops::BitOr;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PlayerBitSet {
+    set: u16,
+}
+
+impl PlayerBitSet {
+    pub fn new(players: usize) -> Self {
+        let set = (1 << players) - 1;
+        Self { set }
+    }
+    pub fn count(&self) -> usize {
+        self.set.count_ones() as usize
+    }
+    pub fn empty(&self) -> bool {
+        self.set == 0
+    }
+    pub fn enable(&mut self, idx: usize) {
+        self.set |= 1 << idx;
+    }
+    pub fn disable(&mut self, idx: usize) {
+        self.set &= !(1 << idx);
+    }
+    pub fn get(&self, idx: usize) -> bool {
+        (self.set & (1 << idx)) != 0
+    }
+    pub fn ones(self) -> ActivePlayerBitSetIter {
+        ActivePlayerBitSetIter { set: self.set }
+    }
+}
+
+impl BitOr for PlayerBitSet {
+    type Output = PlayerBitSet;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self {
+            set: self.set | rhs.set,
+        }
+    }
+}
+
+pub struct ActivePlayerBitSetIter {
+    set: u16,
+}
+
+impl Iterator for ActivePlayerBitSetIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.set == 0 {
+            None
+        } else {
+            // Find the index of the first non-zero
+            let idx = self.set.trailing_zeros() as usize;
+            // Then set the first non-zero to zero
+            self.set &= !(1 << idx);
+            // Then emit the next one
+            Some(idx)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_count() {
+        assert_eq!(7, PlayerBitSet::new(7).count());
+    }
+
+    #[test]
+    fn test_default_zero_count() {
+        assert_eq!(0, PlayerBitSet::default().count());
+    }
+
+    #[test]
+    fn test_disable_count() {
+        let mut s = PlayerBitSet::new(7);
+
+        assert_eq!(7, s.count());
+        s.disable(6);
+        assert_eq!(6, s.count());
+        s.disable(0);
+        assert_eq!(5, s.count());
+    }
+
+    #[test]
+    fn test_enable_count() {
+        let mut s = PlayerBitSet::default();
+
+        assert_eq!(0, s.count());
+        s.enable(0);
+        assert_eq!(1, s.count());
+        s.enable(0);
+        assert_eq!(1, s.count());
+
+        s.enable(2);
+        assert_eq!(2, s.count());
+
+        s.disable(0);
+        assert_eq!(1, s.count());
+    }
+
+    #[test]
+    fn test_iter() {
+        let s = PlayerBitSet::new(2);
+        let mut iter = s.ones();
+
+        assert_eq!(Some(0), iter.next());
+        assert_eq!(Some(1), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn test_iter_with_disabled() {
+        let mut s = PlayerBitSet::new(3);
+        let mut iter = s.ones();
+
+        assert_eq!(Some(0), iter.next());
+        assert_eq!(Some(1), iter.next());
+        assert_eq!(Some(2), iter.next());
+        assert_eq!(None, iter.next());
+
+        s.disable(0);
+
+        let mut after_iter = s.ones();
+        assert_eq!(Some(1), after_iter.next());
+        assert_eq!(Some(2), after_iter.next());
+        assert_eq!(None, after_iter.next());
+    }
+
+    #[test]
+    fn test_iter_with_enabled() {
+        let mut s = PlayerBitSet::default();
+        let mut iter = s.ones();
+        assert_eq!(None, iter.next());
+
+        s.enable(3);
+
+        let mut after_iter = s.ones();
+        assert_eq!(Some(3), after_iter.next());
+        assert_eq!(None, after_iter.next());
+    }
+}


### PR DESCRIPTION
We know there aren't that many players at a table. Way below 16 (however sometimes above 8) so we can use a u16 as our storage type. Allowing no heap allocations, and fast bit twidling since we don't have the vec indirection.

- Add on a PlayerBitSet that's useful for keeping track of players doing something at a table.
- Changed arena to use this
- Changed monte carlo game simulation to use this