### PR TITLE
test: add more fuzzing goodness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -328,9 +331,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
@@ -580,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags",
  "errno",
@@ -614,18 +617,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 thiserror = "1.0.44"
-serde = { version = "1.0.180", optional = true, features = ["derive"] }
+serde = { version = "1.0.181", optional = true, features = ["derive"] }
 arbitrary = { version = "1.3.0", optional = true, features = ["derive"] }
 tracing = { version = "0.1.37", optional = true}
 

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1688772518,
-        "narHash": "sha256-ol7gZxwvgLnxNSZwFTDJJ49xVY5teaSvF7lzlo3YQfM=",
+        "lastModified": 1691089569,
+        "narHash": "sha256-PYiaVen8kZKOl8Fd+IiChhRwR5oc9HwCqscvIArEEhU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b08e96c9af8c6e3a2b69af5a7fa168750fcf88e",
+        "rev": "1a551ae11bff91521cbeaebb8ca59a101c9f33f8",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1690611557,
-        "narHash": "sha256-VP59ksXc+4DUWTHl7Ly7TquDXZB/tW8MWLLcBKk82ic=",
+        "lastModified": 1691130041,
+        "narHash": "sha256-Ikwndx1YOsoUAY7TEp4kH0UVnXBuhLeLkTl/Fpimi6g=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "4253a8cb191d91dcf88d15966c3574f2460bad85",
+        "rev": "4322b4dc010b4ba7a2e4df49f8939e872473e4a7",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690630721,
-        "narHash": "sha256-Y04onHyBQT4Erfr2fc82dbJTfXGYrf4V0ysLUYnPOP8=",
+        "lastModified": 1691155369,
+        "narHash": "sha256-CIuJO5pgwCMsZM8flIU2OiZ79QfDCesXPsAiokCzlNM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2b52322f35597c62abf56de91b0236746b2a03d",
+        "rev": "7d050b98e51cdbdd88ad960152d398d41c7ff5b4",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688351637,
-        "narHash": "sha256-CLTufJ29VxNOIZ8UTg0lepsn3X03AmopmaLTTeHDCL4=",
+        "lastModified": 1691029059,
+        "narHash": "sha256-QwVeE9YTgH3LmL7yw2V/hgswL6yorIvYSp4YGI8lZYM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f9b92316727af9e6c7fee4a761242f7f46880329",
+        "rev": "99df4908445be37ddb2d332580365fce512a7dcf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,7 @@
             inherit cargoArtifacts;
             partitions = 1;
             partitionType = "count";
+            cargoNextestExtraArgs = "--all-targets";
           });
         } // lib.optionalAttrs (system == "x86_64-linux") {
           # NB: cargo-tarpaulin only supports x86_64 systems
@@ -139,6 +140,10 @@
             git
             cmake
             openssl
+
+            cargo-audit
+            cargo-watch
+            cargo-fuzz
           ];
 
           shellHook = ''

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ features = ["arbitrary"]
 
 [dependencies]
 libfuzzer-sys = { version = "0.4.6", features = ["arbitrary-derive"] }
-arbitrary = { version = "1", features = ["derive"] }
+arbitrary = { version = "1.3.0", features = ["derive"] }
 rand = "0.8.5"
 
 # Prevent this from interfering with workspaces
@@ -45,5 +45,12 @@ doc = false
 [[bin]]
 name = "replay_agent"
 path = "fuzz_targets/replay_agent.rs"
+test = false
+doc = false
+
+
+[[bin]]
+name = "multi_replay_agent"
+path = "fuzz_targets/multi_replay_agent.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzzer_script_1.rs
+++ b/fuzz/fuzz_targets/fuzzer_script_1.rs
@@ -8,7 +8,7 @@ use std::str;
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = str::from_utf8(data) {
         if let Ok(h) = RangeParser::parse_one(s) {
-            assert!(h.len() > 0);
+            assert!(!h.is_empty());
         }
     }
 });

--- a/fuzz/fuzz_targets/fuzzer_script_2.rs
+++ b/fuzz/fuzz_targets/fuzzer_script_2.rs
@@ -8,7 +8,7 @@ use std::str;
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = str::from_utf8(data) {
         if let Ok(h) = Hand::new_from_str(s) {
-            assert!(h.len() >= 0);
+            assert!(s.len() >= h.len());
         }
     }
 });

--- a/fuzz/fuzz_targets/multi_replay_agent.rs
+++ b/fuzz/fuzz_targets/multi_replay_agent.rs
@@ -1,0 +1,102 @@
+#![no_main]
+
+extern crate arbitrary;
+extern crate libfuzzer_sys;
+extern crate rand;
+extern crate rs_poker;
+
+use rand::{rngs::StdRng, SeedableRng};
+
+use rs_poker::arena::{
+    action::AgentAction, agent::VecReplayAgent, test_util::assert_valid_game_state,
+    test_util::assert_valid_round_data, Agent, GameState, HoldemSimulation,
+    RngHoldemSimulationBuilder,
+};
+
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Debug, Clone, arbitrary::Arbitrary)]
+struct PlayerInput {
+    pub stack: u16,
+    pub actions: Vec<AgentAction>,
+}
+
+#[derive(Debug, Clone, arbitrary::Arbitrary)]
+struct MultiInput {
+    pub players: Vec<PlayerInput>,
+    pub sb: i16,
+    pub bb: i16,
+    pub dealer_idx: usize,
+    pub seed: u64,
+}
+
+fn build_agent(actions: Vec<AgentAction>) -> Box<dyn Agent> {
+    Box::<VecReplayAgent>::new(VecReplayAgent::new(actions))
+}
+
+fuzz_target!(|input: MultiInput| {
+    let num_players = input.players.len();
+    let sb = input.sb as i32;
+    let bb = input.bb as i32;
+
+    // Extract the stacks adding the big blind to make sure that every agent can at
+    // least post the blinds (which would be required at any tale in the world)
+    let stacks: Vec<i32> = input
+        .players
+        .iter()
+        .map(|pi| pi.stack as i32)
+        .collect();
+
+    // The Safety Valves for input
+    if num_players < 2 {
+        return;
+    }
+    if num_players > 9 {
+        return;
+    }
+    if sb < 1 {
+        return;
+    }
+    if bb < sb || bb < 2 {
+        return;
+    }
+    if bb > *stacks.iter().min().unwrap_or(&0) {
+        return;
+    }
+
+    let agents: Vec<Box<dyn Agent>> = input
+        .players
+        .into_iter()
+        .map(|pi| build_agent(pi.actions))
+        .collect();
+
+    // Create the game state
+    // Notice that dealer_idx is sanitized to ensure it's in the proper range here
+    // rather than with the rest of the safety checks.
+    let game_state = GameState::new(stacks, bb, sb, input.dealer_idx % agents.len());
+    let rng = StdRng::seed_from_u64(input.seed);
+
+    // Do the thing
+    let mut sim: HoldemSimulation = RngHoldemSimulationBuilder::default()
+        .rng(rng)
+        .game_state(game_state)
+        .agents(agents)
+        .build()
+        .unwrap();
+    sim.run();
+
+    // For every round that we saw
+    // Check that it's valid
+    sim.game_state
+        .round_data
+        .iter()
+        .for_each(assert_valid_round_data);
+
+    assert_valid_game_state(&sim.game_state);
+
+    assert!(
+        sim.actions.len() >= 10,
+        "We expected there to be a lot of actions but only found {}",
+        sim.actions.len()
+    );
+});

--- a/fuzz/fuzz_targets/replay_agent.rs
+++ b/fuzz/fuzz_targets/replay_agent.rs
@@ -48,5 +48,9 @@ fuzz_target!(|input: Input| {
         .iter()
         .for_each(assert_valid_round_data);
 
-    assert!(sim.actions.len() > 10, "We expected there to be a lot of actions but only found {}", sim.actions.len());
+    assert!(
+        sim.actions.len() >= 10,
+        "We expected there to be a lot of actions but only found {}",
+        sim.actions.len()
+    );
 });

--- a/src/arena/action.rs
+++ b/src/arena/action.rs
@@ -21,8 +21,8 @@ pub struct GameStartPayload {
 
 #[derive(Debug, Clone, PartialEq, Copy, Hash)]
 pub struct PlayerSitPayload {
-    pub stack: i32,
     pub idx: usize,
+    pub player_stack: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Copy, Hash)]
@@ -41,6 +41,7 @@ pub struct ForcedBetPayload {
     /// amount which could be lower if that puts the player all in.
     pub bet: i32,
     pub idx: usize,
+    pub player_stack: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Copy, Hash)]
@@ -49,6 +50,7 @@ pub struct PlayedActionPayload {
     // The tried Action
     pub action: AgentAction,
     pub idx: usize,
+    pub player_stack: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Copy, Hash)]
@@ -59,6 +61,7 @@ pub struct FailedActionPayload {
     // The result action
     pub result_action: AgentAction,
     pub idx: usize,
+    pub player_stack: i32,
 }
 
 /// Represents an action that can happen in a game.

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -194,8 +194,9 @@ impl Agent for RandomPotControlAgent {
 mod tests {
     use crate::{
         arena::{
-            game_state::GameState, simulation::HoldemSimulationBuilder,
-            test_util::assert_valid_round_data,
+            game_state::GameState,
+            simulation::HoldemSimulationBuilder,
+            test_util::{assert_valid_game_state, assert_valid_round_data},
         },
         core::{Deck, FlatDeck},
     };
@@ -239,6 +240,8 @@ mod tests {
             .round_data
             .iter()
             .for_each(assert_valid_round_data);
+
+        assert_valid_game_state(&sim.game_state);
     }
 
     #[test_log::test]
@@ -269,6 +272,7 @@ mod tests {
             .round_data
             .iter()
             .for_each(assert_valid_round_data);
+        assert_valid_game_state(&sim.game_state);
     }
 
     #[test_log::test]
@@ -291,5 +295,6 @@ mod tests {
         sim.run();
         assert!(sim.game_state.is_complete());
         assert_eq!(7, sim.game_state.round_data.len());
+        assert_valid_game_state(&sim.game_state);
     }
 }

--- a/src/arena/agent/replay.rs
+++ b/src/arena/agent/replay.rs
@@ -40,3 +40,98 @@ impl<'a> Agent for SliceReplayAgent<'a> {
         *self.actions.get(idx).unwrap_or(&self.default)
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use crate::arena::{
+        action::AgentAction, agent::VecReplayAgent, test_util::assert_valid_game_state, Agent,
+        GameState, HoldemSimulation, RngHoldemSimulationBuilder,
+    };
+
+    #[test_log::test]
+    fn test_all_in_for_less() {
+        let agent_one = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Bet(10),
+            AgentAction::Bet(0),
+            AgentAction::Bet(0),
+            AgentAction::Bet(690),
+        ]));
+        let agent_two = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Bet(10),
+            AgentAction::Bet(0),
+            AgentAction::Bet(0),
+            AgentAction::Bet(690),
+        ]));
+        let agent_three = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Bet(10),
+            AgentAction::Bet(0),
+            AgentAction::Bet(0),
+            AgentAction::Bet(90),
+        ]));
+        let agent_four = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Bet(10),
+            AgentAction::Fold,
+        ]));
+
+        let stacks = vec![700, 900, 100, 800];
+        let game_state = GameState::new(stacks, 10, 5, 0);
+        let agents: Vec<Box<dyn Agent>> = vec![agent_one, agent_two, agent_three, agent_four];
+        let rng = StdRng::seed_from_u64(421);
+
+        let mut sim: HoldemSimulation = RngHoldemSimulationBuilder::default()
+            .rng(rng)
+            .game_state(game_state)
+            .agents(agents)
+            .build()
+            .unwrap();
+        sim.run();
+
+        assert_valid_game_state(&sim.game_state);
+    }
+
+    #[test_log::test]
+    fn test_from_fuzz() {
+        // This test was discoverd by fuzzing.
+        //
+        // Previously it would fail as the last two agents in
+        // a round both fold leaving orphaned money in the pot.
+        let agent_one = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![]));
+        let agent_two = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Bet(259),
+            AgentAction::Bet(16711936),
+        ]));
+        let agent_three = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Bet(259),
+            AgentAction::Bet(259),
+            AgentAction::Bet(259),
+            AgentAction::Fold,
+        ]));
+        let agent_four =
+            Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![AgentAction::Bet(57828)]));
+        let agent_five = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Bet(259),
+            AgentAction::Bet(259),
+            AgentAction::Bet(259),
+            AgentAction::Fold,
+        ]));
+
+        let stacks = vec![22784, 260, 65471, 255, 65471];
+        let game_state = GameState::new(stacks, 114, 96, 210439175936 % 5);
+        let agents: Vec<Box<dyn Agent>> =
+            vec![agent_one, agent_two, agent_three, agent_four, agent_five];
+        let rng = StdRng::seed_from_u64(0);
+
+        let mut sim: HoldemSimulation = RngHoldemSimulationBuilder::default()
+            .rng(rng)
+            .game_state(game_state)
+            .agents(agents)
+            .build()
+            .unwrap();
+        sim.run();
+
+        assert_valid_game_state(&sim.game_state);
+    }
+}

--- a/src/arena/errors.rs
+++ b/src/arena/errors.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum GameStateError {
+    #[error("Invalid number for a bet")]
+    BetInvalidSize,
     #[error("The ammount bet doesn't call the previous bet")]
     BetSizeDoesntCall,
     #[error("The ammount bet doesn't call our own previous bet")]

--- a/src/arena/test_util.rs
+++ b/src/arena/test_util.rs
@@ -1,4 +1,6 @@
-use super::game_state::RoundData;
+use crate::arena::game_state::Round;
+
+use super::{game_state::RoundData, GameState};
 
 pub fn assert_valid_round_data(round_data: &RoundData) {
     // Get all of the player still active at the end of the round.
@@ -29,4 +31,44 @@ pub fn assert_valid_round_data(round_data: &RoundData) {
         .for_each(|(bet_count, raise_count)| {
             assert!(*bet_count >= *raise_count);
         });
+}
+
+pub fn assert_valid_game_state(game_state: &GameState) {
+    assert_eq!(Round::Complete, game_state.round);
+
+    let total_bet: i32 = game_state.player_bet.iter().cloned().sum();
+    assert_eq!(total_bet, game_state.total_pot);
+    assert_ne!(0, total_bet);
+
+    let total_winning: i32 = game_state.player_winnings.iter().cloned().sum();
+
+    // Because we split winnings on ties and these are all integers.
+    // It's possible that there's some winnings that aren't awarded
+    assert!(total_winning <= total_bet);
+    assert!(total_winning <= game_state.total_pot);
+
+    assert!(
+        total_winning + game_state.num_players as i32 >= total_bet,
+        "invalid game state total winnings = {} total bet = {} game state = {:?}",
+        total_winning,
+        total_bet,
+        game_state
+    );
+    assert!(total_winning + game_state.num_players as i32 >= game_state.total_pot);
+
+    // The dealer has to be well specified.
+    assert!(game_state.dealer_idx < game_state.num_players);
+
+    // The board should be full or getting full
+    assert!(game_state.board.len() <= 5);
+
+    assert!(game_state.small_blind <= game_state.big_blind);
+
+    for idx in 0..game_state.num_players {
+        // If they aren't active (folded)
+        // and aren't all in then they shouldn't win anything
+        if !game_state.player_active.get(idx) && !game_state.player_all_in.get(idx) {
+            assert_eq!(0, game_state.player_winnings[idx]);
+        }
+    }
 }

--- a/src/core/flat_deck.rs
+++ b/src/core/flat_deck.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 /// `FlatDeck` is a deck of cards that allows easy
 /// indexing into the cards. It does not provide
 /// contains methods.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FlatDeck {
     /// Card storage.
     cards: Vec<Card>,
@@ -89,9 +89,12 @@ impl From<Deck> for FlatDeck {
     /// Flatten this deck, consuming it to produce a `FlatDeck` that's
     /// easier to get random access to.
     fn from(value: Deck) -> Self {
-        Self {
-            cards: value.into_iter().collect(),
-        }
+        // We sort the cards so that the same input
+        // cards always result in the same starting flat deck
+        let mut cards: Vec<Card> = value.into_iter().collect();
+        cards.sort();
+
+        Self { cards }
     }
 }
 impl Default for FlatDeck {
@@ -105,6 +108,8 @@ impl Default for FlatDeck {
 
 #[cfg(test)]
 mod tests {
+    use rand::{rngs::StdRng, SeedableRng};
+
     use super::*;
     use crate::core::card::{Suit, Value};
 
@@ -126,5 +131,20 @@ mod tests {
 
         assert_eq!(1, flat_deck.len());
         assert_eq!(c, flat_deck.deal().unwrap());
+    }
+
+    #[test]
+    fn test_shuffle_rng() {
+        let mut fd_one: FlatDeck = Deck::default().into();
+        let mut fd_two: FlatDeck = Deck::default().into();
+
+        let mut rng_one = StdRng::seed_from_u64(420);
+        let mut rng_two = StdRng::seed_from_u64(420);
+
+        fd_one.shuffle(&mut rng_one);
+        fd_two.shuffle(&mut rng_two);
+
+        assert_eq!(fd_one, fd_two);
+        assert_eq!(fd_one, fd_two);
     }
 }


### PR DESCRIPTION
Summary:
I want to use the multi-agent fuzzing to test the more precise
action log. So this is a first pass at adding that and cleaning up
around it

Then when writing that fuzz we can re-use the test utils everywhere.

That found an issue. We were transitioning the game to complete if an
agent folded. However there was still one player to act in a previous
round. So since we reset counts and data, it allowed invalid actions

This also found another issue: We were not starting on the dealer flop
on.

This also found another issue: The action log was using an incorrect idx
for the player.

Test Plan:
The whole thing is a test
