### PR TITLE
feat: add PerRoundFixedGameStateIteratorGen

### DIFF
--- a/examples/cfr_hand_demo.rs
+++ b/examples/cfr_hand_demo.rs
@@ -1,7 +1,7 @@
 use rs_poker::arena::{
     Agent, Historian, HoldemSimulationBuilder,
     cfr::{
-        BasicCFRActionGenerator, CFRAgent, ExportFormat, FixedGameStateIteratorGen,
+        BasicCFRActionGenerator, CFRAgent, ExportFormat, PerRoundFixedGameStateIteratorGen,
         export_cfr_state,
     },
     historian::DirectoryHistorian,
@@ -26,13 +26,13 @@ fn run_simulation(num_agents: usize, export_path: Option<std::path::PathBuf>) {
                 // They have their own CFR state and
                 // and for now a fixed game state iterator
                 // that will try a very few hands
-                CFRAgent::<BasicCFRActionGenerator, FixedGameStateIteratorGen>::new(
+                CFRAgent::<BasicCFRActionGenerator, PerRoundFixedGameStateIteratorGen>::new(
                     s.clone(),
                     // please note that this is way too small
                     // for a real CFR simulation, but it is
                     // enough to demonstrate the CFR state tree
                     // and the export of the game history
-                    FixedGameStateIteratorGen::new(3),
+                    PerRoundFixedGameStateIteratorGen::default(),
                     i,
                 ),
             )

--- a/src/arena/cfr/gamestate_iterator_gen.rs
+++ b/src/arena/cfr/gamestate_iterator_gen.rs
@@ -1,4 +1,4 @@
-use crate::arena::GameState;
+use crate::arena::{GameState, game_state};
 
 /// This trait defines an interface for types that can generate an iterator
 /// over possible game states from a given initial game state.
@@ -14,6 +14,12 @@ pub struct FixedGameStateIteratorGen {
 impl FixedGameStateIteratorGen {
     pub fn new(num_hands: usize) -> Self {
         Self { num_hands }
+    }
+}
+
+impl Default for FixedGameStateIteratorGen {
+    fn default() -> Self {
+        Self { num_hands: 10 }
     }
 }
 
@@ -33,8 +39,62 @@ impl FixedGameStateIteratorGen {
 /// Returns an iterator that yields `num_hands` clones of the input `game_state`
 impl GameStateIteratorGen for FixedGameStateIteratorGen {
     fn generate(&self, game_state: &GameState) -> impl Iterator<Item = GameState> {
-        let num_hands = self.num_hands;
-        (0..num_hands).map(move |_| game_state.clone())
+        (0..self.num_hands).map(|_| game_state.clone())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PerRoundFixedGameStateIteratorGen {
+    // For PreFlop
+    pub pre_flop_num_hands: usize,
+    // For Flop
+    pub flop_num_hands: usize,
+    // For Turn
+    pub turn_num_hands: usize,
+    // For River
+    pub river_num_hands: usize,
+}
+
+impl PerRoundFixedGameStateIteratorGen {
+    pub fn new(
+        pre_flop_num_hands: usize,
+        flop_num_hands: usize,
+        turn_num_hands: usize,
+        river_num_hands: usize,
+    ) -> Self {
+        Self {
+            pre_flop_num_hands,
+            flop_num_hands,
+            turn_num_hands,
+            river_num_hands,
+        }
+    }
+
+    fn num_hands(&self, game_state: &GameState) -> usize {
+        match game_state.round {
+            game_state::Round::Preflop => self.pre_flop_num_hands,
+            game_state::Round::Flop => self.flop_num_hands,
+            game_state::Round::Turn => self.turn_num_hands,
+            game_state::Round::River => self.river_num_hands,
+            _ => 1, // Handle any other rounds if necessary
+        }
+    }
+}
+
+impl Default for PerRoundFixedGameStateIteratorGen {
+    fn default() -> Self {
+        Self {
+            pre_flop_num_hands: 5,
+            flop_num_hands: 3,
+            turn_num_hands: 3,
+            river_num_hands: 1,
+        }
+    }
+}
+
+impl GameStateIteratorGen for PerRoundFixedGameStateIteratorGen {
+    fn generate(&self, game_state: &GameState) -> impl Iterator<Item = GameState> {
+        (0..self.num_hands(game_state)).map(|_| game_state.clone())
     }
 }
 
@@ -52,5 +112,62 @@ mod tests {
         assert_eq!(iter.next().unwrap(), game_state);
         assert_eq!(iter.next().unwrap(), game_state);
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_per_round() {
+        let mut game_state = GameState::new_starting(vec![100.0; 3], 10.0, 5.0, 0.0, 0);
+        let generator = PerRoundFixedGameStateIteratorGen::new(2, 3, 4, 1);
+
+        game_state.advance_round();
+        game_state.advance_round();
+        game_state.advance_round();
+
+        assert_eq!(game_state.round, game_state::Round::Preflop);
+
+        // Preflop
+        {
+            let mut iter = generator.generate(&game_state);
+            assert_eq!(iter.next().unwrap(), game_state);
+            assert_eq!(iter.next().unwrap(), game_state);
+            assert!(iter.next().is_none());
+        }
+
+        // Flop
+        game_state.advance_round();
+        game_state.advance_round();
+        assert_eq!(game_state.round, game_state::Round::Flop);
+        {
+            let mut iter_flop = generator.generate(&game_state);
+            assert_eq!(iter_flop.next().unwrap(), game_state);
+            assert_eq!(iter_flop.next().unwrap(), game_state);
+            assert_eq!(iter_flop.next().unwrap(), game_state);
+            assert!(iter_flop.next().is_none());
+        }
+
+        // Turn
+        game_state.advance_round();
+        game_state.advance_round();
+        assert_eq!(game_state.round, game_state::Round::Turn);
+        {
+            let mut iter_turn = generator.generate(&game_state);
+
+            assert_eq!(iter_turn.next().unwrap(), game_state);
+            assert_eq!(iter_turn.next().unwrap(), game_state);
+            assert_eq!(iter_turn.next().unwrap(), game_state);
+            assert_eq!(iter_turn.next().unwrap(), game_state);
+            assert!(iter_turn.next().is_none());
+        }
+
+        // River
+        game_state.advance_round();
+        game_state.advance_round();
+        assert_eq!(game_state.round, game_state::Round::River);
+        {
+            let mut iter_river = generator.generate(&game_state);
+
+            assert_eq!(iter_river.next().unwrap(), game_state);
+            assert!(iter_river.next().is_none());
+        }
     }
 }

--- a/src/arena/cfr/mod.rs
+++ b/src/arena/cfr/mod.rs
@@ -50,7 +50,9 @@ mod state;
 pub use action_generator::{ActionGenerator, BasicCFRActionGenerator};
 pub use agent::CFRAgent;
 pub use export::{ExportFormat, export_cfr_state, export_to_dot, export_to_png, export_to_svg};
-pub use gamestate_iterator_gen::{FixedGameStateIteratorGen, GameStateIteratorGen};
+pub use gamestate_iterator_gen::{
+    FixedGameStateIteratorGen, GameStateIteratorGen, PerRoundFixedGameStateIteratorGen,
+};
 pub use historian::CFRHistorian;
 pub use node::{Node, NodeData, PlayerData, TerminalData};
 pub use state::{CFRState, TraversalState};


### PR DESCRIPTION
Summary:
- PerRoundFixedGameStateIteratorGen allows changing the number of
  gamestates to explore. For the river we don't have any more cards to
  come so fewer iterations are needed.

Test Plan:
- Perf got much better.
