### PR TITLE
fix: make llm cov package optional on osx

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
 
         packages = {
           default = rs-poker;
+        } // lib.optionalAttrs (system == "x86_64-linux") {
           rs-poker-llvm-coverage = craneLibLLvmTools.cargoLlvmCov (commonArgs // {
             inherit cargoArtifacts;
           });


### PR DESCRIPTION
Summary:
On aarch64 there's no coverage targets. So don't try and generate packages that need the tools

Test Plan:
nix flake check on my mac laptop
