### PR TITLE
fix: allow simulations to restart from player actions

### DIFF
--- a/src/arena/action.rs
+++ b/src/arena/action.rs
@@ -32,6 +32,12 @@ pub struct DealStartingHandPayload {
     pub card: Card,
     pub idx: usize,
 }
+#[derive(Debug, Clone, PartialEq)]
+pub enum ForcedBetType {
+    Ante,
+    SmallBlind,
+    BigBlind,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 /// A player tried to play an action and failed
@@ -42,6 +48,7 @@ pub struct ForcedBetPayload {
     pub bet: f32,
     pub player_stack: f32,
     pub idx: usize,
+    pub forced_bet_type: ForcedBetType,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/arena/agent/mod.rs
+++ b/src/arena/agent/mod.rs
@@ -22,4 +22,4 @@ pub trait Agent {
 pub use calling::CallingAgent;
 pub use folding::FoldingAgent;
 pub use random::{RandomAgent, RandomPotControlAgent};
-pub use replay::{SliceReplayAgent, VecReplayAgent};
+pub use replay::{SharedVecReplayAgent, SliceReplayAgent, VecReplayAgent};

--- a/src/arena/historian/vec.rs
+++ b/src/arena/historian/vec.rs
@@ -1,18 +1,29 @@
 use std::{cell::RefCell, rc::Rc};
 
-use crate::arena::action::Action;
+use crate::arena::{action::Action, GameState};
 
 use super::{Historian, HistorianError};
+
+#[derive(Debug, Clone)]
+pub struct HistoryRecord {
+    pub before_game_state: Option<GameState>,
+    pub action: Action,
+    pub after_game_state: GameState,
+}
 
 /// VecHistorian is a historian that will
 /// append each action to a vector.
 pub struct VecHistorian {
-    actions: Rc<RefCell<Vec<Action>>>,
+    previous: Option<GameState>,
+    records: Rc<RefCell<Vec<HistoryRecord>>>,
 }
 
 impl VecHistorian {
-    pub fn new(actions: Rc<RefCell<Vec<Action>>>) -> Self {
-        Self { actions }
+    pub fn new(actions: Rc<RefCell<Vec<HistoryRecord>>>) -> Self {
+        Self {
+            records: actions,
+            previous: None,
+        }
     }
 }
 
@@ -20,25 +31,37 @@ impl Historian for VecHistorian {
     fn record_action(
         &mut self,
         _id: &uuid::Uuid,
-        _game_state: &crate::arena::GameState,
+        game_state: &GameState,
         action: Action,
     ) -> Result<(), HistorianError> {
-        let mut act = self.actions.try_borrow_mut()?;
-        act.push(action);
+        let mut act = self.records.try_borrow_mut()?;
+
+        // Now that we have the lock, we can record the action
+        act.push(HistoryRecord {
+            before_game_state: self.previous.clone(),
+            action,
+            after_game_state: game_state.clone(),
+        });
+
+        // Record the game state for the next action
+        self.previous = Some(game_state.clone());
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::arena::{agent::RandomAgent, Agent, GameState, HoldemSimulationBuilder};
+    use crate::arena::{
+        agent::{CallingAgent, RandomAgent},
+        Agent, HoldemSimulationBuilder,
+    };
 
     use super::*;
 
     #[test]
     fn test_vec_historian() {
-        let actions = Rc::new(RefCell::new(Vec::new()));
-        let hist = Box::new(VecHistorian::new(actions.clone()));
+        let records = Rc::new(RefCell::new(Vec::new()));
+        let hist = Box::new(VecHistorian::new(records.clone()));
 
         let stacks = vec![100.0; 5];
         let agents: Vec<Box<dyn Agent>> = vec![
@@ -59,7 +82,70 @@ mod tests {
 
         sim.run();
 
-        assert!(actions.borrow().len() > 10);
-        dbg!(&actions.borrow());
+        assert!(records.borrow().len() > 10);
+    }
+
+    #[test]
+    fn test_restarting_simulations() {
+        // The first records.
+        let records = Rc::new(RefCell::new(Vec::new()));
+        let hist = Box::new(VecHistorian::new(records.clone()));
+
+        let stacks = vec![100.0; 2];
+        let agents: Vec<Box<dyn Agent>> = vec![
+            Box::<CallingAgent>::default(),
+            Box::<CallingAgent>::default(),
+        ];
+
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
+
+        let mut sim = HoldemSimulationBuilder::default()
+            .game_state(game_state)
+            .agents(agents)
+            .historians(vec![hist])
+            .build()
+            .unwrap();
+
+        sim.run();
+
+        // Now we have a set of records of what happenend in the first simulation.
+        // It doesn't matter what actions the agents took, we just need to know that
+        // the simulation always restarts at asking the same player to play
+
+        for r in records.borrow().iter() {
+            if let (Action::PlayedAction(played_action), Some(before_game_state)) =
+                (&r.action, &r.before_game_state)
+            {
+                let inner_agents: Vec<Box<dyn Agent>> = vec![
+                    Box::<CallingAgent>::default(),
+                    Box::<CallingAgent>::default(),
+                ];
+
+                let inner_records = Rc::new(RefCell::new(Vec::new()));
+                let inner_hist = Box::new(VecHistorian::new(inner_records.clone()));
+
+                // We can now restart the simulation and see if the same player takes the next
+                // turn
+                let mut inner_sim = HoldemSimulationBuilder::default()
+                    .game_state(before_game_state.clone())
+                    .agents(inner_agents)
+                    .historians(vec![inner_hist])
+                    .build()
+                    .unwrap();
+
+                inner_sim.run();
+
+                let first_record = inner_records.borrow().first().unwrap().clone();
+
+                if let Action::PlayedAction(inner_played_action) = first_record.action {
+                    assert_eq!(played_action.idx, inner_played_action.idx);
+                } else {
+                    panic!(
+                        "The first action should be a played action, found {:?}",
+                        first_record.action
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -211,6 +211,9 @@ mod tests {
             assert_eq!(99.0, sim.game_state.stacks[i]);
         }
 
+        // Deal Pre-Flop
+        sim.run_round();
+
         // Post the blinds and check the results.
         sim.run_round();
         assert_eq!(6.0, sim.game_state.player_bet[1]);
@@ -245,6 +248,18 @@ mod tests {
         let mut game_state = GameState::new(stacks, 10.0, 5.0, 2.0, 0);
         let mut deck = CardBitSet::default();
 
+        // Start
+        game_state.advance_round();
+
+        // Ante
+        game_state.do_bet(2.0, true).unwrap(); // ante@idx 1
+        game_state.do_bet(2.0, true).unwrap(); // ante@idx 2
+        game_state.do_bet(2.0, true).unwrap(); // ante@idx 3
+        game_state.do_bet(2.0, true).unwrap(); // ante@idx 4
+        game_state.do_bet(2.0, true).unwrap(); // ante@idx 0
+        game_state.advance_round();
+
+        // Deal Preflop
         deal_hand_card(0, "Ks", &mut deck, &mut game_state);
         deal_hand_card(0, "Kh", &mut deck, &mut game_state);
 
@@ -259,16 +274,6 @@ mod tests {
 
         deal_hand_card(4, "9d", &mut deck, &mut game_state);
         deal_hand_card(4, "9s", &mut deck, &mut game_state);
-
-        // Start
-        game_state.advance_round();
-
-        // Ante
-        game_state.do_bet(2.0, true).unwrap(); // ante@idx 1
-        game_state.do_bet(2.0, true).unwrap(); // ante@idx 2
-        game_state.do_bet(2.0, true).unwrap(); // ante@idx 3
-        game_state.do_bet(2.0, true).unwrap(); // ante@idx 4
-        game_state.do_bet(2.0, true).unwrap(); // ante@idx 0
         game_state.advance_round();
 
         // Preflop
@@ -277,27 +282,35 @@ mod tests {
         game_state.fold(); // idx 3
         game_state.do_bet(10.0, false).unwrap(); // idx 4
         game_state.do_bet(10.0, false).unwrap(); // idx 0
-
         game_state.advance_round();
-        assert_eq!(game_state.num_active_players(), 2);
 
+        // Deal Flop
         deal_community_card("6c", &mut deck, &mut game_state);
         deal_community_card("2d", &mut deck, &mut game_state);
         deal_community_card("3d", &mut deck, &mut game_state);
+        game_state.advance_round();
+
         // Flop
+        assert_eq!(game_state.num_active_players(), 2);
         game_state.do_bet(90.0, false).unwrap(); // idx 4
         game_state.do_bet(90.0, false).unwrap(); // idx 0
         game_state.advance_round();
         assert_eq!(game_state.num_active_players(), 1);
 
+        // Deal Turn
         deal_community_card("8h", &mut deck, &mut game_state);
+        game_state.advance_round();
+
         // Turn
         game_state.do_bet(0.0, false).unwrap(); // idx 4
         game_state.advance_round();
         assert_eq!(game_state.num_active_players(), 1);
 
-        // River
+        // Deal River
         deal_community_card("8s", &mut deck, &mut game_state);
+        game_state.advance_round();
+
+        // River
         game_state.do_bet(100.0, false).unwrap(); // idx 4
         game_state.advance_round();
         assert_eq!(game_state.num_active_players(), 0);


### PR DESCRIPTION
Summary:
When given a game state a simulation should always restart from the
exact same place. This fixes the issues where we were not living up to
that

- We would double blind
- We would not respect that the last player to act in a round might be
  because we are restarting the simulation

This also splits the simulation up into a lot more rounds to make it
easier to see round changes as state changes in the game state.

Test Plan:

This was all found by the added test
Then the solution was further refined with fuzz testing
