### PR TITLE
Add a parse function to parse a comma separated list

### DIFF
--- a/src/holdem/parse.rs
+++ b/src/holdem/parse.rs
@@ -539,25 +539,20 @@ impl RangeParser {
     /// // Filters out duplicates.
     /// assert_eq!(RangeParser::parse_many("AK-87s,A2s+").unwrap().len(), 72)
     /// ```
-    pub fn parse_many(r_str: &str) -> Result<Vec<Hand>, Vec<RSPokerError>> {
-        let mut errors: Vec<RSPokerError> = vec![];
-        let mut set = HashSet::new();
-
-        let hands: Vec<_> = r_str
+    pub fn parse_many(r_str: &str) -> Result<Vec<Hand>, RSPokerError> {
+        let all_hands: Vec<_> = r_str
+            // Split into different ranges
             .split(',')
+            // Try to parse the ranges.
             .map(|s| RangeParser::parse_one(s.trim()))
-            .filter_map(|r| r.map_err(|e| errors.push(e)).ok())
-            .flatten()
-            .collect();
+            // Use FromIterator to get a result and unwrap it.
+            .collect::<Result<Vec<_>, _>>()?;
 
-        match errors.is_empty() {
-            true => {
-                set.extend(hands);
+        // Filter the unique hands.
+        let unique_hands: HashSet<Hand> = all_hands.into_iter().flatten().collect();
 
-                Ok(set.into_iter().collect())
-            }
-            false => Err(errors),
-        }
+        // Transform hands into a vec for storage
+        Ok(unique_hands.into_iter().collect())
     }
 }
 

--- a/src/holdem/parse.rs
+++ b/src/holdem/parse.rs
@@ -755,11 +755,21 @@ mod test {
 
     #[test]
     fn test_parse_multiple() {
-        assert_eq!(RangeParser::parse(&String::from("KK+, A2s+")).unwrap().len(), 60);
+        assert_eq!(
+            RangeParser::parse(&String::from("KK+, A2s+"))
+                .unwrap()
+                .len(),
+            60
+        );
     }
 
     #[test]
     fn test_filters_duplicates() {
-        assert_eq!(RangeParser::parse(&String::from("AK-87s,A2s+")).unwrap().len(), 72);
+        assert_eq!(
+            RangeParser::parse(&String::from("AK-87s,A2s+"))
+                .unwrap()
+                .len(),
+            72
+        );
     }
 }

--- a/src/holdem/parse.rs
+++ b/src/holdem/parse.rs
@@ -550,14 +550,14 @@ impl RangeParser {
             .flatten()
             .collect();
 
-        return match errors.is_empty() {
+        match errors.is_empty() {
             true => {
                 set.extend(hands);
 
                 Ok(set.into_iter().collect())
             }
             false => Err(errors),
-        };
+        }
     }
 }
 

--- a/src/holdem/parse.rs
+++ b/src/holdem/parse.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
 use crate::core::{Card, Hand, RSPokerError, Suit, Value};
 use crate::holdem::Suitedness;
+use std::collections::HashSet;
 use std::iter::Iterator;
 
 /// Inclusive Range of card values.
@@ -543,8 +543,9 @@ impl RangeParser {
         let mut errors: Vec<RSPokerError> = vec![];
         let mut set = HashSet::new();
 
-        let hands: Vec<_> = r_str.split(',')
-            .map(|r| RangeParser::parse_one(r.trim()))
+        let hands: Vec<_> = r_str
+            .split(',')
+            .map(|s| RangeParser::parse_one(s.trim()))
             .filter_map(|r| r.map_err(|e| errors.push(e)).ok())
             .flatten()
             .collect();
@@ -554,8 +555,8 @@ impl RangeParser {
                 set.extend(hands);
 
                 Ok(set.into_iter().collect())
-            },
-            false => Err(errors)
+            }
+            false => Err(errors),
         };
     }
 }


### PR DESCRIPTION
This fixes #77 
Not sure if having both functionalities in one function would be better.

Let me know if I should change anything 🙂 
Thanks for the great library!