### PR TITLE
feat: allow historians to fail

### DIFF
--- a/src/arena/historian/mod.rs
+++ b/src/arena/historian/mod.rs
@@ -1,5 +1,18 @@
 use super::{action::Action, GameState};
 
+/// HistorianError is the error type for historian implementations.
+#[derive(Error, Debug)]
+pub enum HistorianError {
+    #[error("Unable to record action")]
+    UnableToRecordAction,
+    #[error("IO Error: {0}")]
+    IOError(#[from] std::io::Error),
+    #[error("Borrow Mut Error: {0}")]
+    BorrowMutError(#[from] std::cell::BorrowMutError),
+    #[error("Borrow Error: {0}")]
+    BorrowError(#[from] std::cell::BorrowError),
+}
+
 /// Historians are a way for the simulation to record or notify of
 /// actions while the game is progressing. This is useful for
 /// logging, debugging, or even for implementing a replay system.
@@ -12,11 +25,24 @@ pub trait Historian {
     /// - `id` - The id of the simulation that the action was received on.
     /// - `game_state` - The game state after the action was played
     /// - `action` - The action that was played
-    fn record_action(&mut self, id: &uuid::Uuid, game_state: &GameState, action: Action);
+    ///
+    /// # Returns
+    /// - `Ok(())` if the action was recorded successfully
+    /// - `Err(HistorianError)` if there was an error recording the action.
+    ///
+    /// Returning an error will cause the historian to be dropped from the
+    /// `Simulation`.
+    fn record_action(
+        &mut self,
+        id: &uuid::Uuid,
+        game_state: &GameState,
+        action: Action,
+    ) -> Result<(), HistorianError>;
 }
 
 mod fn_historian;
 mod vec;
 
 pub use fn_historian::FnHistorian;
+use thiserror::Error;
 pub use vec::VecHistorian;

--- a/src/arena/historian/vec.rs
+++ b/src/arena/historian/vec.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::arena::action::Action;
 
-use super::Historian;
+use super::{Historian, HistorianError};
 
 /// VecHistorian is a historian that will
 /// append each action to a vector.
@@ -22,8 +22,10 @@ impl Historian for VecHistorian {
         _id: &uuid::Uuid,
         _game_state: &crate::arena::GameState,
         action: Action,
-    ) {
-        self.actions.borrow_mut().push(action)
+    ) -> Result<(), HistorianError> {
+        let mut act = self.actions.try_borrow_mut()?;
+        act.push(action);
+        Ok(())
     }
 }
 

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -84,5 +84,6 @@ pub mod test_util;
 
 pub use agent::Agent;
 pub use game_state::GameState;
+pub use historian::{Historian, HistorianError};
 pub use sim_builder::{HoldemSimulationBuilder, RngHoldemSimulationBuilder};
 pub use simulation::HoldemSimulation;


### PR DESCRIPTION
Summary:
Historians are just watching the simulation. We should be able to drop some of them out.

Test Plan:
Use it in cfr and logging