### PR TITLE
refactor: panic by default if a historian fails

### DIFF
--- a/src/arena/historian/fn_historian.rs
+++ b/src/arena/historian/fn_historian.rs
@@ -97,6 +97,7 @@ mod tests {
             .agents(agents)
             .game_state(game_state)
             .historians(vec![historian])
+            .panic_on_historian_error(false)
             .build()
             .unwrap()
             .run();

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -184,7 +184,7 @@ impl<R: Rng> Default for RngHoldemSimulationBuilder<R> {
             game_state: None,
             deck: None,
             rng: None,
-            panic_on_historian_error: false,
+            panic_on_historian_error: true,
         }
     }
 }


### PR DESCRIPTION
Summary:
- We are in a place where historians don't fail often so make the
  default show that.

Test Plan:
- Tests Changed
- CI
