### PR TITLE
Fix typo: ammount -> amount

### DIFF
--- a/src/arena/action.rs
+++ b/src/arena/action.rs
@@ -36,7 +36,7 @@ pub struct DealStartingHandPayload {
 /// A player tried to play an action and failed
 pub struct ForcedBetPayload {
     /// A bet that the player is forced to make
-    /// The ammount is the forced ammount, not the final
+    /// The amount is the forced amount, not the final
     /// amount which could be lower if that puts the player all in.
     pub bet: f32,
     pub player_stack: f32,
@@ -69,7 +69,7 @@ pub struct PlayedActionPayload {
 }
 
 impl PlayedActionPayload {
-    pub fn raise_ammount(&self) -> f32 {
+    pub fn raise_amount(&self) -> f32 {
         self.final_bet - self.starting_bet
     }
 }
@@ -86,7 +86,7 @@ pub struct FailedActionPayload {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AwardPayload {
     pub total_pot: f32,
-    pub award_ammount: f32,
+    pub award_amount: f32,
     pub rank: Option<Rank>,
     pub hand: Option<Hand>,
     pub idx: usize,
@@ -106,7 +106,7 @@ pub enum Action {
     /// If the action failed then there is no PlayedAction event coming.
     ///
     /// Players can fail to fold when there's no money being wagered.
-    /// Players can fail to bet when they bet an illegal ammount.
+    /// Players can fail to bet when they bet an illegal amount.
     FailedAction(FailedActionPayload),
     ForcedBet(ForcedBetPayload),
     /// A community card has been dealt.

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -83,7 +83,7 @@ impl Agent for RandomAgent {
             AgentAction::Bet(curr_bet)
         } else if max > min {
             // If there's some range and the rng didn't choose another option. So bet some
-            // ammount.
+            // amount.
             AgentAction::Bet(rng.gen_range(min..max))
         } else {
             AgentAction::Bet(max)

--- a/src/arena/errors.rs
+++ b/src/arena/errors.rs
@@ -4,9 +4,9 @@ use thiserror::Error;
 pub enum GameStateError {
     #[error("Invalid number for a bet")]
     BetInvalidSize,
-    #[error("The ammount bet doesn't call the previous bet")]
+    #[error("The amount bet doesn't call the previous bet")]
     BetSizeDoesntCall,
-    #[error("The ammount bet doesn't call our own previous bet")]
+    #[error("The amount bet doesn't call our own previous bet")]
     BetSizeDoesntCallSelf,
     #[error("The raise is below the minimum raise size")]
     RaiseSizeTooSmall,

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -277,7 +277,7 @@ impl HoldemSimulation {
                     self.record_action(Action::Award(AwardPayload {
                         idx: *idx,
                         total_pot: pot as f32,
-                        award_ammount: split as f32,
+                        award_amount: split as f32,
                         // Since we had a showdown we cen copy the hand
                         // and the resulting rank.
                         rank: Some(rank),
@@ -425,8 +425,8 @@ impl HoldemSimulation {
                     self.player_fold();
                 }
             }
-            AgentAction::Bet(bet_ammount) => {
-                let bet_result = self.game_state.do_bet(bet_ammount, false);
+            AgentAction::Bet(bet_amount) => {
+                let bet_result = self.game_state.do_bet(bet_amount, false);
 
                 match bet_result {
                     Err(error) => {
@@ -508,7 +508,7 @@ impl HoldemSimulation {
                 self.record_action(Action::Award(AwardPayload {
                     idx: winning_idx,
                     total_pot,
-                    award_ammount: total_pot,
+                    award_amount: total_pot,
                     rank: None,
                     hand: None,
                 }))


### PR DESCRIPTION
I hope this helps. I assume the changes to the public interface are compatible with a 3.0.0 release, but of course I might be wrong.