### PR TITLE
pref: don't re-explore nodes with enough games

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -153,18 +153,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -367,9 +367,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
+checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
 dependencies = [
  "jiff-static",
  "log",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
+checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -419,9 +419,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "little-sorry"
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -833,9 +833,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3.19", default-features = true, features = [
     "env-filter",
     "fmt",
 ] }
-env_logger = { version = "0.11.7" }
+env_logger = { version = "0.11.8" }
 approx = { version = "0.5.1" }
 tempfile = "3.8.1"
 

--- a/src/arena/cfr/export.rs
+++ b/src/arena/cfr/export.rs
@@ -574,7 +574,7 @@ mod tests {
             "Raise action not properly labeled"
         );
         assert!(
-            content.contains("%"),
+            content.contains('%'),
             "Action percentages not properly displayed"
         );
 

--- a/src/arena/cfr/gamestate_iterator_gen.rs
+++ b/src/arena/cfr/gamestate_iterator_gen.rs
@@ -84,9 +84,9 @@ impl PerRoundFixedGameStateIteratorGen {
 impl Default for PerRoundFixedGameStateIteratorGen {
     fn default() -> Self {
         Self {
-            pre_flop_num_hands: 5,
-            flop_num_hands: 3,
-            turn_num_hands: 3,
+            pre_flop_num_hands: 10,
+            flop_num_hands: 10,
+            turn_num_hands: 10,
             river_num_hands: 1,
         }
     }

--- a/src/arena/historian/stats_tracking.rs
+++ b/src/arena/historian/stats_tracking.rs
@@ -82,7 +82,7 @@ impl StatsTrackingHistorian {
     }
 
     fn record_played_action(
-        &mut self,
+        &self,
         games_state: &GameState,
         payload: PlayedActionPayload,
     ) -> Result<(), super::HistorianError> {

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -335,20 +335,20 @@ mod tests {
         deck: &mut CardBitSet,
         game_state: &mut GameState,
     ) {
-        let c = Card::try_from(card_str).unwrap();
-        assert!(deck.contains(c));
-        deck.remove(c);
-        game_state.hands[idx].insert(c);
+        let card = Card::try_from(card_str).unwrap();
+        assert!(deck.contains(card));
+        deck.remove(card);
+        game_state.hands[idx].insert(card);
     }
 
     fn deal_community_card(card_str: &str, deck: &mut CardBitSet, game_state: &mut GameState) {
-        let c = Card::try_from(card_str).unwrap();
-        assert!(deck.contains(c));
-        deck.remove(c);
+        let card = Card::try_from(card_str).unwrap();
+        assert!(deck.contains(card));
+        deck.remove(card);
         for h in &mut game_state.hands {
-            h.insert(c);
+            h.insert(card);
         }
 
-        game_state.board.push(c);
+        game_state.board.push(card);
     }
 }

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -337,7 +337,7 @@ impl HoldemSimulation {
                 // Here we use that property to find the max bet that this pot
                 // will give for this round of splitting ties.
                 let max_wager = bets[players[start_idx]];
-                let mut pot: f64 = folded_pot as f64;
+                let mut pot: f64 = f64::from(folded_pot);
                 folded_pot = 0.0;
 
                 // Most common is that ties will

--- a/src/core/card_iter.rs
+++ b/src/core/card_iter.rs
@@ -1,4 +1,4 @@
-use crate::core::*;
+use crate::core::{Card, FlatDeck};
 
 /// Given some cards create sets of possible groups of cards.
 #[derive(Debug)]
@@ -95,6 +95,8 @@ impl<'a> IntoIterator for &'a FlatDeck {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::{Deck, FlatHand, Suit, Value};
+
     use super::*;
 
     #[test]

--- a/src/core/flat_deck.rs
+++ b/src/core/flat_deck.rs
@@ -5,7 +5,7 @@ use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 extern crate rand;
 use rand::Rng;
 use rand::rng;
-use rand::seq::*;
+use rand::seq::{IndexedRandom, SliceRandom};
 
 /// `FlatDeck` is a deck of cards that allows easy
 /// indexing into the cards. It does not provide

--- a/src/core/flat_hand.rs
+++ b/src/core/flat_hand.rs
@@ -1,4 +1,4 @@
-use crate::core::card::*;
+use crate::core::card::{Card, Suit, Value};
 use std::ops::Index;
 use std::ops::{RangeFrom, RangeFull, RangeTo};
 use std::slice::Iter;
@@ -84,7 +84,7 @@ impl FlatHand {
     }
     /// Truncate the hand to the given number of cards.
     pub fn truncate(&mut self, len: usize) {
-        self.0.truncate(len)
+        self.0.truncate(len);
     }
     /// How many cards are in this hand so far ?
     pub fn len(&self) -> usize {

--- a/src/simulated_icm/mod.rs
+++ b/src/simulated_icm/mod.rs
@@ -111,7 +111,7 @@ mod tests {
         let payments = vec![10_000, 6_000, 4_000, 1_000, 800];
         let mut rng = rng();
 
-        for num_players in [2, 3, 4, 5, 15, 16, 32].iter() {
+        for num_players in &[2, 3, 4, 5, 15, 16, 32] {
             let chips: Vec<i32> = (0..*num_players)
                 .map(|_pn| rng.random_range(1..500))
                 .collect();
@@ -138,7 +138,7 @@ mod tests {
 
         let final_share: Vec<f64> = total_winnings
             .iter()
-            .map(|v| (*v as f64) / (num_trials as f64))
+            .map(|v| f64::from(*v) / f64::from(num_trials))
             .collect();
 
         assert!(
@@ -161,12 +161,12 @@ mod tests {
                 .iter()
                 .zip(single_wins.iter())
                 .map(|(a, b)| a + b)
-                .collect()
+                .collect();
         }
 
         let final_share: Vec<f64> = total_winnings
             .iter()
-            .map(|v| (*v as f64) / (num_trials as f64))
+            .map(|v| f64::from(*v) / f64::from(num_trials))
             .collect();
 
         let sum: f64 = final_share.iter().sum();


### PR DESCRIPTION
Summary:
- This allows agents to use the computed solution from before. Greatly
  speeding up the process
- Added `CFRAgent.needs_to_explore()`
- Don't create the regret until needed.
- Use the presence of the regret matcher to keep track
- Up the number of games that the example uses as it's too fast for
  timing now.

Test Plan:
- cargo test --all-features
- hyperfine
