### PR TITLE
fix: fix fuzzing with 1.80 nightly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1713579674,
-        "narHash": "sha256-JXiXi2Egq7gHfIvigBXFSdzNsxIjk1s9fcq1ibfoD/U=",
+        "lastModified": 1719490091,
+        "narHash": "sha256-FIDzlKCLL8D02bSWgNUw0ydc+ctyV34ELirYuENvjlE=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "6ab370c779c140c9cb2e7ff1367dd1b66c415409",
+        "rev": "f5b488da7f6994a1fef6c4c78250cb25275c6c99",
         "type": "github"
       },
       "original": {
@@ -23,37 +23,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1713673197,
-        "narHash": "sha256-akCll53JuKHtJc76NGs92bnPGGRW5eufm6XXVJ+VgAs=",
+        "lastModified": 1719249093,
+        "narHash": "sha256-0q1haa3sw6GbmJ+WhogMnducZGjEaCa/iR6hF2vq80I=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3dda6d40ca7ae22cad80269709fb223ed6288f08",
+        "rev": "9791c77eb7e98b8d8ac5b0305d47282f994411ca",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": []
-      },
-      "locked": {
-        "lastModified": 1713680591,
-        "narHash": "sha256-3pbv7UgAgetwz9YdjzIT/lZ6Rgj6wj6MR4mphBLyDjU=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "19aaa94a73cc670a4d87e84f0909966cd8f8cd79",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
         "type": "github"
       }
     },
@@ -77,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713627711,
-        "narHash": "sha256-kWlK1w/rqPBrs5rF4btRgXpzVstmNxA8rgc6kBzc89s=",
+        "lastModified": 1719436386,
+        "narHash": "sha256-NBGYaic5FLRg8AWSj6yr4g2IlMPUxNCVjRK6+RNuQBc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c97ced70e0b92d46e5e53e239fec5201f8b0811",
+        "rev": "c66e984bda09e7230ea7b364e677c5ba4f0d36d0",
         "type": "github"
       },
       "original": {
@@ -95,9 +74,29 @@
       "inputs": {
         "advisory-db": "advisory-db",
         "crane": "crane",
-        "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719454714,
+        "narHash": "sha256-MojqG0lyUINkEk0b3kM2drsU5vyaF8DFZe/FAlZVOGs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d1c527659cf076ecc4b96a91c702d080b213801e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,12 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.rust-analyzer-src.follows = "";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
     };
-
 
     advisory-db = {
       url = "github:rustsec/advisory-db";
@@ -23,129 +23,127 @@
     };
   };
 
-  outputs = { self, nixpkgs, crane, fenix, flake-utils, advisory-db, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+      rust-overlay,
+      flake-utils,
+      advisory-db,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
-        overlays = [ fenix.overlays.default ];
         pkgs = import nixpkgs {
-          inherit system overlays;
-           config.allowBroken = true;
+          inherit system;
+          config = {
+            allowBroken = true;
+          };
+          overlays = [ (import rust-overlay) ];
         };
 
         inherit (pkgs) lib;
 
-        craneLib = crane.lib.${system};
+        rust-toolchain = pkgs.rust-bin.selectLatestNightlyWith (
+          toolchain:
+          toolchain.default.override {
+            extensions = [ "rust-src" ];
+            targets = [
+              "aarch64-apple-darwin"
+              "x86_64-apple-darwin"
+              "aarch64-unknown-linux-gnu"
+              "x86_64-unknown-linux-gnu"
+            ];
+          }
+        );
+
+        craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
         src = craneLib.cleanCargoSource (craneLib.path ./.);
 
-        # Common arguments can be set here to avoid repeating them later
         commonArgs = {
           inherit src;
 
-          buildInputs = [
-            # Add additional build inputs here
-          ]
-          ++ lib.optionals pkgs.stdenv.isDarwin [
-            # Additional darwin specific inputs can be set here
-            pkgs.libiconv
-          ];
+          buildInputs =
+            [ ]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              # Additional darwin specific inputs can be set here
+              pkgs.libiconv
+            ];
         };
-
-        toolchain = "complete";
-        rustPkg = fenix.packages.${system}.${toolchain}.withComponents
-          [
-            "cargo"
-            "clippy"
-            "rust-src"
-            "llvm-tools"
-            "rustc"
-            "rustfmt"
-          ];
-
-        craneLibLLvmTools = craneLib.overrideToolchain rustPkg;
 
         # Build *just* the cargo dependencies, so we can reuse
         # all of that work (e.g. via cachix) when running in CI
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-        # Build the actual crate itself, reusing the dependency
-        # artifacts from above.
-        rs-poker = craneLib.buildPackage (commonArgs // { inherit cargoArtifacts; });
+        rs-poker = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
+            doCheck = false;
+          }
+        );
       in
       {
-        checks = {
-          # Build the crate as part of `nix flake check` for convenience
-          inherit rs-poker;
+        checks =
+          {
+            # Build the crate as part of `nix flake check` for convenience
+            inherit rs-poker;
 
-          # Run clippy (and deny all warnings) on the crate source,
-          # again, resuing the dependency artifacts from above.
-          #
-          # Note that this is done as a separate derivation so that
-          # we can block the CI if there are issues here, but not
-          # prevent downstream consumers from building our crate by itself.
-          rs-poker-clippy = craneLib.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-          });
+            # Run clippy (and deny all warnings) on the crate source,
+            # again, resuing the dependency artifacts from above.
+            rs-poker-clippy = craneLib.cargoClippy (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+              }
+            );
 
-          rs-poker-doc = craneLib.cargoDoc (commonArgs // {
-            inherit cargoArtifacts;
-          });
+            rs-poker-doc = craneLib.cargoDoc (commonArgs // { inherit cargoArtifacts; });
 
-          # Check formatting
-          rs-poker-fmt = craneLib.cargoFmt {
-            inherit src;
-            cargoClippyExtraArgs = "--all --check";
+            # Check formatting
+            rs-poker-fmt = craneLib.cargoFmt {
+              inherit src;
+              cargoClippyExtraArgs = "--all --check";
+            };
+
+            # Audit dependencies
+            rs-poker-audit = craneLib.cargoAudit { inherit src advisory-db; };
+
+            # Run tests since rs-poker has doCheck = false;
+            rs-poker-nextest = craneLib.cargoNextest (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                partitions = 1;
+                partitionType = "count";
+                cargoNextestExtraArgs = "--all-targets";
+              }
+            );
+          }
+          // lib.optionalAttrs (system == "x86_64-linux") {
+            rs-poker-coverage = craneLib.cargoTarpaulin (commonArgs // { inherit cargoArtifacts; });
           };
-
-          # Audit dependencies
-          rs-poker-audit = craneLib.cargoAudit {
-            inherit src advisory-db;
-          };
-
-          # Run tests with cargo-nextest
-          # Consider setting `doCheck = false` on `rs-poker` if you do not want
-          # the tests to run twice
-          rs-poker-nextest = craneLib.cargoNextest (commonArgs // {
-            inherit cargoArtifacts;
-            partitions = 1;
-            partitionType = "count";
-            cargoNextestExtraArgs = "--all-targets";
-          });
-        } // lib.optionalAttrs (system == "x86_64-linux") {
-          # NB: cargo-tarpaulin only supports x86_64 systems
-          # Check code coverage (note: this will not upload coverage anywhere)
-          rs-poker-coverage = craneLib.cargoTarpaulin (commonArgs // {
-            inherit cargoArtifacts;
-          });
-        };
 
         packages = {
+          inherit rs-poker;
           default = rs-poker;
-        } // lib.optionalAttrs (system == "x86_64-linux") {
-          rs-poker-llvm-coverage = craneLibLLvmTools.cargoLlvmCov (commonArgs // {
-            inherit cargoArtifacts;
-          });
         };
 
-        apps.default = flake-utils.lib.mkApp {
-          drv = rs-poker;
-        };
+        apps.default = flake-utils.lib.mkApp { drv = rs-poker; };
 
         devShells.default = pkgs.mkShell {
           inputsFrom = builtins.attrValues self.checks.${system};
 
           nativeBuildInputs = with pkgs; [
-            rustPkg
-            rust-analyzer-nightly
+            rust-toolchain
+            rust-analyzer
             pkg-config
             git
             cmake
             openssl
-
-            cargo-release
-            cargo-audit
-            cargo-watch
-            cargo-fuzz
           ];
 
           shellHook = ''
@@ -157,5 +155,6 @@
             export PATH=$CARGO_HOME/bin:$PATH
           '';
         };
-      });
+      }
+    );
 }

--- a/src/arena/historian/directory_historian.rs
+++ b/src/arena/historian/directory_historian.rs
@@ -18,7 +18,8 @@ impl DirectoryHistorian {
     ///
     /// # Arguments
     ///
-    /// * `base_path` - The base path where the game action files will be stored.
+    /// * `base_path` - The base path where the game action files will be
+    ///   stored.
     pub fn new(base_path: PathBuf) -> Self {
         DirectoryHistorian {
             base_path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@
 //! * `HoldemCompetition` that keeps track of all simulation based stats from
 //!   simluations genreated via `HoldemSimulationGenerator`.
 //! * Each `HoldemSimulationGenerator` is built of `AgentsGenerator`,
-//! `HistorianGenerator`, and `GameStateGenerator`
+//!   `HistorianGenerator`, and `GameStateGenerator`
 //!
 //!
 //! ### Example


### PR DESCRIPTION
Summary:
Rust started using their own linker that blows up when in nix. So
rust-overlay wraps that linker with their own scripts. Fenix hasn't
found a fix yet.

I really want to get rid of gcc

Test Plan:
`cargo fuzz run multi_replay_agent -- -runs=1`
