### PR TITLE
perf: use bitsets for deck and hands

### DIFF
--- a/benches/rank.rs
+++ b/benches/rank.rs
@@ -4,17 +4,17 @@ extern crate rand;
 extern crate rs_poker;
 
 use criterion::Criterion;
-use rs_poker::core::{Deck, FlatDeck, Hand, Rankable};
+use rs_poker::core::{Deck, FlatDeck, FlatHand, Rankable};
 
 fn rank_one(c: &mut Criterion) {
     let d: FlatDeck = Deck::default().into();
-    let hand = Hand::new_with_cards(d.sample(5));
+    let hand = FlatHand::new_with_cards(d.sample(5));
     c.bench_function("Rank one 5 card hand", move |b| b.iter(|| hand.rank()));
 }
 
 fn rank_best_seven(c: &mut Criterion) {
     let d: FlatDeck = Deck::default().into();
-    let hand = Hand::new_with_cards(d.sample(7));
+    let hand = FlatHand::new_with_cards(d.sample(7));
     c.bench_function("Rank best 5card hand from 7", move |b| {
         b.iter(|| hand.rank())
     });

--- a/fuzz/fuzz_targets/fuzzer_script_2.rs
+++ b/fuzz/fuzz_targets/fuzzer_script_2.rs
@@ -2,12 +2,12 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate rs_poker;
-use rs_poker::core::Hand;
+use rs_poker::core::FlatHand;
 use std::str;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = str::from_utf8(data) {
-        if let Ok(h) = Hand::new_from_str(s) {
+        if let Ok(h) = FlatHand::new_from_str(s) {
             assert!(s.len() >= h.len());
         }
     }

--- a/fuzz/fuzz_targets/rank_seven.rs
+++ b/fuzz/fuzz_targets/rank_seven.rs
@@ -7,7 +7,7 @@ use std::str;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = str::from_utf8(data) {
-        if let Ok(h) = Hand::new_from_str(s) {
+        if let Ok(h) = FlatHand::new_from_str(s) {
             if h.len() == 7 {
                 let r_seven = h.rank();
                 let r_five_max = CardIter::new(&h[..], 5)

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -136,7 +136,9 @@ impl RandomPotControlAgent {
     }
 
     fn clean_hands(&self, game_state: &GameState) -> Vec<Hand> {
-        let default_hand = Hand::new_with_cards(game_state.board.clone());
+        let mut default_hand = Hand::new();
+        // Copy the board into the default hand
+        default_hand.extend(game_state.board.iter().cloned());
 
         let to_act_idx = game_state.to_act_idx();
         game_state
@@ -259,8 +261,8 @@ mod tests {
 
         // Add two random cards to every hand.
         for hand in game_state.hands.iter_mut() {
-            hand.push(deck.deal().unwrap());
-            hand.push(deck.deal().unwrap());
+            hand.insert(deck.deal().unwrap());
+            hand.insert(deck.deal().unwrap());
         }
 
         let mut sim = HoldemSimulationBuilder::default()

--- a/src/arena/game_state.rs
+++ b/src/arena/game_state.rs
@@ -317,7 +317,7 @@ impl GameState {
                 // Count all the money in the pot.
                 total_pot += *bet;
 
-                // Handle the case that they have no money left
+                // FlatHandle the case that they have no money left
                 if *stack <= 0.0 {
                     if *bet > 0.0 && round != Round::Starting {
                         // If the player is out of money and they've put money in
@@ -378,7 +378,7 @@ impl GameState {
             round_data,
             // No board cards
             vec![],
-            // Hands are empty
+            // FlatHands are empty
             vec![Hand::default(); num_players],
             // Current stacks
             stacks,

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -14,7 +14,7 @@ fn build_flat_deck<R: Rng>(game_state: &GameState, rng: &mut R) -> FlatDeck {
 
     for hand in game_state.hands.iter() {
         for card in hand.iter() {
-            d.remove(*card);
+            d.remove(card);
         }
     }
     let mut flat_deck: FlatDeck = d.into();
@@ -356,7 +356,7 @@ mod tests {
         let c = Card::try_from(card_str).unwrap();
         assert!(deck.contains(c));
         deck.remove(c);
-        game_state.hands[idx].push(c);
+        game_state.hands[idx].insert(c);
     }
 
     fn deal_community_card(card_str: &str, deck: &mut CardBitSet, game_state: &mut GameState) {
@@ -364,7 +364,7 @@ mod tests {
         assert!(deck.contains(c));
         deck.remove(c);
         for h in &mut game_state.hands {
-            h.push(c);
+            h.insert(c);
         }
 
         game_state.board.push(c);

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -443,7 +443,7 @@ impl HoldemSimulation {
         let action = self.agents[idx].act(&self.id, &self.game_state);
 
         event!(parent: &span, Level::TRACE, ?action, idx);
-        self.run_agent_action(action)
+        self.run_agent_action(action);
     }
 
     /// Given the action that an agent wants to take, this function will
@@ -638,7 +638,10 @@ impl HoldemSimulation {
                         // Some user might never error.
                         // For them it's a panic.
                         if self.panic_on_historian_error {
-                            panic!("Historian error {}", error);
+                            panic!(
+                                "Historian error {}\naction={:?}\ngame_state = {:?}",
+                                error, action, self.game_state
+                            );
                         }
                         None
                     }

--- a/src/core/card_iter.rs
+++ b/src/core/card_iter.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_iter_one() {
-        let mut h = Hand::default();
+        let mut h = FlatHand::default();
         h.push(Card {
             value: Value::Two,
             suit: Suit::Spade,
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn test_iter_two() {
-        let mut h = Hand::default();
+        let mut h = FlatHand::default();
         h.push(Card {
             value: Value::Two,
             suit: Suit::Spade,

--- a/src/core/flat_hand.rs
+++ b/src/core/flat_hand.rs
@@ -1,0 +1,223 @@
+use crate::core::card::*;
+use std::ops::Index;
+use std::ops::{RangeFrom, RangeFull, RangeTo};
+use std::slice::Iter;
+
+use super::RSPokerError;
+
+/// Struct to hold cards.
+///
+/// This doesn't have the ability to easily check if a card is
+/// in the hand. So do that before adding/removing a card.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct FlatHand(Vec<Card>);
+
+impl FlatHand {
+    /// Create the hand with specific hand.
+    pub fn new_with_cards(cards: Vec<Card>) -> Self {
+        Self(cards)
+    }
+    /// From a str create a new hand.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rs_poker::core::FlatHand;
+    /// let hand = FlatHand::new_from_str("AdKd").unwrap();
+    /// ```
+    ///
+    /// Anything that can't be parsed will return an error.
+    ///
+    /// ```
+    /// use rs_poker::core::FlatHand;
+    /// let hand = FlatHand::new_from_str("AdKx");
+    /// assert!(hand.is_err());
+    /// ```
+    pub fn new_from_str(hand_string: &str) -> Result<Self, RSPokerError> {
+        // Get the chars iterator.
+        let mut chars = hand_string.chars();
+        // Where we will put the cards
+        //
+        // We make the assumption that the hands will have 2 plus five cards.
+        let mut cards: Vec<Card> = Vec::with_capacity(7);
+
+        // Keep looping until we explicitly break
+        loop {
+            // Now try and get a char.
+            let vco = chars.next();
+            // If there was no char then we are done.
+            if vco.is_none() {
+                break;
+            } else {
+                // If we got a value char then we should get a
+                // suit.
+                let sco = chars.next();
+                // Now try and parse the two chars that we have.
+                let v = vco
+                    .and_then(Value::from_char)
+                    .ok_or(RSPokerError::UnexpectedValueChar)?;
+                let s = sco
+                    .and_then(Suit::from_char)
+                    .ok_or(RSPokerError::UnexpectedSuitChar)?;
+
+                let c = Card { value: v, suit: s };
+
+                match cards.binary_search(&c) {
+                    Ok(_) => return Err(RSPokerError::DuplicateCardInHand(c)),
+                    Err(i) => cards.insert(i, c),
+                };
+            }
+        }
+
+        if chars.next().is_some() {
+            return Err(RSPokerError::UnparsedCharsRemaining);
+        }
+
+        cards.reserve(7);
+        Ok(Self(cards))
+    }
+    /// Add card at to the hand.
+    /// No verification is done at all.
+    pub fn push(&mut self, c: Card) {
+        self.0.push(c);
+    }
+    /// Truncate the hand to the given number of cards.
+    pub fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+    /// How many cards are in this hand so far ?
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    /// Are there any cards at all ?
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    /// Create an iter on the cards.
+    pub fn iter(&self) -> Iter<Card> {
+        self.0.iter()
+    }
+}
+
+impl Default for FlatHand {
+    /// Create the default empty hand.
+    fn default() -> Self {
+        Self(Vec::with_capacity(7))
+    }
+}
+
+/// Allow indexing into the hand.
+impl Index<usize> for FlatHand {
+    type Output = Card;
+    fn index(&self, index: usize) -> &Card {
+        &self.0[index]
+    }
+}
+
+/// Allow the index to get refernce to every card.
+impl Index<RangeFull> for FlatHand {
+    type Output = [Card];
+    fn index(&self, range: RangeFull) -> &[Card] {
+        &self.0[range]
+    }
+}
+
+impl Index<RangeTo<usize>> for FlatHand {
+    type Output = [Card];
+    fn index(&self, index: RangeTo<usize>) -> &[Card] {
+        &self.0[index]
+    }
+}
+impl Index<RangeFrom<usize>> for FlatHand {
+    type Output = [Card];
+    fn index(&self, index: RangeFrom<usize>) -> &[Card] {
+        &self.0[index]
+    }
+}
+
+impl Extend<Card> for FlatHand {
+    fn extend<T: IntoIterator<Item = Card>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_card() {
+        let mut h = FlatHand::default();
+        let c = Card {
+            value: Value::Three,
+            suit: Suit::Spade,
+        };
+        h.push(c);
+        // Make sure that the card was added to the vec.
+        //
+        // This will also test that has len works
+        assert_eq!(1, h.len());
+    }
+
+    #[test]
+    fn test_index() {
+        let mut h = FlatHand::default();
+        h.push(Card {
+            value: Value::Four,
+            suit: Suit::Spade,
+        });
+        // Make sure the card is there
+        assert_eq!(
+            Card {
+                value: Value::Four,
+                suit: Suit::Spade,
+            },
+            h[0]
+        );
+    }
+    #[test]
+    fn test_parse_error() {
+        assert!(FlatHand::new_from_str("BAD").is_err());
+        assert!(FlatHand::new_from_str("Adx").is_err());
+    }
+
+    #[test]
+    fn test_parse_one_hand() {
+        let h = FlatHand::new_from_str("Ad").unwrap();
+        assert_eq!(1, h.len())
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        let h = FlatHand::new_from_str("").unwrap();
+        assert!(h.is_empty());
+    }
+
+    #[test]
+    fn test_new_with_cards() {
+        let h = FlatHand::new_with_cards(vec![
+            Card::new(Value::Jack, Suit::Spade),
+            Card::new(Value::Jack, Suit::Heart),
+        ]);
+
+        assert_eq!(2, h.len());
+    }
+
+    #[test]
+    fn test_error_on_duplicate_card() {
+        assert!(FlatHand::new_from_str("AdAd").is_err());
+    }
+
+    #[test]
+    fn test_deterministic_new_from_str() {
+        let h = FlatHand::new_from_str("AdKd").unwrap();
+
+        assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
+        assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
+        assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
+        assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
+        assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
+        assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
+    }
+}

--- a/src/core/hand.rs
+++ b/src/core/hand.rs
@@ -1,59 +1,110 @@
-use crate::core::card::*;
-use std::ops::Index;
-use std::ops::{RangeFrom, RangeFull, RangeTo};
-use std::slice::Iter;
+use super::{Card, CardBitSet, CardBitSetIter, RSPokerError, Suit, Value};
 
-use super::RSPokerError;
-
-/// Struct to hold cards.
-///
-/// This doesn't have the ability to easily check if a card is
-/// in the hand. So do that before adding/removing a card.
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct Hand(Vec<Card>);
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Hand(CardBitSet);
 
 impl Hand {
-    /// Create the hand with specific hand.
-    pub fn new_with_cards(cards: Vec<Card>) -> Self {
-        Self(cards)
-    }
-    /// From a str create a new hand.
+    /// Create a new empty hand
     ///
     /// # Examples
     ///
     /// ```
     /// use rs_poker::core::Hand;
-    /// let hand = Hand::new_from_str("AdKd").unwrap();
-    /// ```
     ///
-    /// Anything that can't be parsed will return an error.
+    /// let hand = Hand::new();
+    ///
+    /// assert!(hand.is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Self(CardBitSet::new())
+    }
+
+    pub fn new_with_cards(cards: Vec<Card>) -> Self {
+        let mut bitset = CardBitSet::new();
+        for card in cards {
+            bitset.insert(card);
+        }
+        Self(bitset)
+    }
+
+    /// Given a card, is it in the current hand?
+    ///
+    /// # Examples
     ///
     /// ```
-    /// use rs_poker::core::Hand;
-    /// let hand = Hand::new_from_str("AdKx");
-    /// assert!(hand.is_err());
+    /// use rs_poker::core::{Card, Hand, Suit, Value};
+    ///
+    /// let mut hand = Hand::new();
+    ///
+    /// let card = Card::new(Value::Ace, Suit::Club);
+    /// assert!(!hand.contains(&card));
+    ///
+    /// hand.insert(card);
+    /// assert!(hand.contains(&card));
     /// ```
+    pub fn contains(&self, c: &Card) -> bool {
+        self.0.contains(*c)
+    }
+
+    /// Remove a card from the hand
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rs_poker::core::{Card, Hand, Suit, Value};
+    ///
+    /// let mut hand = Hand::new();
+    ///
+    /// let card = Card::new(Value::Ace, Suit::Club);
+    /// assert!(!hand.contains(&card));
+    ///
+    /// hand.insert(card);
+    /// assert!(hand.contains(&card));
+    ///
+    /// hand.remove(&card);
+    /// assert!(!hand.contains(&card));
+    /// ```
+    pub fn remove(&mut self, c: &Card) -> bool {
+        let contains = self.contains(c);
+        self.0.remove(*c);
+        contains
+    }
+
+    pub fn insert(&mut self, c: Card) -> bool {
+        let contains = self.contains(&c);
+        self.0.insert(c);
+        !contains
+    }
+
+    pub fn count(&self) -> usize {
+        self.0.count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> CardBitSetIter {
+        self.0.into_iter()
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
     pub fn new_from_str(hand_string: &str) -> Result<Self, RSPokerError> {
-        // Get the chars iterator.
         let mut chars = hand_string.chars();
-        // Where we will put the cards
-        //
-        // We make the assumption that the hands will have 2 plus five cards.
-        let mut cards: Vec<Card> = Vec::with_capacity(7);
+        let mut bitset = CardBitSet::new();
 
         // Keep looping until we explicitly break
         loop {
-            // Now try and get a char.
             let vco = chars.next();
-            // If there was no char then we are done.
             if vco.is_none() {
                 break;
             } else {
-                // If we got a value char then we should get a
-                // suit.
                 let sco = chars.next();
-                // Now try and parse the two chars that we have.
                 let v = vco
                     .and_then(Value::from_char)
                     .ok_or(RSPokerError::UnexpectedValueChar)?;
@@ -63,10 +114,11 @@ impl Hand {
 
                 let c = Card { value: v, suit: s };
 
-                match cards.binary_search(&c) {
-                    Ok(_) => return Err(RSPokerError::DuplicateCardInHand(c)),
-                    Err(i) => cards.insert(i, c),
-                };
+                if bitset.contains(c) {
+                    return Err(RSPokerError::DuplicateCardInHand(c));
+                } else {
+                    bitset.insert(c);
+                }
             }
         }
 
@@ -74,150 +126,20 @@ impl Hand {
             return Err(RSPokerError::UnparsedCharsRemaining);
         }
 
-        cards.reserve(7);
-        Ok(Self(cards))
-    }
-    /// Add card at to the hand.
-    /// No verification is done at all.
-    pub fn push(&mut self, c: Card) {
-        self.0.push(c);
-    }
-    /// Truncate the hand to the given number of cards.
-    pub fn truncate(&mut self, len: usize) {
-        self.0.truncate(len)
-    }
-    /// How many cards are in this hand so far ?
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-    /// Are there any cards at all ?
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-    /// Create an iter on the cards.
-    pub fn iter(&self) -> Iter<Card> {
-        self.0.iter()
+        Ok(Self(bitset))
     }
 }
 
 impl Default for Hand {
-    /// Create the default empty hand.
     fn default() -> Self {
-        Self(Vec::with_capacity(7))
-    }
-}
-
-/// Allow indexing into the hand.
-impl Index<usize> for Hand {
-    type Output = Card;
-    fn index(&self, index: usize) -> &Card {
-        &self.0[index]
-    }
-}
-
-/// Allow the index to get refernce to every card.
-impl Index<RangeFull> for Hand {
-    type Output = [Card];
-    fn index(&self, range: RangeFull) -> &[Card] {
-        &self.0[range]
-    }
-}
-
-impl Index<RangeTo<usize>> for Hand {
-    type Output = [Card];
-    fn index(&self, index: RangeTo<usize>) -> &[Card] {
-        &self.0[index]
-    }
-}
-impl Index<RangeFrom<usize>> for Hand {
-    type Output = [Card];
-    fn index(&self, index: RangeFrom<usize>) -> &[Card] {
-        &self.0[index]
+        Self(CardBitSet::new())
     }
 }
 
 impl Extend<Card> for Hand {
     fn extend<T: IntoIterator<Item = Card>>(&mut self, iter: T) {
-        self.0.extend(iter);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_add_card() {
-        let mut h = Hand::default();
-        let c = Card {
-            value: Value::Three,
-            suit: Suit::Spade,
-        };
-        h.push(c);
-        // Make sure that the card was added to the vec.
-        //
-        // This will also test that has len works
-        assert_eq!(1, h.len());
-    }
-
-    #[test]
-    fn test_index() {
-        let mut h = Hand::default();
-        h.push(Card {
-            value: Value::Four,
-            suit: Suit::Spade,
-        });
-        // Make sure the card is there
-        assert_eq!(
-            Card {
-                value: Value::Four,
-                suit: Suit::Spade,
-            },
-            h[0]
-        );
-    }
-    #[test]
-    fn test_parse_error() {
-        assert!(Hand::new_from_str("BAD").is_err());
-        assert!(Hand::new_from_str("Adx").is_err());
-    }
-
-    #[test]
-    fn test_parse_one_hand() {
-        let h = Hand::new_from_str("Ad").unwrap();
-        assert_eq!(1, h.len())
-    }
-
-    #[test]
-    fn test_parse_empty() {
-        let h = Hand::new_from_str("").unwrap();
-        assert!(h.is_empty());
-    }
-
-    #[test]
-    fn test_new_with_cards() {
-        let h = Hand::new_with_cards(vec![
-            Card::new(Value::Jack, Suit::Spade),
-            Card::new(Value::Jack, Suit::Heart),
-        ]);
-
-        assert_eq!(2, h.len());
-    }
-
-    #[test]
-    fn test_error_on_duplicate_card() {
-        assert!(Hand::new_from_str("AdAd").is_err());
-    }
-
-    #[test]
-    fn test_deterministic_new_from_str() {
-        let h = Hand::new_from_str("AdKd").unwrap();
-
-        assert_eq!(h, Hand::new_from_str("AdKd").unwrap());
-        assert_eq!(h, Hand::new_from_str("AdKd").unwrap());
-        assert_eq!(h, Hand::new_from_str("AdKd").unwrap());
-        assert_eq!(h, Hand::new_from_str("AdKd").unwrap());
-        assert_eq!(h, Hand::new_from_str("AdKd").unwrap());
-        assert_eq!(h, Hand::new_from_str("AdKd").unwrap());
+        for card in iter {
+            self.insert(card);
+        }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,10 +8,14 @@ mod card;
 /// Re-export Card, Value, and Suit
 pub use self::card::{Card, Suit, Value};
 
-/// Code related to cards in hands.
+/// The bitset hand.
 mod hand;
-/// Everything in there should be public.
+/// Export the hand
 pub use self::hand::*;
+/// Code related to cards in flattened hands.
+mod flat_hand;
+/// Everything in there should be public.
+pub use self::flat_hand::*;
 
 /// We want to be able to iterate over five card hands.
 mod card_iter;

--- a/src/holdem/parse.rs
+++ b/src/holdem/parse.rs
@@ -1,4 +1,4 @@
-use crate::core::{Card, Hand, RSPokerError, Suit, Value};
+use crate::core::{Card, FlatHand, RSPokerError, Suit, Value};
 use crate::holdem::Suitedness;
 use std::collections::HashSet;
 
@@ -199,11 +199,11 @@ impl RangeIter {
 
 /// `Iterator` implementation for `RangeIter`
 impl Iterator for RangeIter {
-    type Item = Hand;
+    type Item = FlatHand;
     /// Get the next value if there are any.
-    fn next(&mut self) -> Option<Hand> {
+    fn next(&mut self) -> Option<FlatHand> {
         if self.has_more() {
-            let h = Hand::new_with_cards(vec![self.first_card(), self.second_card()]);
+            let h = FlatHand::new_with_cards(vec![self.first_card(), self.second_card()]);
             self.incr();
             Some(h)
         } else {
@@ -362,7 +362,7 @@ impl RangeParser {
     /// // We'll never get here
     /// println!("Hands = {:?}", hands);
     /// ```
-    pub fn parse_one(r_str: &str) -> Result<Vec<Hand>, RSPokerError> {
+    pub fn parse_one(r_str: &str) -> Result<Vec<FlatHand>, RSPokerError> {
         let mut iter = r_str.chars().peekable();
         let mut first_range = InclusiveValueRange {
             start: Value::Two,
@@ -515,7 +515,7 @@ impl RangeParser {
             }
         }
 
-        let filtered: Vec<Hand> = citer
+        let filtered: Vec<FlatHand> = citer
             // Need to make sure that the first card is in the range
             .filter(|hand| first_range.include(hand[0].value))
             // Make sure the second card is in the range
@@ -564,7 +564,7 @@ impl RangeParser {
     /// // Filters out duplicates.
     /// assert_eq!(RangeParser::parse_many("AK-87s,A2s+").unwrap().len(), 72)
     /// ```
-    pub fn parse_many(r_str: &str) -> Result<Vec<Hand>, RSPokerError> {
+    pub fn parse_many(r_str: &str) -> Result<Vec<FlatHand>, RSPokerError> {
         let all_hands: Vec<_> = r_str
             // Split into different ranges
             .split(',')
@@ -574,7 +574,7 @@ impl RangeParser {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Filter the unique hands.
-        let unique_hands: HashSet<Hand> = all_hands.into_iter().flatten().collect();
+        let unique_hands: HashSet<FlatHand> = all_hands.into_iter().flatten().collect();
 
         // Transform hands into a vec for storage
         Ok(unique_hands.into_iter().collect())

--- a/src/holdem/starting_hand.rs
+++ b/src/holdem/starting_hand.rs
@@ -1,4 +1,4 @@
-use crate::core::{Card, Hand, Suit, Value};
+use crate::core::{Card, FlatHand, Suit, Value};
 
 /// Enum to represent how the suits of a hand correspond to each other.
 /// `Suitedness::Suited` will mean that all cards have the same suit
@@ -35,7 +35,7 @@ impl Default {
     }
 
     /// Create a new vector of all suited hands.
-    fn create_suited(&self) -> Vec<Hand> {
+    fn create_suited(&self) -> Vec<FlatHand> {
         // Can't have a suited pair. Not unless you're cheating.
         if self.is_pair() {
             return vec![];
@@ -43,7 +43,7 @@ impl Default {
         Suit::suits()
             .iter()
             .map(|s| {
-                Hand::new_with_cards(vec![
+                FlatHand::new_with_cards(vec![
                     Card {
                         value: self.value_one,
                         suit: *s,
@@ -58,7 +58,7 @@ impl Default {
     }
 
     /// Create a new vector of all the off suit hands.
-    fn create_offsuit(&self) -> Vec<Hand> {
+    fn create_offsuit(&self) -> Vec<FlatHand> {
         // Since the values are the same there is no reason to swap the suits.
         let expected_hands = if self.is_pair() { 6 } else { 12 };
         self.append_offsuit(Vec::with_capacity(expected_hands))
@@ -68,12 +68,12 @@ impl Default {
     /// then return it.
     ///
     /// @returns the passed in vector with offsuit hands appended.
-    fn append_offsuit(&self, mut hands: Vec<Hand>) -> Vec<Hand> {
+    fn append_offsuit(&self, mut hands: Vec<FlatHand>) -> Vec<FlatHand> {
         let suits = Suit::suits();
         for (i, suit_one) in suits.iter().enumerate() {
             for suit_two in &suits[i + 1..] {
                 // Push the hands in.
-                hands.push(Hand::new_with_cards(vec![
+                hands.push(FlatHand::new_with_cards(vec![
                     Card {
                         value: self.value_one,
                         suit: *suit_one,
@@ -86,7 +86,7 @@ impl Default {
 
                 // If this isn't a pair then the flipped suits is needed.
                 if self.value_one != self.value_two {
-                    hands.push(Hand::new_with_cards(vec![
+                    hands.push(FlatHand::new_with_cards(vec![
                         Card {
                             value: self.value_one,
                             suit: *suit_two,
@@ -104,7 +104,7 @@ impl Default {
 
     /// Get all the possible starting hands represented by the
     /// two values of this starting hand.
-    fn possible_hands(&self) -> Vec<Hand> {
+    fn possible_hands(&self) -> Vec<FlatHand> {
         match self.suited {
             Suitedness::Suited => self.create_suited(),
             Suitedness::OffSuit => self.create_offsuit(),
@@ -129,7 +129,7 @@ pub struct SingleCardRange {
 
 impl SingleCardRange {
     /// Generate all the possible hands for this starting hand type.
-    fn possible_hands(&self) -> Vec<Hand> {
+    fn possible_hands(&self) -> Vec<FlatHand> {
         let mut cur_value = self.start;
         let mut hands = vec![];
         // TODO: Make a better iterator for values.
@@ -203,7 +203,7 @@ impl StartingHand {
     }
 
     /// From a `StartingHand` specify all the hands this could represent.
-    pub fn possible_hands(&self) -> Vec<Hand> {
+    pub fn possible_hands(&self) -> Vec<FlatHand> {
         match *self {
             Self::Def(ref h) => h.possible_hands(),
             Self::SingleCardRange(ref h) => h.possible_hands(),


### PR DESCRIPTION
Summary:
- Move Deck to use CardBitSet
- Add FlatHand that allows indexing and ordering of cards  (it follow
  FlatDeck's example)
- Add Hand that uses CardBitSet to do it's thing
- Move to using Hand and Deck in Simulation

Test Plan:

- CI
- Tests added
