### PR TITLE
feat: agents can be notified of actions as they happen

### DIFF
--- a/src/arena/agent/fn_observer.rs
+++ b/src/arena/agent/fn_observer.rs
@@ -1,0 +1,81 @@
+use crate::arena::{
+    action::{Action, AgentAction},
+    game_state::GameState,
+};
+
+use super::{random::RandomAgent, Agent};
+
+/// This `Agent` is an implmentation that returns
+/// random actions. However, it also takes in a function
+/// that is called when an action is received. This is
+/// useful for testing and debugging.
+#[derive(Debug, Clone)]
+pub struct FnObserverRandomAgent<F> {
+    func: F,
+    random_agent: RandomAgent,
+}
+
+impl<F: Fn(&Action)> FnObserverRandomAgent<F> {
+    pub fn new(f: F) -> Self {
+        Self {
+            func: f,
+            random_agent: RandomAgent::default(),
+        }
+    }
+}
+
+impl<F: Clone + Fn(&Action)> Agent for FnObserverRandomAgent<F> {
+    fn act(&mut self, game_state: &GameState) -> AgentAction {
+        // Delegate to the random agent
+        self.random_agent.act(game_state)
+    }
+
+    fn action_received(&mut self, _game_state: &GameState, action: &Action) {
+        // Call the function with the action that was received
+        (self.func)(action);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{cell::RefCell, rc::Rc};
+
+    use super::*;
+    use crate::arena::HoldemSimulationBuilder;
+
+    #[test]
+    fn test_observer_agent() {
+        let game_state = GameState::new(vec![100.0, 100.0], 10.0, 5.0, 0);
+
+        let count = Rc::new(RefCell::new(0));
+        let last_action: Rc<RefCell<Option<Action>>> = Rc::new(RefCell::new(None));
+
+        let agents: Vec<Box<dyn Agent>> = (0..2)
+            .map(|_| {
+                let local_count = count.clone();
+                let local_action = last_action.clone();
+
+                let a = FnObserverRandomAgent::new(move |action: &Action| {
+                    *local_count.borrow_mut() += 1;
+                    *local_action.borrow_mut() = Some(action.clone());
+                });
+                Box::new(a) as Box<dyn Agent>
+            })
+            .collect();
+
+        let mut sim = HoldemSimulationBuilder::default()
+            .agents(agents)
+            .game_state(game_state)
+            .build()
+            .unwrap();
+
+        sim.run();
+
+        assert_ne!(0, count.take());
+
+        let act = last_action.take();
+
+        assert!(act.is_some());
+    }
+}

--- a/src/arena/agent/mod.rs
+++ b/src/arena/agent/mod.rs
@@ -3,11 +3,15 @@
 //!
 //! Some basic agents are provided as a way of testing baseline value.
 mod calling;
+mod fn_observer;
 mod folding;
 mod random;
 mod replay;
 
-use crate::arena::{action::AgentAction, game_state::GameState};
+use super::{
+    action::{Action, AgentAction},
+    game_state::GameState,
+};
 use dyn_clone::DynClone;
 /// This is the trait that you need to implement in order to implenet
 /// different strategies. It's up to you to to implement the logic and state.
@@ -16,12 +20,18 @@ use dyn_clone::DynClone;
 /// issues to the writer of agent but also allows single threaded simulations
 /// not to need Arc<Mutex<T>>'s overhead.
 pub trait Agent: DynClone {
+    /// This is the method that will be called by the game to get the action
     fn act(&mut self, game_state: &GameState) -> AgentAction;
+    /// When some action happens that changes the game state, the agent can be
+    /// notified The game state will be the new state after the action has
+    /// been applied
+    fn action_received(&mut self, _game_state: &GameState, _action: &Action) {}
 }
 
 dyn_clone::clone_trait_object!(Agent);
 
 pub use calling::CallingAgent;
+pub use fn_observer::FnObserverRandomAgent;
 pub use folding::FoldingAgent;
 pub use random::{RandomAgent, RandomPotControlAgent};
 pub use replay::{SliceReplayAgent, VecReplayAgent};

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -53,7 +53,7 @@ use super::GameState;
 ///   `FoldingAgent` as a stand in and set the active bit to false.
 #[derive(Clone)]
 pub struct HoldemSimulation {
-    agents: Vec<Box<dyn Agent>>,
+    pub agents: Vec<Box<dyn Agent>>,
     pub game_state: GameState,
     pub deck: FlatDeck,
     pub actions: Vec<Action>,
@@ -479,6 +479,11 @@ impl HoldemSimulation {
 
     fn add_action(&mut self, action: Action) {
         event!(Level::TRACE, action = ?action, game_state = ?self.game_state, "add_action");
+        // Let all of the agents know about what just happened.
+        // This lets them keep track of the game state as it progresses.
+        for agent in &mut self.agents {
+            agent.action_received(&self.game_state, &action);
+        }
         self.actions.push(action);
     }
 }


### PR DESCRIPTION
Summary:
If we're going to have a CFR Agent then the agent needs to be able to
follow the game tree not just during it's own action, but also as other
actions are happening.

Test Plan:

Tests added
FnObserverRandomAgent is a good demonstration
