### PR TITLE
fix: clear warnings about redundant use

### DIFF
--- a/src/arena/agent/calling.rs
+++ b/src/arena/agent/calling.rs
@@ -18,7 +18,7 @@ impl Agent for CallingAgent {
 mod tests {
     use rand::thread_rng;
 
-    use crate::arena::{GameState, HoldemSimulationBuilder};
+    use crate::arena::HoldemSimulationBuilder;
 
     use super::*;
 

--- a/src/arena/agent/folding.rs
+++ b/src/arena/agent/folding.rs
@@ -21,7 +21,7 @@ mod tests {
     use approx::assert_relative_eq;
     use rand::{rngs::StdRng, SeedableRng};
 
-    use crate::arena::{game_state::Round, GameState, RngHoldemSimulationBuilder};
+    use crate::arena::{game_state::Round, RngHoldemSimulationBuilder};
 
     use super::*;
 

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -212,7 +212,6 @@ impl Agent for RandomPotControlAgent {
 mod tests {
     use crate::{
         arena::{
-            game_state::GameState,
             test_util::{assert_valid_game_state, assert_valid_round_data},
             HoldemSimulationBuilder,
         },

--- a/src/arena/historian/vec.rs
+++ b/src/arena/historian/vec.rs
@@ -29,8 +29,6 @@ impl Historian for VecHistorian {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
     use crate::arena::{agent::RandomAgent, Agent, GameState, HoldemSimulationBuilder};
 
     use super::*;

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -183,14 +183,9 @@ pub type HoldemSimulationBuilder = RngHoldemSimulationBuilder<ThreadRng>;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use rand::{rngs::StdRng, SeedableRng};
 
-    use crate::{
-        arena::{game_state::Round, GameState},
-        core::{Card, CardBitSet},
-    };
+    use crate::{arena::game_state::Round, core::Card};
 
     use super::*;
 

--- a/src/core/card.rs
+++ b/src/core/card.rs
@@ -373,7 +373,6 @@ impl TryFrom<&str> for Card {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem;
 
     #[test]
     fn test_constructor() {

--- a/src/core/card_bit_set.rs
+++ b/src/core/card_bit_set.rs
@@ -250,7 +250,7 @@ impl Iterator for CardBitSetIter {
 mod tests {
     use std::collections::HashSet;
 
-    use crate::core::{Deck, FlatDeck};
+    use crate::core::Deck;
 
     use super::*;
 

--- a/src/core/card_iter.rs
+++ b/src/core/card_iter.rs
@@ -96,10 +96,6 @@ impl<'a> IntoIterator for &'a FlatDeck {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::card::Card;
-    use crate::core::deck::*;
-    use crate::core::flat_deck::*;
-    use crate::core::hand::Hand;
 
     #[test]
     fn test_iter_one() {

--- a/src/core/deck.rs
+++ b/src/core/deck.rs
@@ -112,7 +112,6 @@ impl Default for Deck {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::card::*;
 
     #[test]
     fn test_contains_in() {

--- a/src/core/hand.rs
+++ b/src/core/hand.rs
@@ -145,7 +145,6 @@ impl Extend<Card> for Hand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::card::Card;
 
     #[test]
     fn test_add_card() {

--- a/src/holdem/monte_carlo_game.rs
+++ b/src/holdem/monte_carlo_game.rs
@@ -148,8 +148,6 @@ impl MonteCarloGame {
 mod test {
     use super::*;
     use crate::core::Card;
-    use crate::core::Hand;
-    use crate::core::Rank;
     use crate::core::Suit;
     use crate::core::Value;
 

--- a/src/holdem/parse.rs
+++ b/src/holdem/parse.rs
@@ -584,7 +584,6 @@ impl RangeParser {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::core::Value;
 
     #[test]
     fn test_range_iter_static() {

--- a/src/holdem/starting_hand.rs
+++ b/src/holdem/starting_hand.rs
@@ -214,7 +214,6 @@ impl StartingHand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::Value;
 
     #[test]
     fn test_aces() {


### PR DESCRIPTION
Summary:
Tests that use super::* are starting to give warnings.

Test Plan:
warnings are gone on build