### PR TITLE
chore: skip a version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rs_poker"
-version = "3.0.0-beta.14"
+version = "3.0.0-beta.16"
 dependencies = [
  "approx",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_poker"
-version = "3.0.0-beta.14"
+version = "3.0.0-beta.16"
 authors = ["Elliott Clark <eclark@apache.org>"]
 keywords = ["cards", "poker"]
 categories = ["games"]


### PR DESCRIPTION
Summary:
beta.15 was released off a branch rather than master. So skip it

Test Plan:
Release master
