### PR TITLE
[feat]: allow user to interact with the examples through cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -96,10 +96,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -164,6 +182,14 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "cli"
+version = "0.1.0"
+dependencies = [
+ "inquire",
+ "rs_poker",
+]
 
 [[package]]
 name = "colorchoice"
@@ -233,6 +259,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +299,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -276,6 +333,32 @@ dependencies = [
  "env_filter",
  "humantime",
  "log",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "game_simulation"
+version = "0.1.0"
+dependencies = [
+ "cli",
+ "rs_poker",
 ]
 
 [[package]]
@@ -312,6 +395,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "inquire"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b"
+dependencies = [
+ "bitflags 2.5.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,7 +419,7 @@ checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -359,6 +459,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +488,27 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -415,6 +546,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -525,6 +679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +807,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -787,6 +986,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,11 +1133,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -935,14 +1170,20 @@ version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -952,9 +1193,21 @@ checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -964,9 +1217,21 @@ checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -976,9 +1241,21 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+workspace = { members = ["examples/cli", "examples/game_simulation"] }
 [package]
 name = "rs_poker"
 version = "3.0.0-beta.14"
@@ -26,7 +27,6 @@ test-log = { version = "0.2.15", features = ["trace", "log"] }
 tracing-subscriber = {version = "0.3.18", default-features = true, features = ["env-filter", "fmt"]}
 env_logger = {version = "0.11.3"}
 approx = { version = "0.5.1"}
-
 
 [features]
 default = ["arena", "serde"]

--- a/examples/agent_battle.rs
+++ b/examples/agent_battle.rs
@@ -24,6 +24,7 @@ fn main() {
     // This isn't deep stack poker at it's finest.
     let game_state_gen =
         RandomGameStateGenerator::new(agents.len(), 100.0, 10000.0, 10.0, 5.0, 0.0);
+
     let gen = StandardSimulationGenerator::new(
         CloningAgentsGenerator::new(agents),
         game_state_gen,

--- a/examples/cli/Cargo.toml
+++ b/examples/cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cli"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+inquire = "0.7.4"
+rs_poker = { path = "../.." }
+

--- a/examples/cli/src/lib.rs
+++ b/examples/cli/src/lib.rs
@@ -1,0 +1,100 @@
+use std::fmt::Display;
+
+use rs_poker::core::{Hand, RSPokerError};
+
+use inquire::{error::InquireResult, validator::Validation, Select, Text};
+
+#[derive(Debug, Copy, Clone)]
+pub enum GameType {
+    MonteCarlo,
+    Omaha,
+}
+
+impl Display for GameType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as std::fmt::Debug>::fmt(&self, f)
+    }
+}
+
+pub struct Config {
+    pub game_type: GameType,
+    pub num_of_players: u8,
+    pub hands: Vec<Hand>,
+    pub num_of_games_to_simulate: u64,
+}
+
+impl Config {
+    pub fn new() -> InquireResult<Self> {
+        let game_type =
+            Select::new("Type of game:", vec![GameType::MonteCarlo, GameType::Omaha]).prompt()?;
+
+        let num_of_players = Text::new("Number of players:")
+            .with_help_message("requires a number between 2 - 10")
+            .with_validator(|input: &str| {
+                const NUM_PLAYERS_ERR: &'static str = "Please enter a number between 2 to 10";
+
+                if let Ok(parsed_num) = u8::from_str_radix(input, 10) {
+                    if parsed_num <= 10 && parsed_num >= 2 {
+                        Ok(Validation::Valid)
+                    } else {
+                        Ok(Validation::Invalid(NUM_PLAYERS_ERR.into()))
+                    }
+                } else {
+                    Ok(Validation::Invalid(NUM_PLAYERS_ERR.into()))
+                }
+            })
+            .prompt()?
+            .parse::<u8>()
+            //[SAFETY]: this should be never panic as we already did the necessary validation
+            .unwrap();
+
+        let hands = (0..num_of_players)
+            .map(|player_num| -> InquireResult<Hand> {
+                let hand = Text::new(&format!("Hand of player {}:", player_num + 1))
+                    .with_help_message("A valid hand is contiguous string of valid cards. Each card is a 2 character sequence starting with a valid `Value` identifier, followed by a valid `Suite` identifier")
+                    .with_validator(|input: &str| {
+                        match input.parse::<Hand>() {
+                            Ok(_) => Ok(Validation::Valid),
+                            Err(RSPokerError::UnexpectedValueChar) => Ok(Validation::Invalid("Value can only be a char from [`A`, `K`, `Q`, `J`, `T`, `9`, `8`, `7`, `6`, `5`, `4`, `3`, `2`]".into())),
+                            Err(RSPokerError::UnexpectedSuitChar) => Ok(Validation::Invalid("Suite can only be a char from [`d`, `s`, `h`, `c`]".into())),
+                            Err(RSPokerError::DuplicateCardInHand(c)) => Ok(Validation::Invalid(format!("Card {c} appears more than once").into())),
+                            Err(RSPokerError::UnparsedCharsRemaining) => Ok(Validation::Invalid("Extraneous trailing characters encountered".into())),
+                            _ => unreachable!()
+                        }
+                    })
+                    .prompt()?
+                    .parse::<Hand>()
+                    //[SAFETY]: this should be never panic as we already did the necessary validation
+                    .unwrap();
+
+                Ok(hand)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let num_of_games_to_simulate = Text::new("Number of games to simulate:")
+            .with_validator(|input: &str| {
+                const NUM_PLAYERS_ERR: &'static str = "Please enter a number greater than 0";
+
+                if let Ok(parsed_num) = u64::from_str_radix(input, 10) {
+                    if parsed_num > 0 {
+                        Ok(Validation::Valid)
+                    } else {
+                        Ok(Validation::Invalid(NUM_PLAYERS_ERR.into()))
+                    }
+                } else {
+                    Ok(Validation::Invalid(NUM_PLAYERS_ERR.into()))
+                }
+            })
+            .prompt()?
+            .parse::<u64>()
+            //[SAFETY]: this should be never panic as we already did the necessary validation
+            .unwrap();
+
+        Ok(Self {
+            game_type,
+            num_of_games_to_simulate,
+            num_of_players,
+            hands,
+        })
+    }
+}

--- a/examples/game_simulate.rs
+++ b/examples/game_simulate.rs
@@ -10,8 +10,10 @@ fn main() {
         .iter()
         .map(|s| Hand::new_from_str(s).expect("Should be able to create a hand."))
         .collect();
+
     let mut g = MonteCarloGame::new(hands).expect("Should be able to create a game.");
     let mut wins: [u64; 2] = [0, 0];
+
     for _ in 0..GAMES_COUNT {
         let r = g.simulate();
         g.reset();

--- a/examples/game_simulation/Cargo.toml
+++ b/examples/game_simulation/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "game_simulation"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cli = { path = "../cli/" }
+rs_poker = { path = "../.." }
+

--- a/examples/game_simulation/src/main.rs
+++ b/examples/game_simulation/src/main.rs
@@ -1,0 +1,30 @@
+use cli::{Config, GameType};
+use rs_poker::holdem::MonteCarloGame;
+
+fn main() {
+    let config = Config::new().expect("Failed to get CLI config");
+    println!("Starting Hands =\t{:?}", &config.hands);
+
+    let mut g = match config.game_type {
+        GameType::MonteCarlo => {
+            MonteCarloGame::new(config.hands).expect("Should be able to create a game.")
+        }
+        GameType::Omaha => unimplemented!(),
+    };
+
+    let mut wins: [u64; 2] = [0, 0];
+
+    for _ in 0..config.num_of_games_to_simulate {
+        let r = g.simulate();
+        g.reset();
+        wins[r.0.ones().next().unwrap()] += 1
+    }
+
+    let normalized: Vec<f64> = wins
+        .iter()
+        .map(|cnt| *cnt as f64 / config.num_of_games_to_simulate as f64)
+        .collect();
+
+    println!("Wins =\t\t\t{:?}", wins);
+    println!("Normalized Wins =\t{:?}", normalized);
+}

--- a/src/core/hand.rs
+++ b/src/core/hand.rs
@@ -2,6 +2,7 @@ use crate::core::card::*;
 use std::ops::Index;
 use std::ops::{RangeFrom, RangeFull, RangeTo};
 use std::slice::Iter;
+use std::str::FromStr;
 
 use super::RSPokerError;
 
@@ -97,6 +98,13 @@ impl Hand {
     /// Create an iter on the cards.
     pub fn iter(&self) -> Iter<Card> {
         self.0.iter()
+    }
+}
+
+impl FromStr for Hand {
+    type Err = RSPokerError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Hand::new_from_str(s)
     }
 }
 


### PR DESCRIPTION
A quick prototype of the "interaction with examples" functionality, as far as i understood. I'll flesh things out from here if this seems fine. 

Not trying to push for a merge, but creating this PR to track the discussion related to issue #111 

Currently this allows the user to: 
- Select the `GameMode`.
  - This has two variants `MonteCarlo` and `Omaha` for now (TBH, i have no clue what any of those are). `Omaha` actually does not do anything for now. 
- Select the number of players. 
  - This is a number between 2 and 10. 
- Select the hands of each player
  - For now this is a string in the same format, which is used in the rest of the codebase and performs same validation and checks. 
- Select the number of games to simulate
  - This is any number greater than 0. 
  
This functionality is isolated inside a helper `lib` in the examples folder for now. I suspect that this might be useful in other parts of the lib as well. I have also made the `game_simulation` example as a separate rust `bin` package. (So now to run an example, you would have to use `cargo run --package game_simulation` 

I also notice that you are moving towards decoupling the core poker functionalities and the different modes of games which sit on top of the core layer. A workspace based crate organization might help with that.. But anyways i digress.

Feel free to raise any particular issues related to architecture, design or anything. 


 