### PR TITLE
Fix Incorrect Tree Structure

### DIFF
--- a/src/arena/cfr/action_generator.rs
+++ b/src/arena/cfr/action_generator.rs
@@ -2,7 +2,7 @@ use std::cell::Ref;
 
 use tracing::event;
 
-use crate::arena::{GameState, action::AgentAction};
+use crate::arena::{action::AgentAction, game_state::Round, GameState};
 
 use super::{CFRState, Node, NodeData, TraversalState};
 
@@ -134,7 +134,7 @@ impl ActionGenerator for BasicCFRActionGenerator {
         let mut res: Vec<AgentAction> = Vec::with_capacity(3);
         let to_call =
             game_state.current_round_bet() - game_state.current_round_current_player_bet();
-        if to_call > 0.0 {
+        if to_call > 0.0 || matches!(game_state.round, Round::Preflop) {
             res.push(AgentAction::Fold);
         }
         // Call, Match the current bet (if the bet is 0 this is a check)

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -255,8 +255,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::any::Any;
-
     use crate::arena::cfr::BasicCFRActionGenerator;
 
     use crate::arena::game_state;

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -1,10 +1,10 @@
-use std::cell::RefMut;
+use std::{cell::RefMut, path::Path};
 
 use little_sorry::RegretMatcher;
 use ndarray::ArrayView1;
 use tracing::event;
 
-use crate::arena::{Agent, GameState, Historian, HoldemSimulationBuilder, action::AgentAction};
+use crate::arena::{action::AgentAction, cfr::export_to_png, Agent, GameState, Historian, HoldemSimulationBuilder};
 
 use super::{
     CFRHistorian, NodeData,
@@ -35,7 +35,7 @@ where
             traversal_state,
             action_generator,
             forced_action: None,
-            num_iterations: 100,
+            num_iterations: 4,
         }
     }
 
@@ -50,7 +50,7 @@ where
             traversal_state,
             action_generator,
             forced_action: Some(forced_action),
-            num_iterations: 10,
+            num_iterations: 4,
         }
     }
 
@@ -64,7 +64,7 @@ where
         let states: Vec<_> = (0..num_agents)
             .map(|i| {
                 if i == self.traversal_state.player_idx() {
-                    self.cfr_state.clone()
+                    CFRState::deep_copy(&self.cfr_state)
                 } else {
                     CFRState::new(game_state.clone())
                 }
@@ -77,7 +77,7 @@ where
             .map(|(i, s)| {
                 if i == self.traversal_state.player_idx() {
                     Box::new(CFRAgent::<T>::new_with_forced_action(
-                        self.cfr_state.clone(),
+                        s,
                         TraversalState::new(
                             self.traversal_state.node_idx(),
                             self.traversal_state.chosen_child_idx(),
@@ -147,6 +147,7 @@ where
                     // This should never happen
                     // The agent should only be called when it's the player's turn
                     // and some agent should create this node.
+					export_to_png(&self.cfr_state, Path::new("output.png"), false).unwrap();
                     panic!("Expected player data, found {:?}", target_node);
                 }
                 t
@@ -254,6 +255,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+
     use crate::arena::cfr::BasicCFRActionGenerator;
 
     use crate::arena::game_state;
@@ -267,7 +270,6 @@ mod tests {
         let _ = CFRAgent::<BasicCFRActionGenerator>::new(cfr_state.clone(), 0);
     }
 
-    #[ignore = "Broken"]
     #[test]
     fn test_run_heads_up() {
         let num_agents = 2;
@@ -300,5 +302,7 @@ mod tests {
             .unwrap();
 
         sim.run();
+
+		println!("GAME STATE {:?}", sim.game_state);
     }
 }

--- a/src/arena/cfr/export.rs
+++ b/src/arena/cfr/export.rs
@@ -232,9 +232,9 @@ pub fn generate_dot(state: &CFRState) -> String {
                 let percentage = (count as f32 / total_count as f32) * 100.0;
                 let penwidth = 1.0 + (percentage / 10.0).min(8.0);
                 let color = format!(
-                    "#{:02X}{:02X}FF",
-                    (155.0 + percentage).min(255.0) as u8,
-                    (155.0 + percentage).min(255.0) as u8
+                    "#{:02X}{:02X}00",
+                    (255.0 - (255.0 * percentage / 100.0)) as u8,
+                    (255.0 * percentage / 100.0) as u8
                 );
                 format!(
                     " [label=\"{}\", penwidth={}, color=\"{}\", tooltip=\"Frequency: {:.1}%\", xlabel=\"{:.0}%\", weight={}]",

--- a/src/arena/cfr/state.rs
+++ b/src/arena/cfr/state.rs
@@ -70,6 +70,16 @@ impl CFRState {
         }
     }
 
+    pub fn deep_copy(original: &CFRState) -> Self {
+        CFRState {
+            inner_state: Rc::new(RefCell::new(CFRStateInternal {
+                nodes: original.inner_state.borrow().nodes.clone(),
+                starting_game_state: original.starting_game_state(),
+                next_node_idx: original.inner_state.borrow().next_node_idx
+            }))
+        }
+    }
+
     pub fn starting_game_state(&self) -> GameState {
         self.inner_state.borrow().starting_game_state.clone()
     }

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -681,8 +681,6 @@ impl fmt::Debug for HoldemSimulation {
 
 #[cfg(test)]
 mod tests {
-    use std::{thread::sleep, time::Duration};
-
     use crate::arena::{agent::CallingAgentGenerator, cfr::{BasicCFRActionGenerator, CFRAgent, CFRState}, game_state, Agent, AgentGenerator, HoldemSimulationBuilder};
 
     #[test]


### PR DESCRIPTION
Fixes #145 
/claim #145 

The issue was with shallow cloning of the CFR state object across simulations. The state would be modified in a sub simulation, leaving the tree in a bad state with regards to the original simulation's traversal state.

For example, Historian::ensure_target_node would ensure that a node exists at the current target location, but makes no guarantees on what _type_ of node is there in the case that one already exists. A sub simulation would place a terminal node at index 3, exit out to the original simulation after the specified number of iterations, which would try to create a player action node at index 3 (not expecting there to be a terminal node to be at index 3). Since a terminal node already exists there, Historian::ensure_target_node just returns Ok(3), and continues. This is how the graphs got so randomly messed up before eventually panicking completely. A deep copy of the CFR state before entering a sub simulation fixes this.

Another issue was with the logic for deciding if more actions needed to be taken in the round. The new logic says that if there are any active players who have not taken an action yet, another action needs taken this round.

I reduced the number of iterations down to 4 for the sake of runtime. The runtime seems to be exponential, with the following table showing num_iterations vs runtime:
2-2: 00:01.409
3-3: 00:02.428
4-4: 00:13.060
5-5: 00:58.319
8-8: 33:53.370