### PR TITLE
chore: add edition to fuzz Cargo.toml

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ name = "rs_poker-fuzz"
 version = "0.0.2"
 authors = ["Automatically generated"]
 publish = false
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
This cleans up a warning when building fuzz targets.