### PR TITLE
feat: use a builder pattern for holdem simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "arbitrary"
@@ -88,18 +88,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.3"
+version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
+checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.3"
+version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
+checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
 dependencies = [
  "anstyle",
  "bitflags",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
@@ -368,9 +368,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -381,15 +381,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
@@ -402,9 +402,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1686749016,
-        "narHash": "sha256-len42vQO+iY65mhqRCCVjpXyTRKFDHuXGv/Nko7hdDY=",
+        "lastModified": 1687448588,
+        "narHash": "sha256-xgzcyeo7xVYaYL99Jg1mkySkfQmWR089WUPSuarLYy0=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "13b9455e9f7d2927f81088db3cffaafd6a6bbe16",
+        "rev": "9cf72357c8c52629d22edd8b4b8d7f7cdeea2504",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1686621798,
-        "narHash": "sha256-FUwWszmSiDzUdTk8f69xwMoYlhdPaLvDaIYOE/y6VXc=",
+        "lastModified": 1687310026,
+        "narHash": "sha256-20RHFbrnC+hsG4Hyeg/58LvQAK7JWfFItTPFAFamu8E=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "75f7d715f8088f741be9981405f6444e2d49efdd",
+        "rev": "116b32c30b5ff28e49f4fcbeeb1bbe3544593204",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1686723693,
-        "narHash": "sha256-wd6WE5M1EdnZPvK5h9zh3hE9F+h+7z2YhK1UpobkjGQ=",
+        "lastModified": 1687674253,
+        "narHash": "sha256-wXpJrXGIcGbwyxF1ky1VyPg8YoVuAkoj57+kSRJ5yek=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "ac2f1271f1e6623717220f31890658af351b0b2c",
+        "rev": "447bb10577505fb657724a7c02d406bfdec431ed",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "lastModified": 1687701825,
+        "narHash": "sha256-aMC9hqsf+4tJL7aJWSdEUurW2TsjxtDcJBwM9Y4FIYM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
+        "rev": "07059ee2fa34f1598758839b9af87eae7f7ae6ea",
         "type": "github"
       },
       "original": {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,8 +13,9 @@ path = ".."
 features = ["arbitrary"]
 
 [dependencies]
-libfuzzer-sys = { version = "0.4.6", features = ["arbitrary-derive"]}
+libfuzzer-sys = { version = "0.4.6", features = ["arbitrary-derive"] }
 arbitrary = { version = "1", features = ["derive"] }
+rand = "0.8.5"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/src/arena/agent/calling.rs
+++ b/src/arena/agent/calling.rs
@@ -13,7 +13,9 @@ impl Agent for CallingAgent {
 
 #[cfg(test)]
 mod tests {
-    use crate::arena::{GameState, HoldemSimulation};
+    use rand::thread_rng;
+
+    use crate::arena::{GameState, HoldemSimulationBuilder};
 
     use super::*;
 
@@ -21,15 +23,17 @@ mod tests {
     fn test_call_agents() {
         let stacks = vec![100; 4];
         let game_state = GameState::new(stacks, 10, 5, 0);
-        let mut sim = HoldemSimulation::new_with_agents(
-            game_state,
-            vec![
+        let mut sim = HoldemSimulationBuilder::default()
+            .rng(thread_rng())
+            .game_state(game_state)
+            .agents(vec![
                 Box::new(CallingAgent {}),
                 Box::new(CallingAgent {}),
                 Box::new(CallingAgent {}),
                 Box::new(CallingAgent {}),
-            ],
-        );
+            ])
+            .build()
+            .unwrap();
 
         sim.run();
 

--- a/src/arena/agent/folding.rs
+++ b/src/arena/agent/folding.rs
@@ -18,18 +18,24 @@ impl Agent for FoldingAgent {
 
 #[cfg(test)]
 mod tests {
-    use crate::arena::{game_state::Round, GameState, HoldemSimulation};
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use crate::arena::{game_state::Round, GameState, RngHoldemSimulationBuilder};
 
     use super::*;
 
     #[test]
     fn test_folding_agents() {
         let stacks = vec![100; 2];
+        let rng = StdRng::seed_from_u64(420);
+
         let game_state = GameState::new(stacks, 10, 5, 0);
-        let mut sim = HoldemSimulation::new_with_agents(
-            game_state,
-            vec![Box::new(FoldingAgent {}), Box::new(FoldingAgent {})],
-        );
+        let mut sim = RngHoldemSimulationBuilder::default()
+            .rng(rng)
+            .game_state(game_state)
+            .agents(vec![Box::new(FoldingAgent {}), Box::new(FoldingAgent {})])
+            .build()
+            .unwrap();
 
         sim.run();
 

--- a/src/arena/agent/mod.rs
+++ b/src/arena/agent/mod.rs
@@ -17,5 +17,5 @@ pub trait Agent {
 
 pub use calling::CallingAgent;
 pub use folding::FoldingAgent;
-pub use random::RandomAgent;
+pub use random::{RandomAgent, RandomPotControlAgent};
 pub use replay::{SliceReplayAgent, VecReplayAgent};

--- a/src/arena/errors.rs
+++ b/src/arena/errors.rs
@@ -11,3 +11,9 @@ pub enum GameStateError {
     #[error("Can't advance after showdown")]
     CantAdvanceRound,
 }
+
+#[derive(Error, Debug, PartialEq, Eq, Clone, Copy)]
+pub enum HoldemSimulationError {
+    #[error("Builder needs a game state")]
+    NeedGameState,
+}

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -9,4 +9,4 @@ pub mod test_util;
 
 pub use agent::Agent;
 pub use game_state::GameState;
-pub use simulation::HoldemSimulation;
+pub use simulation::{HoldemSimulation, HoldemSimulationBuilder, RngHoldemSimulationBuilder};

--- a/src/core/flat_deck.rs
+++ b/src/core/flat_deck.rs
@@ -5,6 +5,7 @@ use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 extern crate rand;
 use rand::seq::*;
 use rand::thread_rng;
+use rand::Rng;
 
 /// `FlatDeck` is a deck of cards that allows easy
 /// indexing into the cards. It does not provide
@@ -35,9 +36,8 @@ impl FlatDeck {
 
     /// Randomly shuffle the flat deck.
     /// This will ensure the there's no order to the deck.
-    pub fn shuffle(&mut self) {
-        let mut rng = thread_rng();
-        self.cards.shuffle(&mut rng)
+    pub fn shuffle<R: Rng>(&mut self, rng: &mut R) {
+        self.cards.shuffle(rng)
     }
 
     /// Deal a card if there is one there to deal.


### PR DESCRIPTION
- Switch to a builder for `HoldemSimulation`
- Add the ability to set the rng
- Use that ability in fuzzing to explore decks