### PR TITLE
docs: add an example .envrc

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,7 @@
+if [[ $(type -t use_flake) != function ]]; then
+  echo "ERROR: use_flake function missing."
+  echo "Please update direnv to v2.30.0 or later."
+  exit 1
+fi
+use flake
+watch_file flake.nix flake.lock


### PR DESCRIPTION
We don't require nix, but we also don't want to make its usage a mystery. So this adds an example

Test:
This is a copy of the envrc I'm currently using