### PR TITLE
test: add a test to ensure bets call in GameState

### DIFF
--- a/src/arena/errors.rs
+++ b/src/arena/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum GameStateError {
     #[error("The ammount bet doesn't call the previous bet")]
     BetSizeDoesntCall,


### PR DESCRIPTION
Digging into #45 adding a tests to make sure that GameState rejects bad bets that don't call the previous.