### PR TITLE
feat: keep track of the round before simlation completes

### DIFF
--- a/src/arena/competition/holdem_competition.rs
+++ b/src/arena/competition/holdem_competition.rs
@@ -1,6 +1,9 @@
-use std::{collections::VecDeque, fmt::Debug};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+};
 
-use crate::arena::{errors::HoldemSimulationError, HoldemSimulation};
+use crate::arena::{errors::HoldemSimulationError, game_state::Round, HoldemSimulation};
 
 use super::sim_gen::HoldemSimulationGenerator;
 
@@ -24,6 +27,8 @@ pub struct HoldemCompetition<T: HoldemSimulationGenerator> {
     pub loss_count: Vec<usize>,
     // How many times the agent has lost no money
     pub zero_count: Vec<usize>,
+    // Count of the round before the simulation stopped
+    pub before_count: HashMap<Round, usize>,
 
     /// Maximum number of HoldemSimulation's to
     /// keep in a long call to `run`
@@ -50,6 +55,8 @@ impl<T: HoldemSimulationGenerator> HoldemCompetition<T> {
             win_count: vec![0; MAX_PLAYERS],
             loss_count: vec![0; MAX_PLAYERS],
             zero_count: vec![0; MAX_PLAYERS],
+            // Round before stopping
+            before_count: HashMap::new(),
         }
     }
 
@@ -115,6 +122,12 @@ impl<T: HoldemSimulationGenerator> HoldemCompetition<T> {
                 self.zero_count[idx] += 1;
             }
         }
+        // Update the count
+        let count = self
+            .before_count
+            .entry(running_sim.game_state.round_before)
+            .or_default();
+        *count += 1;
     }
 }
 impl<T: HoldemSimulationGenerator> Debug for HoldemCompetition<T> {
@@ -127,6 +140,7 @@ impl<T: HoldemSimulationGenerator> Debug for HoldemCompetition<T> {
             .field("win_count", &self.win_count)
             .field("zero_count", &self.zero_count)
             .field("loss_count", &self.loss_count)
+            .field("round_before", &self.before_count)
             .finish()
     }
 }


### PR DESCRIPTION
Summary:
When running a simulation we can transition from lots of different
rounds to complete via folding or via showdown. So keep track of what
the last round we have seen before complete'ing the sim.

Test Plan:
Ran `cargo run --release --example agent_battle`

Got:

```
Current Competition Stats: HoldemCompetition { num_rounds: 2500, total_change: [422.86856, -2458.051, 3308.6985, -1273.5121, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], max_change: [846.8667, 643.11194, 636.79913, 471.92227, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], min_change: [-641.6119, -835.31396, -411.79034, -774.67834, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], win_count: [975, 1111, 207, 212, 0, 0, 0, 0, 0, 0, 0, 0], zero_count: [273, 333, 1117, 1085, 0, 0, 0, 0, 0, 0, 0, 0], loss_count: [1252, 1056, 1176, 1203, 0, 0, 0, 0, 0, 0, 0, 0], round_before: {Preflop: 1300, Flop: 515, Showdown: 275, Turn: 262, River: 148} }
```

That's about the distribution I would have expected. Lots of folding
before starting with non-premium hands. Then we lose a lot on the flop.
Rounds after that not many fold. I doubt that the actions are GTO
but they look reasonable.
