### PR TITLE
fix: simplify betting continuation

### DIFF
--- a/fuzz/fuzz_targets/multi_replay_agent.rs
+++ b/fuzz/fuzz_targets/multi_replay_agent.rs
@@ -52,7 +52,7 @@ fuzz_target!(|input: MultiInput| {
     let stacks: Vec<f32> = input
         .players
         .iter()
-        .map(|pi| (pi.stack + bb + ante).clamp(0.0, 1_000_000.0))
+        .map(|pi| (pi.stack + bb + ante + sb).clamp(0.0, 1_000_000.0))
         .collect();
 
     // The Safety Valves for input

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -57,7 +57,7 @@ impl Agent for RandomAgent {
         // calling a pot sized bet (plus a little more for spicyness)
         //
         // That could be the same as the min
-        let pot_value = (round_data.num_active_players() as f32 + 1.0) * game_state.total_pot;
+        let pot_value = (round_data.num_players_need_action() as f32 + 1.0) * game_state.total_pot;
         let max = (player_bet + player_stack).min(pot_value).max(min);
 
         // We shouldn't fold when checking is an option.

--- a/src/arena/agent/replay.rs
+++ b/src/arena/agent/replay.rs
@@ -99,8 +99,10 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
 
     use crate::arena::{
-        action::AgentAction, agent::VecReplayAgent, test_util::assert_valid_game_state, Agent,
-        GameState, HoldemSimulation, RngHoldemSimulationBuilder,
+        action::AgentAction,
+        agent::VecReplayAgent,
+        test_util::{assert_valid_game_state, assert_valid_round_data},
+        Agent, GameState, HoldemSimulation, RngHoldemSimulationBuilder,
     };
 
     #[test_log::test]
@@ -141,6 +143,30 @@ mod tests {
             .unwrap();
         sim.run();
 
+        assert_valid_game_state(&sim.game_state);
+    }
+
+    #[test]
+    fn test_cant_bet_after_folds() {
+        let agent_one = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![]));
+        let agent_two = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![]));
+        let agent_three =
+            Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![AgentAction::Bet(100.0)]));
+
+        let stacks = vec![100.0, 100.0, 100.0];
+        let game_state = GameState::new(stacks, 10.0, 5.0, 0.0, 0);
+        let agents: Vec<Box<dyn Agent>> = vec![agent_one, agent_two, agent_three];
+        let rng = StdRng::seed_from_u64(421);
+
+        let mut sim: HoldemSimulation = RngHoldemSimulationBuilder::default()
+            .rng(rng)
+            .game_state(game_state)
+            .agents(agents)
+            .build()
+            .unwrap();
+        sim.run();
+
+        assert_valid_round_data(&sim.game_state.round_data);
         assert_valid_game_state(&sim.game_state);
     }
 

--- a/src/arena/test_util.rs
+++ b/src/arena/test_util.rs
@@ -13,7 +13,7 @@ pub fn assert_valid_round_data(round_data: &RoundData) {
         .player_bet
         .iter()
         .enumerate()
-        .filter(|(idx, _)| round_data.player_active.get(*idx))
+        .filter(|(idx, _)| round_data.needs_action.get(*idx))
         .map(|(_, bet)| *bet)
         .collect();
 

--- a/src/core/player_bit_set.rs
+++ b/src/core/player_bit_set.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::{Debug, Display},
-    ops::BitOr,
+    ops::{BitAnd, BitOr},
 };
 
 /// A struct representing a bit set for players.
@@ -128,6 +128,16 @@ impl BitOr for PlayerBitSet {
     fn bitor(self, rhs: Self) -> Self::Output {
         Self {
             set: self.set | rhs.set,
+        }
+    }
+}
+
+impl BitAnd for PlayerBitSet {
+    type Output = PlayerBitSet;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self {
+            set: self.set & rhs.set,
         }
     }
 }


### PR DESCRIPTION
Summary:
Should we ask the next agent for an action or just skip everything is a
common question. This simplifes that by cleaning up the round active
logic to be explicit about who needs to act.

Test Plan:
Tests added
Fuzzing clean
