### PR TITLE
fix: add the player idx for playerdata via historians

### DIFF
--- a/src/arena/cfr/historian.rs
+++ b/src/arena/cfr/historian.rs
@@ -109,7 +109,10 @@ where
         action: AgentAction,
     ) -> Result<(), HistorianError> {
         let action_idx = self.action_generator.action_to_idx(game_state, &action);
-        let to_node_idx = self.ensure_target_node(NodeData::Player(PlayerData::default()))?;
+        let to_node_idx = self.ensure_target_node(NodeData::Player(PlayerData {
+            regret_matcher: None,
+            player_idx: game_state.round_data.to_act_idx,
+        }))?;
         self.traversal_state.move_to(to_node_idx, action_idx);
         Ok(())
     }

--- a/src/arena/cfr/node.rs
+++ b/src/arena/cfr/node.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct PlayerData {
     pub regret_matcher: Option<Box<little_sorry::RegretMatcher>>,
     pub player_idx: usize,
@@ -218,7 +218,10 @@ mod tests {
 
     #[test]
     fn test_node_data_is_player() {
-        let node_data = NodeData::Player(PlayerData::default());
+        let node_data = NodeData::Player(PlayerData {
+            regret_matcher: None,
+            player_idx: 0,
+        });
         assert!(node_data.is_player());
     }
 


### PR DESCRIPTION
Summary:
Previously we when the historian created a node it used the default
playerdata to create the node. However the player idx needs to be
correctly set

Test Plan:
- Tests still pass
