### PR TITLE
chore: add direnv scratch dir to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ perf.data*
 # I like nix but don't require
 # it for the open source project
 .envrc
+.direnv/


### PR DESCRIPTION
If you're using direnv we shouldn't add the scratch dir. So add the ignore here.