### PR TITLE
feat: add on `CardBitSet` for card sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -91,18 +91,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.7"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.7"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -163,31 +163,30 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -196,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "either"
@@ -208,9 +207,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -221,19 +220,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -266,7 +265,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -280,15 +279,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -301,15 +300,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "log"
@@ -362,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -420,9 +419,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -548,22 +547,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -575,25 +574,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -622,15 +615,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -639,18 +632,29 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "test-log"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66edd6b6cd810743c0c71e1d085e92b01ce6a72782032e3f794c8284fe4bcdd"
+checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,18 +663,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -731,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -742,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -788,9 +792,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -798,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -813,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -823,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -836,15 +840,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -887,7 +891,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -896,13 +909,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -912,10 +940,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -924,10 +964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -936,13 +988,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1698111507,
-        "narHash": "sha256-iF+8d6Gvq/rSu+BdEtGJO2oL7vQ1Nxrv/tKQlESBgl8=",
+        "lastModified": 1702652226,
+        "narHash": "sha256-nBq7EmP7E42XRLkMArk4aSjoclBxFT2gxgLmS2xF1EY=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "57d5993efb037c1f9518b7be7ab3a01b4ad475af",
+        "rev": "fd71859263a51bf69da4ad9f692d6ebfe7db525b",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698166613,
-        "narHash": "sha256-y4rdN4flxRiROqNi1waMYIZj/Fs7L2OrszFk/1ry9vU=",
+        "lastModified": 1702749801,
+        "narHash": "sha256-frIhfv0h4RAobzQ/vp7C7a2bEbz2gcZc2qVSc2CElxw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b7db46f0f1751f7b1d1911f6be7daf568ad5bc65",
+        "rev": "3330c0de31e8729bb5d01820e59ceb1640e128dc",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1698214924,
-        "narHash": "sha256-pHErW9RKaC4pAGz+/q0QMlfdTR8EDeP/VOyN18DjEkk=",
+        "lastModified": 1702794080,
+        "narHash": "sha256-lh9IAeo7gq0Z1X+AtgPsO2r+e4uFqhIVE+ZEVH55Dk0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "cd12463c442edf4fb97be8a6d82b03ee1d14ca41",
+        "rev": "07eda01af85c16be6de78c6e35e9cc970721a5c1",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "lastModified": 1702539185,
+        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
         "type": "github"
       },
       "original": {

--- a/src/core/card.rs
+++ b/src/core/card.rs
@@ -169,6 +169,31 @@ impl From<Value> for char {
     }
 }
 
+/// Implement the From trait
+///
+/// # Examples
+///
+/// Ace is a high card in our counting so it's the max value 12
+/// ```
+/// use rs_poker::core::Value;
+/// let v = Value::try_from('A').unwrap();
+/// assert_eq!(Value::Ace, v);
+/// assert_eq!(12, u8::from(v));
+/// ```
+///
+/// Values are zero indexed with 2 being the lowest value.
+/// ```
+/// use rs_poker::core::Value;
+/// let v = Value::try_from('4').unwrap();
+/// assert_eq!(Value::Four, v);
+/// assert_eq!(2, u8::from(v));
+/// ```
+impl From<Value> for u8 {
+    fn from(value: Value) -> Self {
+        value as u8
+    }
+}
+
 /// Enum for the four different suits.
 /// While this has support for ordering it's not
 /// sensical. The sorting is only there to allow sorting cards.
@@ -252,6 +277,12 @@ impl From<u8> for Suit {
     }
 }
 
+impl From<Suit> for u8 {
+    fn from(value: Suit) -> Self {
+        value as u8
+    }
+}
+
 impl TryFrom<char> for Suit {
     type Error = RSPokerError;
 
@@ -291,6 +322,21 @@ pub struct Card {
 impl Card {
     pub fn new(value: Value, suit: Suit) -> Self {
         Self { value, suit }
+    }
+}
+
+impl From<Card> for u8 {
+    fn from(card: Card) -> Self {
+        u8::from(card.suit) * 13 + u8::from(card.value)
+    }
+}
+
+impl From<u8> for Card {
+    fn from(value: u8) -> Self {
+        Self {
+            value: Value::from(value % 13),
+            suit: Suit::from(value / 13),
+        }
     }
 }
 
@@ -338,6 +384,31 @@ mod tests {
         };
         assert_eq!(Suit::Spade, c.suit);
         assert_eq!(Value::Three, c.value);
+    }
+
+    #[test]
+    fn test_suit_from_u8() {
+        assert_eq!(Suit::Spade, Suit::from_u8(0));
+        assert_eq!(Suit::Club, Suit::from_u8(1));
+        assert_eq!(Suit::Heart, Suit::from_u8(2));
+        assert_eq!(Suit::Diamond, Suit::from_u8(3));
+    }
+
+    #[test]
+    fn test_value_from_u8() {
+        assert_eq!(Value::Two, Value::from_u8(0));
+        assert_eq!(Value::Ace, Value::from_u8(12));
+    }
+
+    #[test]
+    fn test_roundtrip_from_u8_all_cards() {
+        for suit in SUITS {
+            for value in VALUES {
+                let c = Card { suit, value };
+                let u = u8::from(c);
+                assert_eq!(c, Card::from(u));
+            }
+        }
     }
 
     #[test]

--- a/src/core/card_bit_set.rs
+++ b/src/core/card_bit_set.rs
@@ -1,0 +1,350 @@
+use std::ops::{BitOr, BitOrAssign, BitXor, BitXorAssign};
+
+use super::{Card, FlatDeck};
+use std::fmt::Debug;
+
+// This struct is a bitset for cards
+// Each card is represented by a bit
+//
+// The bit is set if the card present
+// The bit is unset if the card not in the set
+//
+// It implements the BitOr, BitAnd, and BitXor traits
+// It implements the Display trait
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CardBitSet {
+    // The bitset
+    cards: u64,
+}
+
+const FIFTY_TWO_ONES: u64 = (1 << 52) - 1;
+
+impl CardBitSet {
+    /// Create a new empty bitset
+    ///
+    /// ```
+    /// use rs_poker::core::CardBitSet;
+    /// let cards = CardBitSet::new();
+    /// assert!(cards.is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Self { cards: 0 }
+    }
+
+    /// This does what it says on the tin it insertes a card into the bitset
+    ///
+    /// ```
+    /// use rs_poker::core::{Card, CardBitSet, Deck, Suit, Value};
+    /// let mut cards = CardBitSet::new();
+    ///
+    /// cards.insert(Card::new(Value::Six, Suit::Club));
+    /// cards.insert(Card::new(Value::King, Suit::Club));
+    /// cards.insert(Card::new(Value::Ace, Suit::Club));
+    /// assert_eq!(3, cards.count());
+    /// ```
+    pub fn insert(&mut self, card: Card) {
+        self.cards |= 1 << u8::from(card);
+    }
+
+    /// Remove a card from the bitset
+    ///
+    /// ```
+    /// use rs_poker::core::{Card, CardBitSet, Deck, Suit, Value};
+    /// let mut cards = CardBitSet::new();
+    /// cards.insert(Card::from(17));
+    ///
+    /// // We're using the u8 but it's got a value as well
+    /// assert_eq!(Card::new(Value::Six, Suit::Club), Card::from(17));
+    ///
+    /// // The card is in the bitset
+    /// assert!(cards.contains(Card::new(Value::Six, Suit::Club)));
+    /// // We can remove the card
+    /// cards.remove(Card::new(Value::Six, Suit::Club));
+    ///
+    /// // show that the card is no longer in the bitset
+    /// assert!(!cards.contains(Card::from(17)));
+    /// ```
+    pub fn remove(&mut self, card: Card) {
+        self.cards &= !(1 << u8::from(card));
+    }
+
+    /// Is the card in the bitset ?
+    ///
+    /// ```
+    /// use rs_poker::core::{Card, CardBitSet, Deck, Suit, Value};
+    ///
+    /// let mut cards = CardBitSet::new();
+    /// cards.insert(Card::from(17));
+    ///
+    /// assert!(cards.contains(Card::new(Value::Six, Suit::Club)));
+    /// ```
+    pub fn contains(&self, card: Card) -> bool {
+        (self.cards & (1 << u8::from(card))) != 0
+    }
+
+    /// Is the bitset empty ?
+    ///
+    /// ```
+    /// use rs_poker::core::{Card, CardBitSet};
+    ///
+    /// let mut cards = CardBitSet::new();
+    /// assert!(cards.is_empty());
+    ///
+    /// cards.insert(Card::from(17));
+    /// assert!(!cards.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.cards == 0
+    }
+
+    /// How many cards are in the bitset ?
+    ///
+    /// ```
+    /// use rs_poker::core::{Card, CardBitSet};
+    /// let mut cards = CardBitSet::new();
+    ///
+    /// assert_eq!(0, cards.count());
+    /// for card in 0..13 {
+    ///    cards.insert(Card::from(card));
+    ///    assert_eq!(card as usize + 1, cards.count());
+    /// }
+    /// assert_eq!(13, cards.count());
+    pub fn count(&self) -> usize {
+        self.cards.count_ones() as usize
+    }
+}
+
+impl Default for CardBitSet {
+    /// Create a new bitset with all the cards in it
+    /// ```
+    /// use rs_poker::core::CardBitSet;
+    ///
+    /// let cards = CardBitSet::default();
+    ///
+    /// assert_eq!(52, cards.count());
+    /// assert!(!cards.is_empty());
+    /// ```
+    fn default() -> Self {
+        Self {
+            cards: FIFTY_TWO_ONES,
+        }
+    }
+}
+
+// Trait for converting a CardBitSet into a FlatDeck
+// Create the vec for storage and then return the flatdeck
+impl From<CardBitSet> for FlatDeck {
+    fn from(value: CardBitSet) -> Self {
+        value.into_iter().collect::<Vec<Card>>().into()
+    }
+}
+
+impl Debug for CardBitSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+
+        for idx in (0..52).rev() {
+            let card = Card::from(idx);
+            if self.contains(card) {
+                write!(f, "A")?;
+            } else {
+                write!(f, "_")?;
+            }
+        }
+
+        write!(f, "]")
+    }
+}
+
+impl BitOr<CardBitSet> for CardBitSet {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self {
+            cards: self.cards | rhs.cards,
+        }
+    }
+}
+
+impl BitOr<Card> for CardBitSet {
+    type Output = Self;
+
+    fn bitor(self, rhs: Card) -> Self::Output {
+        Self {
+            cards: self.cards | 1 << u8::from(rhs),
+        }
+    }
+}
+
+impl BitOrAssign<CardBitSet> for CardBitSet {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.cards |= rhs.cards;
+    }
+}
+
+impl BitOrAssign<Card> for CardBitSet {
+    fn bitor_assign(&mut self, rhs: Card) {
+        self.cards |= 1 << u8::from(rhs);
+    }
+}
+
+impl BitXor for CardBitSet {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self {
+            cards: self.cards ^ rhs.cards,
+        }
+    }
+}
+
+impl BitXor<Card> for CardBitSet {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Card) -> Self::Output {
+        Self {
+            cards: self.cards ^ 1 << u8::from(rhs),
+        }
+    }
+}
+
+impl BitXorAssign<Card> for CardBitSet {
+    fn bitxor_assign(&mut self, rhs: Card) {
+        self.cards ^= 1 << u8::from(rhs);
+    }
+}
+
+impl BitXorAssign<CardBitSet> for CardBitSet {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.cards ^= rhs.cards;
+    }
+}
+
+pub struct CardBitSetIter(u64);
+
+impl IntoIterator for CardBitSet {
+    type Item = Card;
+    type IntoIter = CardBitSetIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        CardBitSetIter(self.cards)
+    }
+}
+
+impl Iterator for CardBitSetIter {
+    type Item = Card;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0 == 0 {
+            return None;
+        }
+
+        let card = self.0.trailing_zeros();
+        self.0 &= !(1 << card);
+
+        Some(Card::from(card as u8))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::core::{Deck, FlatDeck};
+
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let cards = CardBitSet::new();
+        assert!(cards.is_empty());
+    }
+
+    #[test]
+    fn test_insert_all() {
+        let mut all_cards = CardBitSet::new();
+        for card in Deck::default() {
+            let mut single_card = CardBitSet::new();
+
+            single_card.insert(card);
+            all_cards |= single_card;
+
+            assert!(single_card.contains(card));
+        }
+
+        assert_eq!(all_cards.count(), 52);
+
+        for card in Deck::default() {
+            assert!(all_cards.contains(card));
+        }
+    }
+
+    #[test]
+    fn test_xor_is_remove() {
+        let mut all_cards = CardBitSet::new();
+        for card in Deck::default() {
+            all_cards |= card;
+        }
+
+        for card in Deck::default() {
+            let xor_masked_set: CardBitSet = all_cards ^ card;
+            assert!(!xor_masked_set.contains(card));
+
+            let mut removed_set = all_cards;
+            removed_set.remove(card);
+
+            assert_eq!(removed_set, xor_masked_set);
+        }
+        assert_eq!(52, all_cards.count());
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let empty = CardBitSet::new();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_not_empty() {
+        let mut cards = CardBitSet::new();
+
+        cards.insert(Card::from(17));
+        assert!(!cards.is_empty());
+    }
+
+    #[test]
+    fn test_add_cards_iter() {
+        let mut hash_set: HashSet<Card> = HashSet::new();
+        let mut bit_set = CardBitSet::new();
+
+        let deck = FlatDeck::from(Deck::default());
+
+        for card in deck.sample(13) {
+            hash_set.insert(card);
+            bit_set.insert(card);
+        }
+
+        assert_eq!(hash_set.len(), bit_set.count());
+        for card in hash_set.clone() {
+            assert!(bit_set.contains(card));
+        }
+
+        for card in bit_set {
+            assert!(hash_set.contains(&card));
+        }
+    }
+
+    #[test]
+    fn test_default_contains() {
+        let mut bitset_cards = CardBitSet::default();
+        assert_eq!(52, bitset_cards.count());
+
+        for card in Deck::default() {
+            assert!(bitset_cards.contains(card));
+            bitset_cards.remove(card);
+        }
+
+        assert_eq!(0, bitset_cards.count());
+        assert!(bitset_cards.is_empty());
+    }
+}

--- a/src/core/deck.rs
+++ b/src/core/deck.rs
@@ -13,9 +13,9 @@ use std::collections::HashSet;
 /// let mut deck = Deck::new();
 ///
 /// // add some cards to the deck
-/// deck.add(Card::new(Value::Ace, Suit::Club));
-/// deck.add(Card::new(Value::King, Suit::Diamond));
-/// deck.add(Card::new(Value::Queen, Suit::Heart));
+/// deck.insert(Card::new(Value::Ace, Suit::Club));
+/// deck.insert(Card::new(Value::King, Suit::Diamond));
+/// deck.insert(Card::new(Value::Queen, Suit::Heart));
 ///
 /// // check if a card is in the deck
 /// let card = Card::new(Value::Ace, Suit::Club);
@@ -60,7 +60,7 @@ impl Deck {
         self.cards.remove(c)
     }
     /// Add a given card to the deck.
-    pub fn add(&mut self, c: Card) -> bool {
+    pub fn insert(&mut self, c: Card) -> bool {
         self.cards.insert(c)
     }
     /// How many cards are there in the deck.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -35,5 +35,9 @@ pub use self::rank::{Rank, Rankable};
 
 // u16 backed player set.
 mod player_bit_set;
+// u64 backed card set.
+mod card_bit_set;
 // Export the bit set and the iterator
 pub use self::player_bit_set::{ActivePlayerBitSetIter, PlayerBitSet};
+// Export the bit set and the iterator used for cards (52 cards so u64 backed)
+pub use self::card_bit_set::{CardBitSet, CardBitSetIter};

--- a/src/holdem/monte_carlo_game.rs
+++ b/src/holdem/monte_carlo_game.rs
@@ -1,6 +1,6 @@
 use rand::thread_rng;
 
-use crate::core::{Deck, FlatDeck, Hand, PlayerBitSet, RSPokerError, Rank, Rankable};
+use crate::core::{CardBitSet, FlatDeck, Hand, PlayerBitSet, RSPokerError, Rank, Rankable};
 
 /// Current state of a game.
 #[derive(Debug)]
@@ -22,7 +22,7 @@ pub struct MonteCarloGame {
 impl MonteCarloGame {
     /// If we already have hands then lets start there.
     pub fn new(hands: Vec<Hand>) -> Result<Self, RSPokerError> {
-        let mut deck = Deck::default();
+        let mut deck = CardBitSet::default();
         let mut max_hand_size: usize = 0;
         let mut cards_needed = 0;
         let mut hand_sizes: Vec<usize> = vec![];
@@ -41,7 +41,7 @@ impl MonteCarloGame {
             cards_needed += 7 - hand_size;
 
             for card in hand.iter() {
-                deck.remove(card);
+                deck.remove(*card);
             }
         }
 


### PR DESCRIPTION
Summary:
We only have 52 cards. So we can use the 64 bit integers as flag set.
This does that and makes deck follow the same api. As such this is a
breaking change to the deck struct.

It's recomended to use  CardBitSet whenever possible as it will be
faster and smaller.

Test Plan:
Lots of tests added
