### PR TITLE
fix: upate the simluation paramter ordering to match the name

### DIFF
--- a/benches/arena.rs
+++ b/benches/arena.rs
@@ -7,7 +7,6 @@ use rs_poker::arena::agent::RandomAgent;
 use rs_poker::arena::Agent;
 use rs_poker::arena::GameState;
 use rs_poker::arena::HoldemSimulation;
-use rs_poker::core::FlatDeck;
 
 const STARTING_STACK: i32 = 100_000;
 const SMALL_BLIND: i32 = 250;
@@ -25,8 +24,7 @@ fn run_one_arena(num_players: usize, percent_fold: f64, percent_call: f64) -> Ga
     let agents: Vec<Box<dyn Agent>> = (0..num_players)
         .map(|_| -> Box<dyn Agent> { Box::new(RandomAgent::new(percent_fold, percent_call)) })
         .collect();
-    let mut sim =
-        HoldemSimulation::new_with_agents_and_deck(game_state, FlatDeck::default(), agents);
+    let mut sim = HoldemSimulation::new_with_agents(game_state, agents);
     sim.run();
     sim.game_state
 }

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -96,7 +96,7 @@ mod tests {
             hand.push(deck.deal().unwrap());
         }
 
-        let mut sim = HoldemSimulation::new_with_agents_and_deck(game_state, deck, agents);
+        let mut sim = HoldemSimulation::new_with_agents_and_deck(game_state, agents, deck);
 
         sim.run();
 

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -50,13 +50,13 @@ impl HoldemSimulation {
         let mut flat_deck: FlatDeck = d.into();
         flat_deck.shuffle();
 
-        Self::new_with_agents_and_deck(game_state, flat_deck, agents)
+        Self::new_with_agents_and_deck(game_state, agents, flat_deck)
     }
 
     pub fn new_with_agents_and_deck(
         game_state: GameState,
-        deck: FlatDeck,
         agents: Vec<Box<dyn Agent>>,
+        deck: FlatDeck,
     ) -> Self {
         Self {
             game_state,


### PR DESCRIPTION
The order of new with hands and deck was off. Deck was not the last paramter despite being the name.

This is a breaking change, but we already needed one for the replay agent so 3.0.0 is incomming.