### PR TITLE
test: add tests discovered by cargo mutants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -153,18 +153,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -367,9 +367,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
+checksum = "e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0"
 dependencies = [
  "jiff-static",
  "log",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
+checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,9 +407,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/core/card.rs
+++ b/src/core/card.rs
@@ -509,4 +509,19 @@ mod tests {
         assert!(12 == Value::Ace.gap(Value::Two));
         assert!(12 == Value::Two.gap(Value::Ace));
     }
+
+    #[test]
+    fn test_suit_to_char() {
+        let s = Suit::Spade;
+        assert_eq!('s', s.to_char());
+
+        let s = Suit::Club;
+        assert_eq!('c', s.to_char());
+
+        let s = Suit::Heart;
+        assert_eq!('h', s.to_char());
+
+        let s = Suit::Diamond;
+        assert_eq!('d', s.to_char());
+    }
 }

--- a/src/core/card_bit_set.rs
+++ b/src/core/card_bit_set.rs
@@ -418,6 +418,48 @@ mod tests {
     }
 
     #[test]
+    fn test_bit_or() {
+        let mut cards = CardBitSet::new();
+        cards.insert(Card::from(17));
+        cards.insert(Card::from(18));
+
+        let mut cards2 = CardBitSet::new();
+        cards2.insert(Card::from(1));
+        cards2.insert(Card::from(2));
+        cards2.insert(Card::from(17));
+
+        let or = cards | cards2;
+        assert_eq!(or.count(), 4);
+        assert!(or.contains(Card::from(17)));
+        assert!(or.contains(Card::from(18)));
+        assert!(or.contains(Card::from(1)));
+        assert!(or.contains(Card::from(2)));
+        assert!(!or.is_empty());
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut cards = CardBitSet::new();
+        cards.insert(Card::from(17));
+        cards.insert(Card::from(18));
+
+        assert!(cards.contains(Card::from(17)));
+        cards.remove(Card::from(17));
+
+        assert!(!cards.contains(Card::from(17)));
+        assert!(cards.contains(Card::from(18)));
+        assert_eq!(1, cards.count());
+        assert!(!cards.is_empty());
+
+        cards.remove(Card::from(18));
+        assert!(!cards.contains(Card::from(18)));
+
+        // Old cards don't come back
+        assert!(!cards.contains(Card::from(17)));
+        assert_eq!(0, cards.count());
+    }
+
+    #[test]
     fn test_is_empty() {
         let empty = CardBitSet::new();
         assert!(empty.is_empty());

--- a/src/core/deck.rs
+++ b/src/core/deck.rs
@@ -235,4 +235,26 @@ mod tests {
         assert!(d_one.is_empty());
         assert!(d_two.is_empty());
     }
+
+    #[test]
+    fn test_insert_returns_bool() {
+        let mut d = Deck::new();
+        let c = Card {
+            value: Value::Ace,
+            suit: Suit::Heart,
+        };
+        assert!(d.insert(c));
+        assert!(!d.insert(c));
+        assert!(d.contains(&c));
+        assert_eq!(d.len(), 1);
+
+        let c2 = Card {
+            value: Value::Two,
+            suit: Suit::Heart,
+        };
+        assert!(d.insert(c2));
+        assert!(!d.insert(c2));
+        assert!(d.contains(&c2));
+        assert_eq!(d.len(), 2);
+    }
 }

--- a/src/core/flat_deck.rs
+++ b/src/core/flat_deck.rs
@@ -147,4 +147,30 @@ mod tests {
         assert_eq!(fd_one, fd_two);
         assert_eq!(fd_one, fd_two);
     }
+
+    #[test]
+    fn test_index() {
+        let mut fd: FlatDeck = Deck::new().into();
+
+        let c = Card {
+            value: Value::Nine,
+            suit: Suit::Heart,
+        };
+        fd.cards.push(c);
+        assert_eq!(c, fd[0]);
+
+        let mut fd: FlatDeck = Deck::new().into();
+        let c = Card {
+            value: Value::Nine,
+            suit: Suit::Heart,
+        };
+        let c2 = Card {
+            value: Value::Ten,
+            suit: Suit::Heart,
+        };
+        fd.cards.push(c);
+        fd.cards.push(c2);
+        assert_eq!(c, fd[0]);
+        assert_eq!(c2, fd[1]);
+    }
 }

--- a/src/core/hand.rs
+++ b/src/core/hand.rs
@@ -165,3 +165,59 @@ impl From<Hand> for CardBitSet {
         val.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert() {
+        let mut hand = Hand::new();
+        for i in 1..7 {
+            let c = Card::from(i);
+            assert!(hand.insert(c));
+            assert!(hand.contains(&c));
+            assert_eq!(hand.count(), usize::from(i));
+        }
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let mut hand = Hand::new();
+        assert!(hand.is_empty());
+
+        hand.insert(Card::from(1));
+        assert!(!hand.is_empty());
+        hand.clear();
+
+        assert!(hand.is_empty());
+        hand.insert(Card::from(2));
+        assert!(!hand.is_empty());
+    }
+
+    #[test]
+    fn test_bit_and() {
+        let mut hand1 = Hand::new();
+        let mut hand2 = Hand::new();
+
+        for i in 1..7 {
+            let c = Card::from(i);
+            hand1.insert(c);
+        }
+
+        for i in 4..10 {
+            let c = Card::from(i);
+            hand2.insert(c);
+        }
+        let hand3 = hand1 & hand2;
+        assert_eq!(hand3.count(), 3);
+        for i in 4..7 {
+            let c = Card::from(i);
+            assert!(hand3.contains(&c));
+        }
+        for i in 1..4 {
+            let c = Card::from(i);
+            assert!(!hand3.contains(&c));
+        }
+    }
+}


### PR DESCRIPTION
Summary:
- These were the most obviously missed tests that cargo mutants has
  found.
- They include Card, Hand, FlatDeck, and Deck

Test Plan:
- These are the tests you were looking for.
