### PR TITLE
chore: add cargo-release

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
             cmake
             openssl
 
+            cargo-release
             cargo-audit
             cargo-watch
             cargo-fuzz


### PR DESCRIPTION
Summary:
To the nix flake add the cargo release command so I can release from any repo

Test Plan:
direnv reload
