### PR TITLE
refactor: remove un-used outputting

### DIFF
--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -298,7 +298,7 @@ mod tests {
         let game_state = GameState::new_starting(stacks, 5.0, 2.5, 0.0, 0);
 
         let states: Vec<_> = (0..num_agents)
-            .map(|_| CFRState::outputting(game_state.clone()))
+            .map(|_| CFRState::new(game_state.clone()))
             .collect();
 
         let agents: Vec<_> = states

--- a/src/arena/cfr/state.rs
+++ b/src/arena/cfr/state.rs
@@ -57,7 +57,6 @@ pub struct CFRStateInternal {
 #[derive(Debug, Clone)]
 pub struct CFRState {
     inner_state: Rc<RefCell<CFRStateInternal>>,
-    pub output: bool,
 }
 
 impl CFRState {
@@ -68,18 +67,6 @@ impl CFRState {
                 starting_game_state: game_state.clone(),
                 next_node_idx: 1,
             })),
-            output: false,
-        }
-    }
-
-    pub fn outputting(game_state: GameState) -> Self {
-        CFRState {
-            inner_state: Rc::new(RefCell::new(CFRStateInternal {
-                nodes: vec![Node::new_root()],
-                starting_game_state: game_state.clone(),
-                next_node_idx: 1,
-            })),
-            output: true,
         }
     }
 


### PR DESCRIPTION
Summary:
CFR State doesn't need that. So lets remove it.

Test Plan:
`cargo check`
