### PR TITLE
Introduce an ante round before preflop

### DIFF
--- a/benches/arena.rs
+++ b/benches/arena.rs
@@ -10,6 +10,7 @@ use rs_poker::arena::GameState;
 use rs_poker::arena::HoldemSimulationBuilder;
 
 const STARTING_STACK: f32 = 100_000.0;
+const ANTE: f32 = 50.0;
 const SMALL_BLIND: f32 = 250.0;
 const BIG_BLIND: f32 = 500.0;
 
@@ -21,7 +22,7 @@ const RANDOM_CHANCES: [(f64, f64); 5] =
 
 fn run_one_arena(num_players: usize, percent_fold: f64, percent_call: f64) -> GameState {
     let stacks = vec![STARTING_STACK; num_players];
-    let game_state = GameState::new(stacks, BIG_BLIND, SMALL_BLIND, 0);
+    let game_state = GameState::new(stacks, BIG_BLIND, SMALL_BLIND, ANTE, 0);
     let agents: Vec<Box<dyn Agent>> = (0..num_players)
         .map(|_| -> Box<dyn Agent> {
             Box::new(RandomAgent::new(vec![percent_fold], vec![percent_call]))
@@ -38,7 +39,7 @@ fn run_one_arena(num_players: usize, percent_fold: f64, percent_call: f64) -> Ga
 
 fn run_one_pot_control_arena(num_players: usize) -> GameState {
     let stacks = vec![STARTING_STACK; num_players];
-    let game_state = GameState::new(stacks, BIG_BLIND, SMALL_BLIND, 0);
+    let game_state = GameState::new(stacks, BIG_BLIND, SMALL_BLIND, ANTE, 0);
     let agents: Vec<Box<dyn Agent>> = (0..num_players)
         .map(|_idx| -> Box<dyn Agent> { Box::new(RandomPotControlAgent::new(vec![0.3])) })
         .collect();

--- a/examples/agent_battle.rs
+++ b/examples/agent_battle.rs
@@ -22,7 +22,7 @@ fn main() {
     // Starting stack of at least 10 big blinds (10x10=100 chips)
     // Starting stack of no more than 1000 big blinds (10x1000=10000 chips)
     // This isn't deep stack poker at it's finest.
-    let game_state_gen = RandomGameStateGenerator::new(agents.len(), 100.0, 10000.0, 10.0, 5.0);
+    let game_state_gen = RandomGameStateGenerator::new(agents.len(), 100.0, 10000.0, 10.0, 5.0, 0.0);
     let gen = StandardSimulationGenerator::new(
         CloningAgentsGenerator::new(agents),
         game_state_gen,

--- a/examples/agent_battle.rs
+++ b/examples/agent_battle.rs
@@ -22,7 +22,8 @@ fn main() {
     // Starting stack of at least 10 big blinds (10x10=100 chips)
     // Starting stack of no more than 1000 big blinds (10x1000=10000 chips)
     // This isn't deep stack poker at it's finest.
-    let game_state_gen = RandomGameStateGenerator::new(agents.len(), 100.0, 10000.0, 10.0, 5.0, 0.0);
+    let game_state_gen =
+        RandomGameStateGenerator::new(agents.len(), 100.0, 10000.0, 10.0, 5.0, 0.0);
     let gen = StandardSimulationGenerator::new(
         CloningAgentsGenerator::new(agents),
         game_state_gen,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ features = ["arbitrary", "arena", "arena-test-util"]
 libfuzzer-sys = { version = "0.4.6", features = ["arbitrary-derive"] }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 rand = "0.8.5"
+approx = "0.5.1"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/multi_replay_agent.rs
+++ b/fuzz/fuzz_targets/multi_replay_agent.rs
@@ -26,6 +26,7 @@ struct MultiInput {
     pub players: Vec<PlayerInput>,
     pub sb: f32,
     pub bb: f32,
+    pub ante: f32,
     pub dealer_idx: usize,
     pub seed: u64,
 }
@@ -38,6 +39,7 @@ fuzz_target!(|input: MultiInput| {
     let num_players = input.players.len();
     let sb = input.sb;
     let bb = input.bb;
+    let ante = input.ante;
 
     for player in &input.players {
         if player.stack.is_nan() || player.stack.is_infinite() || player.stack.is_sign_negative() {
@@ -45,12 +47,12 @@ fuzz_target!(|input: MultiInput| {
         }
     }
 
-    // Extract the stacks adding the big blind to make sure that every agent can at
-    // least post the blinds (which would be required at any tale in the world)
+    // Extract the stacks adding the big blind and the ante to make sure that every agent
+    // can at least post the blinds (which would be required at any table in the world)
     let stacks: Vec<f32> = input
         .players
         .iter()
-        .map(|pi| (pi.stack + bb).min(0.0).max(1_000_000.0))
+        .map(|pi| (pi.stack + bb + ante).clamp(0.0, 1_000_000.0))
         .collect();
 
     // The Safety Valves for input
@@ -62,18 +64,18 @@ fuzz_target!(|input: MultiInput| {
     }
 
     // Handle floating point weirdness
-    if bb.is_infinite() || sb.is_infinite() {
+    if ante.is_sign_negative() || ante.is_nan() || ante.is_infinite() {
         return;
     }
-    if sb.is_sign_negative() || sb.is_nan() || sb.is_infinite() {
+    if sb.is_sign_negative() || sb.is_nan() || sb.is_infinite() || sb < ante {
         return;
     }
-    if bb.is_sign_negative() || bb.is_nan() || bb.is_infinite()  || bb < sb || bb < 2.0 {
+    if bb.is_sign_negative() || bb.is_nan() || bb.is_infinite() || bb < sb || bb < 2.0 {
         return;
     }
 
     // If we can't post then what's the point?
-    if bb > stacks.clone().into_iter().reduce(f32::min).unwrap_or(0.0) {
+    if bb + ante > stacks.clone().into_iter().reduce(f32::min).unwrap_or(0.0) {
         return;
     }
 
@@ -90,7 +92,7 @@ fuzz_target!(|input: MultiInput| {
     // Create the game state
     // Notice that dealer_idx is sanitized to ensure it's in the proper range here
     // rather than with the rest of the safety checks.
-    let game_state = GameState::new(stacks, bb, sb, input.dealer_idx % agents.len());
+    let game_state = GameState::new(stacks, bb, sb, ante, input.dealer_idx % agents.len());
     let rng = StdRng::seed_from_u64(input.seed);
 
     // Do the thing

--- a/fuzz/fuzz_targets/replay_agent.rs
+++ b/fuzz/fuzz_targets/replay_agent.rs
@@ -1,10 +1,12 @@
 #![no_main]
 
+extern crate approx;
 extern crate arbitrary;
 extern crate libfuzzer_sys;
 extern crate rand;
 extern crate rs_poker;
 
+use approx::assert_relative_ne;
 use rand::{rngs::StdRng, SeedableRng};
 
 use rs_poker::arena::{
@@ -23,8 +25,8 @@ struct Input {
 }
 
 fuzz_target!(|input: Input| {
-    let stacks = vec![50; 2];
-    let game_state = GameState::new(stacks, 2, 1, 0);
+    let stacks = vec![50.0; 2];
+    let game_state = GameState::new(stacks, 2.0, 1.0, 0.0, 0);
     let agents: Vec<Box<dyn Agent>> = vec![
         Box::<VecReplayAgent>::new(VecReplayAgent::new(input.dealer_actions)),
         Box::<VecReplayAgent>::new(VecReplayAgent::new(input.sb_actions)),
@@ -39,7 +41,7 @@ fuzz_target!(|input: Input| {
     sim.run();
 
     assert_eq!(Round::Complete, sim.game_state.round);
-    assert_ne!(0, sim.game_state.player_bet.iter().sum());
+    assert_relative_ne!(0.0_f32, sim.game_state.player_bet.iter().sum());
 
     assert_valid_round_data(&sim.game_state.round_data);
 });

--- a/src/arena/action.rs
+++ b/src/arena/action.rs
@@ -15,6 +15,7 @@ pub enum AgentAction {
 #[derive(Debug, Clone, PartialEq)]
 /// The game has started.
 pub struct GameStartPayload {
+    pub ante: f32,
     pub small_blind: f32,
     pub big_blind: f32,
 }

--- a/src/arena/agent/calling.rs
+++ b/src/arena/agent/calling.rs
@@ -25,7 +25,7 @@ mod tests {
     #[test_log::test]
     fn test_call_agents() {
         let stacks = vec![100.0; 4];
-        let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
         let mut sim = HoldemSimulationBuilder::default()
             .rng(thread_rng())
             .game_state(game_state)

--- a/src/arena/agent/folding.rs
+++ b/src/arena/agent/folding.rs
@@ -30,7 +30,7 @@ mod tests {
         let stacks = vec![100.0; 2];
         let rng = StdRng::seed_from_u64(420);
 
-        let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
         let mut sim = RngHoldemSimulationBuilder::default()
             .rng(rng)
             .game_state(game_state)

--- a/src/arena/agent/folding.rs
+++ b/src/arena/agent/folding.rs
@@ -46,6 +46,6 @@ mod tests {
         assert_relative_eq!(15.0_f32, sim.game_state.player_bet.iter().sum());
 
         assert_relative_eq!(15.0_f32, sim.game_state.player_winnings.iter().sum());
-        assert_relative_eq!(15.0_f32, sim.game_state.player_winnings[0]);
+        assert_relative_eq!(15.0_f32, sim.game_state.player_winnings[1]);
     }
 }

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -225,7 +225,7 @@ mod tests {
         let mut deck: FlatDeck = Deck::default().into();
 
         let stacks = vec![100.0; 5];
-        let mut game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let mut game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
         let agents: Vec<Box<dyn Agent>> = vec![
             Box::<RandomAgent>::default(),
             Box::<RandomAgent>::default(),
@@ -273,7 +273,7 @@ mod tests {
     #[test_log::test]
     fn test_five_pot_control() {
         let stacks = vec![100.0; 5];
-        let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
         let agents: Vec<Box<dyn Agent>> = vec![
             Box::new(RandomPotControlAgent::new(vec![0.3])),
             Box::new(RandomPotControlAgent::new(vec![0.3])),
@@ -313,7 +313,7 @@ mod tests {
     #[test_log::test]
     fn test_random_agents_no_fold_get_all_rounds() {
         let stacks = vec![100.0; 5];
-        let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
         let agents: Vec<Box<dyn Agent>> = vec![
             Box::new(RandomAgent::new(vec![0.0], vec![0.75])),
             Box::new(RandomAgent::new(vec![0.0], vec![0.75])),

--- a/src/arena/agent/replay.rs
+++ b/src/arena/agent/replay.rs
@@ -86,7 +86,7 @@ mod tests {
         ]));
 
         let stacks = vec![700.0, 900.0, 100.0, 800.0];
-        let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
         let agents: Vec<Box<dyn Agent>> = vec![agent_one, agent_two, agent_three, agent_four];
         let rng = StdRng::seed_from_u64(421);
 
@@ -128,7 +128,7 @@ mod tests {
         ]));
 
         let stacks = vec![22784.0, 260.0, 65471.0, 255.0, 65471.0];
-        let game_state = GameState::new(stacks, 114.0, 96.0, 210439175936 % 5);
+        let game_state = GameState::new(stacks, 114.0, 96.0, 0.0, 210439175936 % 5);
         let agents: Vec<Box<dyn Agent>> =
             vec![agent_one, agent_two, agent_three, agent_four, agent_five];
         let rng = StdRng::seed_from_u64(0);

--- a/src/arena/competition/generators.rs
+++ b/src/arena/competition/generators.rs
@@ -34,6 +34,7 @@ pub struct RandomGameStateGenerator {
     max_stack: f32,
     big_blind: f32,
     small_blind: f32,
+    ante: f32,
 }
 
 impl RandomGameStateGenerator {
@@ -43,6 +44,7 @@ impl RandomGameStateGenerator {
         max_stack: f32,
         big_blind: f32,
         small_blind: f32,
+        ante: f32,
     ) -> RandomGameStateGenerator {
         RandomGameStateGenerator {
             num_players,
@@ -50,6 +52,7 @@ impl RandomGameStateGenerator {
             max_stack,
             big_blind,
             small_blind,
+            ante,
         }
     }
 }
@@ -67,6 +70,7 @@ impl GameStateGenerator for RandomGameStateGenerator {
             stacks,
             self.big_blind,
             self.small_blind,
+            self.ante,
             rng.gen_range(0..num_players),
         )
     }
@@ -119,7 +123,7 @@ impl AgentsGenerator for CloningAgentsGenerator {
     /// ];
     ///
     /// let stacks = vec![100.0, 100.0];
-    /// let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+    /// let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
     /// let mut sim_gen = CloningAgentsGenerator::new(agents);
     ///
     /// let agents = sim_gen.generate(&game_state);

--- a/src/arena/competition/sim_gen.rs
+++ b/src/arena/competition/sim_gen.rs
@@ -90,7 +90,7 @@ mod tests {
         ];
 
         let stacks = vec![100.0, 100.0];
-        let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
         let mut sim_gen = StandardSimulationGenerator::new(
             CloningAgentsGenerator::new(agents),
             CloneGameStateGenerator::new(game_state),

--- a/src/arena/game_state.rs
+++ b/src/arena/game_state.rs
@@ -176,7 +176,13 @@ pub struct GameState {
 }
 
 impl GameState {
-    pub fn new(stacks: Vec<f32>, big_blind: f32, small_blind: f32, ante: f32, dealer_idx: usize) -> Self {
+    pub fn new(
+        stacks: Vec<f32>,
+        big_blind: f32,
+        small_blind: f32,
+        ante: f32,
+        dealer_idx: usize,
+    ) -> Self {
         let num_players = stacks.len();
         GameState {
             num_players,

--- a/src/arena/game_state.rs
+++ b/src/arena/game_state.rs
@@ -239,24 +239,8 @@ impl GameState {
     pub fn advance_round(&mut self) {
         match self.round {
             Round::Complete => (),
-            Round::Ante => self.advance_preflop(),
             _ => self.advance_normal(),
         }
-    }
-
-    fn advance_preflop(&mut self) {
-        self.round = self.round.advance();
-        // create a new round data
-        // and advance to the next player after
-        // the dealer to start dealing cards.
-        let mut round_data = RoundData::new(
-            self.num_players,
-            self.big_blind,
-            self.player_active,
-            self.dealer_idx,
-        );
-        round_data.advance_action();
-        self.round_data = round_data;
     }
 
     fn advance_normal(&mut self) {
@@ -268,7 +252,10 @@ impl GameState {
             self.player_active,
             self.dealer_idx,
         );
-        if !self.player_active.get(round_data.to_act_idx) {
+        round_data.advance_action();
+        if self.round == Round::Preflop && self.num_players == 2 {
+            // With only two players, it is the dealer that has
+            // to post the small blind, so pass the action back.
             round_data.advance_action();
         }
         self.round_data = round_data;

--- a/src/arena/game_state.rs
+++ b/src/arena/game_state.rs
@@ -10,6 +10,7 @@ use super::errors::GameStateError;
 pub enum Round {
     #[default]
     Starting,
+    Ante,
     Preflop,
     Flop,
     Turn,
@@ -22,6 +23,7 @@ impl Display for Round {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Round::Starting => write!(f, "Starting"),
+            Round::Ante => write!(f, "Ante"),
             Round::Preflop => write!(f, "Preflop"),
             Round::Flop => write!(f, "Flop"),
             Round::Turn => write!(f, "Turn"),
@@ -35,7 +37,8 @@ impl Display for Round {
 impl Round {
     pub fn advance(&self) -> Self {
         match *self {
-            Round::Starting => Round::Preflop,
+            Round::Starting => Round::Ante,
+            Round::Ante => Round::Preflop,
             Round::Preflop => Round::Flop,
             Round::Flop => Round::Turn,
             Round::Turn => Round::River,
@@ -154,6 +157,8 @@ pub struct GameState {
     pub big_blind: f32,
     /// The small blind size
     pub small_blind: f32,
+    /// The ante size
+    pub ante: f32,
     /// The hands for each player. We keep hands
     /// even if the player is not currently active.
     pub hands: Vec<Hand>,
@@ -171,7 +176,7 @@ pub struct GameState {
 }
 
 impl GameState {
-    pub fn new(stacks: Vec<f32>, big_blind: f32, small_blind: f32, dealer_idx: usize) -> Self {
+    pub fn new(stacks: Vec<f32>, big_blind: f32, small_blind: f32, ante: f32, dealer_idx: usize) -> Self {
         let num_players = stacks.len();
         GameState {
             num_players,
@@ -179,6 +184,7 @@ impl GameState {
             stacks,
             big_blind,
             small_blind,
+            ante,
             player_active: PlayerBitSet::new(num_players),
             player_all_in: PlayerBitSet::default(),
             player_bet: vec![0.0; num_players],
@@ -233,7 +239,7 @@ impl GameState {
     pub fn advance_round(&mut self) {
         match self.round {
             Round::Complete => (),
-            Round::Starting => self.advance_preflop(),
+            Round::Ante => self.advance_preflop(),
             _ => self.advance_normal(),
         }
     }
@@ -427,6 +433,7 @@ impl fmt::Debug for GameState {
             .field("stacks", &self.stacks)
             .field("big_blind", &self.big_blind)
             .field("small_blind", &self.small_blind)
+            .field("ante", &self.ante)
             .field("hands", &self.hands)
             .field("dealer_idx", &self.dealer_idx)
             .field("round", &self.round)
@@ -443,7 +450,8 @@ mod tests {
     #[test]
     fn test_fold_around_call() {
         let stacks = vec![100.0; 4];
-        let mut game_state = GameState::new(stacks, 10.0, 5.0, 1);
+        let mut game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 1);
+        game_state.advance_round();
         game_state.advance_round();
 
         // 0 player, 1 dealer, 2 small blind, 3 big blind
@@ -498,7 +506,8 @@ mod tests {
     #[test]
     fn test_cant_bet_less_0() {
         let stacks = vec![100.0; 5];
-        let mut game_state = GameState::new(stacks, 2.0, 1.0, 0);
+        let mut game_state = GameState::new(stacks, 2.0, 1.0, 0.0, 0);
+        game_state.advance_round();
         game_state.advance_round();
 
         game_state.do_bet(33.0, false).unwrap();
@@ -511,8 +520,9 @@ mod tests {
     #[test]
     fn test_cant_bet_less_with_all_in() {
         let stacks = vec![100.0, 50.0, 50.0, 100.0, 10.0];
-        let mut game_state = GameState::new(stacks, 2.0, 1.0, 0);
-        // Post blinds and setup next to act
+        let mut game_state = GameState::new(stacks, 2.0, 1.0, 0.0, 0);
+        // Do the start and ante rounds and setup next to act
+        game_state.advance_round();
         game_state.advance_round();
 
         // UTG raises to 10
@@ -536,8 +546,9 @@ mod tests {
     #[test]
     fn test_cant_under_minraise_bb() {
         let stacks = vec![500.0; 5];
-        let mut game_state = GameState::new(stacks, 20.0, 10.0, 0);
-        // Post blinds and setup next to act
+        let mut game_state = GameState::new(stacks, 20.0, 10.0, 0.0, 0);
+        // Do the start and ante rounds and setup next to act
+        game_state.advance_round();
         game_state.advance_round();
 
         game_state.do_bet(10.0, true).unwrap();

--- a/src/arena/historian/fn_historian.rs
+++ b/src/arena/historian/fn_historian.rs
@@ -49,7 +49,7 @@ mod tests {
         let agents: Vec<Box<dyn Agent>> = (0..2)
             .map(|_| Box::<RandomAgent>::default() as Box<dyn Agent>)
             .collect();
-        let game_state = GameState::new(vec![100.0, 100.0], 10.0, 5.0, 0);
+        let game_state = GameState::new(vec![100.0, 100.0], 10.0, 5.0, 0.0, 0);
 
         let borrow_count = count.clone();
         let borrow_last_action = last_action.clone();
@@ -88,7 +88,7 @@ mod tests {
             .map(|_| Box::<RandomAgent>::default() as Box<dyn Agent>)
             .collect();
 
-        let game_state = GameState::new(vec![100.0, 100.0], 10.0, 5.0, 0);
+        let game_state = GameState::new(vec![100.0, 100.0], 10.0, 5.0, 0.0, 0);
         let historian = Box::new(FnHistorian::new(|_, _, _| {
             Err(HistorianError::UnableToRecordAction)
         }));

--- a/src/arena/historian/vec.rs
+++ b/src/arena/historian/vec.rs
@@ -48,7 +48,7 @@ mod tests {
             Box::<RandomAgent>::default(),
             Box::<RandomAgent>::default(),
         ];
-        let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
 
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -21,7 +21,7 @@
 //! ];
 //! let rng = StdRng::seed_from_u64(420);
 //!
-//! let game_state = GameState::new(stacks, 10.0, 5.0, 0);
+//! let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
 //! let mut sim = RngHoldemSimulationBuilder::default()
 //!     .game_state(game_state)
 //!     .rng(rng)
@@ -57,7 +57,7 @@
 //! ];
 //!
 //! let agent_gen = CloningAgentsGenerator::new(agents);
-//! let game_state_gen = RandomGameStateGenerator::new(3, 100.0, 500.0, 10.0, 5.0);
+//! let game_state_gen = RandomGameStateGenerator::new(3, 100.0, 500.0, 10.0, 5.0, 0.0);
 //! let sim_gen =
 //!     StandardSimulationGenerator::new(agent_gen, game_state_gen, EmptyHistorianGenerator);
 //!

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -153,7 +153,7 @@ impl HoldemSimulation {
                 self.game_state.do_bet(ante, true).unwrap();
                 self.record_action(Action::ForcedBet(ForcedBetPayload {
                     bet: ante,
-                    idx: idx,
+                    idx,
                     player_stack: self.game_state.stacks[idx],
                 }));
 

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -90,6 +90,7 @@ impl HoldemSimulation {
             // in order to use the per round active bit set
             // for iterating players
             Round::Starting => self.start(),
+            Round::Ante => self.ante(),
             Round::Preflop => self.preflop(),
             Round::Flop => self.flop(),
             Round::Turn => self.turn(),
@@ -105,10 +106,11 @@ impl HoldemSimulation {
         let span = trace_span!("start");
         let _enter = span.enter();
 
-        // Add an action to record the sb and bb
+        // Add an action to record the ante, sb and bb
         // This should allow recreating starting game state
         // together with PlayerSit actions.
         self.record_action(Action::GameStart(GameStartPayload {
+            ante: self.game_state.ante,
             small_blind: self.game_state.small_blind,
             big_blind: self.game_state.big_blind,
         }));
@@ -141,11 +143,31 @@ impl HoldemSimulation {
         self.advance_round();
     }
 
+    fn ante(&mut self) {
+        let ante = self.game_state.ante;
+        if ante > 0.0 {
+            // Force the ante from each active player.
+            while self.game_state.current_round_num_active_players() > 0 {
+                let idx = self.game_state.to_act_idx();
+
+                self.game_state.do_bet(ante, true).unwrap();
+                self.record_action(Action::ForcedBet(ForcedBetPayload {
+                    bet: ante,
+                    idx: idx,
+                    player_stack: self.game_state.stacks[idx],
+                }));
+
+                self.game_state.round_data.player_active.disable(idx);
+            }
+        }
+        self.advance_round();
+    }
+
     fn preflop(&mut self) {
         let span = trace_span!("preflop");
         let _enter = span.enter();
 
-        // We have two different bets to force.
+        // Force the small blind and the big blind.
         let sb = self.game_state.small_blind;
         let sb_idx = self.game_state.to_act_idx();
         self.game_state.do_bet(sb, true).unwrap();


### PR DESCRIPTION
I experimented a bit with changes to GameState to support an ante in addition to the small blind and big blind. The approach in this pull request is to introduce a separate "Ante" round before "Starting" and "Preflop", which is admittedly quite intrusive and impacts a lot of code. Anyway, I am sharing it here in case it is of interest.

A separate commit adjusts the selection of the player first to act after each round (see #102).