### PR TITLE
perf: remove uuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,6 @@ dependencies = [
  "tikv-jemallocator",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -1016,16 +1015,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
-dependencies = [
- "getrandom",
- "serde",
-]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde_json = { version = "~1.0.135", optional = true }
 arbitrary = { version = "~1.4.1", optional = true, features = ["derive"] }
 tracing = { version = "~0.1.41", optional = true }
 approx = { version = "~0.5.1", optional = true }
-uuid = { version = "1.16.0", optional = true, features = ["v7"] }
 little-sorry = { version = "~1.0.0", optional = true, features = [] }
 ndarray = { version = "~0.16.1", optional = true }
 
@@ -39,9 +38,8 @@ tikv-jemallocator = {version = "0.6.0", features = ["profiling", "unprefixed_mal
 
 [features]
 default = ["arena", "serde"]
-uuid = ["dep:uuid"]
-serde = ["dep:serde", "dep:serde_json", "uuid?/serde"]
-arena = ["dep:tracing", "dep:little-sorry", "dep:ndarray", "uuid"]
+serde = ["dep:serde", "dep:serde_json"]
+arena = ["dep:tracing", "dep:little-sorry", "dep:ndarray"]
 arena-test-util = ["arena", "dep:approx"]
 
 [[bench]]

--- a/src/arena/agent/all_in.rs
+++ b/src/arena/agent/all_in.rs
@@ -9,7 +9,7 @@ use super::{Agent, AgentGenerator};
 pub struct AllInAgent;
 
 impl Agent for AllInAgent {
-    fn act(self: &mut AllInAgent, _id: &uuid::Uuid, game_state: &GameState) -> AgentAction {
+    fn act(self: &mut AllInAgent, _id: u128, game_state: &GameState) -> AgentAction {
         AgentAction::Bet(game_state.current_player_stack() + game_state.current_round_bet())
     }
 }

--- a/src/arena/agent/calling.rs
+++ b/src/arena/agent/calling.rs
@@ -9,7 +9,7 @@ use super::{Agent, AgentGenerator};
 pub struct CallingAgent;
 
 impl Agent for CallingAgent {
-    fn act(self: &mut CallingAgent, _id: &uuid::Uuid, game_state: &GameState) -> AgentAction {
+    fn act(self: &mut CallingAgent, _id: u128, game_state: &GameState) -> AgentAction {
         AgentAction::Bet(game_state.current_round_bet())
     }
 }

--- a/src/arena/agent/folding.rs
+++ b/src/arena/agent/folding.rs
@@ -7,7 +7,7 @@ use super::{Agent, AgentGenerator};
 pub struct FoldingAgent;
 
 impl Agent for FoldingAgent {
-    fn act(self: &mut FoldingAgent, _id: &uuid::Uuid, game_state: &GameState) -> AgentAction {
+    fn act(self: &mut FoldingAgent, _id: u128, game_state: &GameState) -> AgentAction {
         let count = game_state.current_round_num_active_players() + game_state.num_all_in_players();
         if count == 1 {
             AgentAction::Bet(game_state.current_round_bet())

--- a/src/arena/agent/mod.rs
+++ b/src/arena/agent/mod.rs
@@ -17,7 +17,7 @@ use super::{action::AgentAction, game_state::GameState};
 /// not to need `Arc<Mutex<T>>`'s overhead.
 pub trait Agent {
     /// This is the method that will be called by the game to get the action
-    fn act(&mut self, id: &uuid::Uuid, game_state: &GameState) -> AgentAction;
+    fn act(&mut self, id: u128, game_state: &GameState) -> AgentAction;
 }
 
 /// AgentBuilder is a trait that is used to build agents for tournaments

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -36,7 +36,7 @@ impl Default for RandomAgent {
 }
 
 impl Agent for RandomAgent {
-    fn act(self: &mut RandomAgent, _id: &uuid::Uuid, game_state: &GameState) -> AgentAction {
+    fn act(self: &mut RandomAgent, _id: u128, game_state: &GameState) -> AgentAction {
         let round_data = &game_state.round_data;
         let player_bet = round_data.current_player_bet();
         let player_stack = game_state.stacks[round_data.to_act_idx];
@@ -220,7 +220,7 @@ impl RandomPotControlAgent {
 }
 
 impl Agent for RandomPotControlAgent {
-    fn act(&mut self, _id: &uuid::Uuid, game_state: &GameState) -> AgentAction {
+    fn act(&mut self, _id: u128, game_state: &GameState) -> AgentAction {
         // We don't want to cheat.
         // So replace all the hands but our own
         let clean_hands = self.clean_hands(game_state);

--- a/src/arena/agent/replay.rs
+++ b/src/arena/agent/replay.rs
@@ -51,11 +51,7 @@ impl Agent for VecReplayAgent {
 }
 
 impl<'a> Agent for SliceReplayAgent<'a> {
-    fn act(
-        self: &mut SliceReplayAgent<'a>,
-        _id: u128,
-        _game_state: &GameState,
-    ) -> AgentAction {
+    fn act(self: &mut SliceReplayAgent<'a>, _id: u128, _game_state: &GameState) -> AgentAction {
         let idx = self.idx;
         self.idx += 1;
         self.actions

--- a/src/arena/agent/replay.rs
+++ b/src/arena/agent/replay.rs
@@ -41,7 +41,7 @@ impl<'a> SliceReplayAgent<'a> {
 }
 
 impl Agent for VecReplayAgent {
-    fn act(self: &mut VecReplayAgent, _id: &uuid::Uuid, _game_state: &GameState) -> AgentAction {
+    fn act(self: &mut VecReplayAgent, _id: u128, _game_state: &GameState) -> AgentAction {
         let idx = self.idx;
         self.idx += 1;
         self.actions
@@ -53,7 +53,7 @@ impl Agent for VecReplayAgent {
 impl<'a> Agent for SliceReplayAgent<'a> {
     fn act(
         self: &mut SliceReplayAgent<'a>,
-        _id: &uuid::Uuid,
+        _id: u128,
         _game_state: &GameState,
     ) -> AgentAction {
         let idx = self.idx;

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -237,11 +237,7 @@ where
     T: ActionGenerator + 'static,
     I: GameStateIteratorGen + Clone + 'static,
 {
-    fn act(
-        &mut self,
-        id: u128,
-        game_state: &GameState,
-    ) -> crate::arena::action::AgentAction {
+    fn act(&mut self, id: u128, game_state: &GameState) -> crate::arena::action::AgentAction {
         event!(tracing::Level::TRACE, ?id, "Agent acting");
         assert!(
             game_state.round_data.to_act_idx == self.traversal_state.player_idx(),

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -239,7 +239,7 @@ where
 {
     fn act(
         &mut self,
-        id: &uuid::Uuid,
+        id: u128,
         game_state: &GameState,
     ) -> crate::arena::action::AgentAction {
         event!(tracing::Level::TRACE, ?id, "Agent acting");

--- a/src/arena/cfr/historian.rs
+++ b/src/arena/cfr/historian.rs
@@ -149,7 +149,7 @@ where
 {
     fn record_action(
         &mut self,
-        _id: &uuid::Uuid,
+        _id: u128,
         game_state: &GameState,
         action: Action,
     ) -> Result<(), HistorianError> {

--- a/src/arena/historian/directory_historian.rs
+++ b/src/arena/historian/directory_historian.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashMap, fs::File, path::PathBuf};
 
-use uuid::Uuid;
-
 use crate::arena::action::Action;
 
 use super::Historian;
@@ -10,7 +8,7 @@ use super::Historian;
 #[derive(Debug, Clone)]
 pub struct DirectoryHistorian {
     base_path: PathBuf,
-    sequence: HashMap<Uuid, Vec<Action>>,
+    sequence: HashMap<u128, Vec<Action>>,
 }
 
 impl DirectoryHistorian {
@@ -41,7 +39,7 @@ impl Historian for DirectoryHistorian {
     /// Returns an error if there was a problem recording the action.
     fn record_action(
         &mut self,
-        id: &uuid::Uuid,
+        id: u128,
         _game_state: &crate::arena::GameState,
         action: crate::arena::action::Action,
     ) -> Result<(), super::HistorianError> {
@@ -55,7 +53,7 @@ impl Historian for DirectoryHistorian {
         // something fails.
         let file = File::create(game_path)?;
         // Add the new action to the sequence
-        let sequence = self.sequence.entry(*id).or_default();
+        let sequence = self.sequence.entry(id).or_default();
         sequence.push(action);
 
         // Write the sequence to the file

--- a/src/arena/historian/failing.rs
+++ b/src/arena/historian/failing.rs
@@ -9,7 +9,7 @@ pub struct FailingHistorian;
 impl Historian for FailingHistorian {
     fn record_action(
         &mut self,
-        _id: &uuid::Uuid,
+        _id: u128,
         _game_state: &GameState,
         _action: crate::arena::action::Action,
     ) -> Result<(), crate::arena::historian::HistorianError> {

--- a/src/arena/historian/fn_historian.rs
+++ b/src/arena/historian/fn_historian.rs
@@ -11,7 +11,7 @@ pub struct FnHistorian<F> {
     func: F,
 }
 
-impl<F: Fn(&uuid::Uuid, &GameState, Action) -> Result<(), HistorianError>> FnHistorian<F> {
+impl<F: Fn(u128, &GameState, Action) -> Result<(), HistorianError>> FnHistorian<F> {
     /// Create a new `FnHistorian` with the provided function
     /// that will be called when an action is received on a simulation.
     pub fn new(f: F) -> Self {
@@ -19,12 +19,12 @@ impl<F: Fn(&uuid::Uuid, &GameState, Action) -> Result<(), HistorianError>> FnHis
     }
 }
 
-impl<F: Clone + Fn(&uuid::Uuid, &GameState, Action) -> Result<(), HistorianError>> Historian
+impl<F: Clone + Fn(u128, &GameState, Action) -> Result<(), HistorianError>> Historian
     for FnHistorian<F>
 {
     fn record_action(
         &mut self,
-        id: &uuid::Uuid,
+        id: u128,
         game_state: &GameState,
         action: Action,
     ) -> Result<(), HistorianError> {

--- a/src/arena/historian/mod.rs
+++ b/src/arena/historian/mod.rs
@@ -42,7 +42,7 @@ pub trait Historian {
     /// `Simulation`.
     fn record_action(
         &mut self,
-        id: &uuid::Uuid,
+        id: u128,
         game_state: &GameState,
         action: Action,
     ) -> Result<(), HistorianError>;

--- a/src/arena/historian/null.rs
+++ b/src/arena/historian/null.rs
@@ -5,7 +5,7 @@ pub struct NullHistorian;
 impl Historian for NullHistorian {
     fn record_action(
         &mut self,
-        _id: &uuid::Uuid,
+        _id: u128,
         _game_state: &crate::arena::GameState,
         _action: crate::arena::action::Action,
     ) -> Result<(), super::HistorianError> {

--- a/src/arena/historian/stats_tracking.rs
+++ b/src/arena/historian/stats_tracking.rs
@@ -146,7 +146,7 @@ impl Default for StatsTrackingHistorian {
 impl Historian for StatsTrackingHistorian {
     fn record_action(
         &mut self,
-        _id: &uuid::Uuid,
+        _id: u128,
         game_state: &GameState,
         action: Action,
     ) -> Result<(), super::HistorianError> {

--- a/src/arena/historian/vec.rs
+++ b/src/arena/historian/vec.rs
@@ -48,7 +48,7 @@ impl Default for VecHistorian {
 impl Historian for VecHistorian {
     fn record_action(
         &mut self,
-        _id: &uuid::Uuid,
+        _id: u128,
         game_state: &GameState,
         action: Action,
     ) -> Result<(), HistorianError> {

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use crate::core::{CardBitSet, Deck};
 
 use super::{
@@ -144,7 +146,8 @@ impl HoldemSimulationBuilder {
         // Create a new simulation id.
         // This will be used to track
         // this exact run of a simulation.
-        let id = uuid::Uuid::now_v7();
+        let mut rand = rand::rng();
+        let id = rand.random::<u128>();
 
         Ok(HoldemSimulation {
             agents,


### PR DESCRIPTION
Summary:
Since I was looking at the flamegraph svg. I noticed a good ammount of
uuid time on cpu. We don't need that complexity. We only need an ID's
not going to repeat with no-coordination. This adds that by using u128

** This is a breaking change. **

It changes the Agent API
It changes the Historian API

Test:
hyperfine tests
