### PR TITLE
feat: track total_raise_count and use that in random agent

### DIFF
--- a/benches/arena.rs
+++ b/benches/arena.rs
@@ -23,7 +23,9 @@ fn run_one_arena(num_players: usize, percent_fold: f64, percent_call: f64) -> Ga
     let stacks = vec![STARTING_STACK; num_players];
     let game_state = GameState::new(stacks, BIG_BLIND, SMALL_BLIND, 0);
     let agents: Vec<Box<dyn Agent>> = (0..num_players)
-        .map(|_| -> Box<dyn Agent> { Box::new(RandomAgent::new(percent_fold, percent_call)) })
+        .map(|_| -> Box<dyn Agent> {
+            Box::new(RandomAgent::new(vec![percent_fold], vec![percent_call]))
+        })
         .collect();
     let mut sim = HoldemSimulationBuilder::default()
         .game_state(game_state)
@@ -38,7 +40,7 @@ fn run_one_pot_control_arena(num_players: usize) -> GameState {
     let stacks = vec![STARTING_STACK; num_players];
     let game_state = GameState::new(stacks, BIG_BLIND, SMALL_BLIND, 0);
     let agents: Vec<Box<dyn Agent>> = (0..num_players)
-        .map(|idx| -> Box<dyn Agent> { Box::new(RandomPotControlAgent::new(0.3, idx)) })
+        .map(|_idx| -> Box<dyn Agent> { Box::new(RandomPotControlAgent::new(vec![0.3])) })
         .collect();
 
     let mut sim = HoldemSimulationBuilder::default()

--- a/src/arena/game_state.rs
+++ b/src/arena/game_state.rs
@@ -40,8 +40,12 @@ pub struct RoundData {
     pub player_bet: Vec<i32>,
     // The number of times the player has put in money.
     pub bet_count: Vec<u8>,
+    // The number of times anyone has put in money
+    pub total_bet_count: u8,
     // The number of times the player has increased the bet voluntarily.
     pub raise_count: Vec<u8>,
+    // The number of times anyone has increased the bet non-forced.
+    pub total_raise_count: u8,
     // The index of the next player to act.
     pub to_act_idx: usize,
 }
@@ -59,6 +63,7 @@ impl RoundData {
     pub fn do_bet(&mut self, extra_ammount: i32, is_forced: bool) {
         self.player_bet[self.to_act_idx] += extra_ammount;
         self.bet_count[self.to_act_idx] += 1;
+        self.total_bet_count += 1;
 
         // The amount to be called is
         // the maximum anyone has wagered.
@@ -68,6 +73,7 @@ impl RoundData {
 
         if !is_forced && player_bet > previous_bet {
             self.raise_count[self.to_act_idx] += 1;
+            self.total_raise_count += 1;
         }
 
         let raise_ammount = self.bet - previous_bet;
@@ -185,7 +191,9 @@ impl GameState {
     fn new_round_data(&self) -> RoundData {
         RoundData {
             player_bet: vec![0; self.num_players],
+            total_bet_count: 0,
             bet_count: vec![0; self.num_players],
+            total_raise_count: 0,
             raise_count: vec![0; self.num_players],
             bet: 0,
             min_raise: self.big_blind,


### PR DESCRIPTION
Summary:
Lets let people try and mimic raising less if there's already been some
aggression. To do that keep track of the total number of raises. Then
rather than a static percentage, use a vector of percentages that we
traverse farther into.

So we can fold more when there's been more betting and we can call more
meaning we also bet less.

Test Plan:

Changed the tests, and they still pass
