### PR TITLE
refactor: remove the FixBitSet depenedency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,12 +230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,7 +491,6 @@ version = "3.0.0-alpha.1"
 dependencies = [
  "arbitrary",
  "criterion",
- "fixedbitset",
  "rand",
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8.5"
-fixedbitset = "0.4.2"
 thiserror = "1.0.40"
 serde = { version = "1.0.164", optional = true, features = ["derive"] }
 arbitrary = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
We use a u16 for players in a table. So this was the only place still remaining that was using fixed bit set. It didnt' seem worth it to keep for one place.