### PR TITLE
fix: fuzzing wasn't updated when I changed HoldemSimulationBuilder

### DIFF
--- a/fuzz/fuzz_targets/multi_replay_agent.rs
+++ b/fuzz/fuzz_targets/multi_replay_agent.rs
@@ -16,7 +16,7 @@ use rs_poker::arena::{
     Agent,
     GameState,
     HoldemSimulation,
-    RngHoldemSimulationBuilder,
+HoldemSimulationBuilder,
 };
 
 use libfuzzer_sys::fuzz_target;
@@ -103,7 +103,11 @@ fn input_good(input: &MultiInput) -> bool {
         for action in &player.actions {
             match action {
                 AgentAction::Bet(bet) => {
-                    if bet.is_sign_negative() || bet.is_nan() || bet.is_infinite() || (*bet == 0.0 || *bet < input.bb) {
+                    if bet.is_sign_negative()
+                        || bet.is_nan()
+                        || bet.is_infinite()
+                        || (*bet == 0.0 || *bet < input.bb)
+                    {
                         return false;
                     }
                 }
@@ -117,7 +121,7 @@ fn input_good(input: &MultiInput) -> bool {
 
 fuzz_target!(|input: MultiInput| {
     let sb = input.sb;
-let bb = input.sb + input.sb;
+    let bb = input.sb + input.sb;
     let ante = input.ante;
 
     if !input_good(&input) {
@@ -146,20 +150,19 @@ let bb = input.sb + input.sb;
     // Notice that dealer_idx is sanitized to ensure it's in the proper range here
     // rather than with the rest of the safety checks.
     let game_state = GameState::new_starting(stacks, bb, sb, ante, input.dealer_idx % agents.len());
-    let rng = StdRng::seed_from_u64(input.seed);
+    let mut rng = StdRng::seed_from_u64(input.seed);
 
     // let records = VecHistorian::new_storage();
     // let hist = Box::new(VecHistorian::new(records.clone()));
 
     // Do the thing
-    let mut sim: HoldemSimulation = RngHoldemSimulationBuilder::default()
-        .rng(rng)
+    let mut sim: HoldemSimulation = HoldemSimulationBuilder::default()
         .game_state(game_state)
         .agents(agents)
-         .historians(historians)
+        .historians(historians)
         .build()
         .unwrap();
-    sim.run();
+    sim.run(&mut rng);
 
     // for _record in records.borrow().iter() {
     //     // println!("{:?}", record.action);

--- a/fuzz/fuzz_targets/replay_agent.rs
+++ b/fuzz/fuzz_targets/replay_agent.rs
@@ -10,7 +10,12 @@ use approx::assert_relative_ne;
 use rand::{rngs::StdRng, SeedableRng};
 
 use rs_poker::arena::{
-    action::{Action, AgentAction}, agent::VecReplayAgent, game_state::Round, historian, test_util::{assert_valid_history, assert_valid_game_state, assert_valid_round_data}, Agent, GameState, HoldemSimulation, RngHoldemSimulationBuilder
+    action::AgentAction,
+    agent::VecReplayAgent,
+    game_state::Round,
+    historian,
+    test_util::{assert_valid_game_state, assert_valid_history, assert_valid_round_data},
+    Agent, GameState, HoldemSimulation, HoldemSimulationBuilder,
 };
 
 use libfuzzer_sys::fuzz_target;
@@ -34,18 +39,15 @@ fuzz_target!(|input: Input| {
 
     let storage = vec_historian.get_storage();
 
-    let historians : Vec<Box<dyn historian::Historian>> = vec![
-        vec_historian
-    ];
-    let rng = StdRng::seed_from_u64(input.seed);
-    let mut sim: HoldemSimulation = RngHoldemSimulationBuilder::default()
-        .rng(rng)
+    let historians: Vec<Box<dyn historian::Historian>> = vec![vec_historian];
+    let mut rng = StdRng::seed_from_u64(input.seed);
+    let mut sim: HoldemSimulation = HoldemSimulationBuilder::default()
         .game_state(game_state)
         .agents(agents)
         .historians(historians)
         .build()
         .unwrap();
-    sim.run();
+    sim.run(&mut rng);
 
     assert_eq!(Round::Complete, sim.game_state.round);
     assert_relative_ne!(0.0_f32, sim.game_state.player_bet.iter().sum());


### PR DESCRIPTION
Summary:
- Change to the new api for sim builder in arena
- Use the mutable rng api for running the sim

Test Plan:
- cargo fuzz run replay_agent
- cargo fuzz run multi_replay_agent
