### PR TITLE
test: more tests for cargo mutants missed core structs

### DIFF
--- a/src/core/card_bit_set.rs
+++ b/src/core/card_bit_set.rs
@@ -438,6 +438,28 @@ mod tests {
     }
 
     #[test]
+    fn test_bit_or_assign() {
+        let mut cards = CardBitSet::new();
+        cards.insert(Card::from(17));
+        cards.insert(Card::from(18));
+
+        let mut cards2 = CardBitSet::new();
+        cards2.insert(Card::from(1));
+        cards2.insert(Card::from(2));
+        cards2.insert(Card::from(17));
+
+        cards |= cards2;
+
+        assert_eq!(cards.count(), 4);
+        assert!(cards.contains(Card::from(17)));
+        assert!(cards.contains(Card::from(18)));
+        assert!(cards.contains(Card::from(1)));
+        assert!(cards.contains(Card::from(2)));
+        assert!(!cards.is_empty());
+        assert_eq!(cards, cards | cards2);
+    }
+
+    #[test]
     fn test_remove() {
         let mut cards = CardBitSet::new();
         cards.insert(Card::from(17));
@@ -586,6 +608,37 @@ mod tests {
         // None of the non-shared are there.
         assert!(!cards.contains(Card::new(crate::core::Value::Ace, crate::core::Suit::Club,)));
         assert!(!cards.contains(Card::new(
+            crate::core::Value::Three,
+            crate::core::Suit::Heart,
+        )));
+    }
+
+    #[test]
+    fn test_bit_xor_assign() {
+        let mut cards = CardBitSet::new();
+        cards.insert(Card::new(crate::core::Value::Ace, crate::core::Suit::Club));
+        cards.insert(Card::new(
+            crate::core::Value::King,
+            crate::core::Suit::Diamond,
+        ));
+
+        let mut cards2 = CardBitSet::new();
+        cards2.insert(Card::new(
+            crate::core::Value::Three,
+            crate::core::Suit::Heart,
+        ));
+        cards2.insert(Card::new(
+            crate::core::Value::King,
+            crate::core::Suit::Diamond,
+        ));
+
+        cards ^= cards2;
+
+        assert_eq!(cards.count(), 2);
+
+        // These were in both card bit sets
+        assert!(cards.contains(Card::new(crate::core::Value::Ace, crate::core::Suit::Club,)));
+        assert!(cards.contains(Card::new(
             crate::core::Value::Three,
             crate::core::Suit::Heart,
         )));

--- a/src/core/deck.rs
+++ b/src/core/deck.rs
@@ -257,4 +257,29 @@ mod tests {
         assert!(d.contains(&c2));
         assert_eq!(d.len(), 2);
     }
+
+    #[test]
+    fn test_count_zero() {
+        let d = Deck::new();
+        assert_eq!(0, d.count());
+    }
+
+    #[test]
+    fn test_count_after_adding() {
+        let mut d = Deck::new();
+
+        let c = Card {
+            value: Value::Ace,
+            suit: Suit::Heart,
+        };
+
+        d.insert(c);
+        assert_eq!(1, d.count());
+        d.insert(Card {
+            value: Value::Two,
+            suit: Suit::Heart,
+        });
+
+        assert_eq!(2, d.count());
+    }
 }

--- a/src/core/flat_deck.rs
+++ b/src/core/flat_deck.rs
@@ -28,6 +28,26 @@ impl FlatDeck {
         self.cards.is_empty()
     }
 
+    /// Add a card to the deck.
+    /// This does not check if the card is already in the deck.
+    /// It will just add it to the end of the deck.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rs_poker::core::{Card, Deck, FlatDeck, Suit, Value};
+    ///
+    /// let mut deck: FlatDeck = Deck::new().into();
+    /// let card = Card::new(Value::Ace, Suit::Club);
+    /// deck.push(card);
+    ///
+    /// assert_eq!(1, deck.len());
+    /// assert_eq!(card, deck.deal().unwrap());
+    /// ```
+    pub fn push(&mut self, c: Card) {
+        self.cards.push(c);
+    }
+
     /// Give a random sample of the cards still left in the deck
     pub fn sample(&self, n: usize) -> Vec<Card> {
         let mut rng = rng();
@@ -93,7 +113,6 @@ impl From<Deck> for FlatDeck {
         // cards always result in the same starting flat deck
         let mut cards: Vec<Card> = value.into_iter().collect();
         cards.sort();
-
         Self { cards }
     }
 }
@@ -156,7 +175,7 @@ mod tests {
             value: Value::Nine,
             suit: Suit::Heart,
         };
-        fd.cards.push(c);
+        fd.push(c);
         assert_eq!(c, fd[0]);
 
         let mut fd: FlatDeck = Deck::new().into();
@@ -168,9 +187,31 @@ mod tests {
             value: Value::Ten,
             suit: Suit::Heart,
         };
-        fd.cards.push(c);
-        fd.cards.push(c2);
+        fd.push(c);
+        fd.push(c2);
         assert_eq!(c, fd[0]);
         assert_eq!(c2, fd[1]);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let mut fd: FlatDeck = Deck::new().into();
+        assert!(fd.is_empty());
+
+        fd.push(Card {
+            value: Value::Nine,
+            suit: Suit::Heart,
+        });
+        assert!(!fd.is_empty());
+        let dealt_card = fd.deal();
+
+        assert!(fd.is_empty());
+        assert_eq!(
+            Some(Card {
+                value: Value::Nine,
+                suit: Suit::Heart,
+            }),
+            dealt_card
+        );
     }
 }

--- a/src/core/flat_hand.rs
+++ b/src/core/flat_hand.rs
@@ -220,4 +220,49 @@ mod tests {
         assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
         assert_eq!(h, FlatHand::new_from_str("AdKd").unwrap());
     }
+
+    #[test]
+    fn test_flat_hand_truncate() {
+        let mut hand = FlatHand::new_with_cards(vec![
+            Card::new(Value::Jack, Suit::Spade),
+            Card::new(Value::Jack, Suit::Heart),
+            Card::new(Value::Queen, Suit::Diamond),
+        ]);
+        assert_eq!(hand.len(), 3);
+
+        hand.truncate(2);
+
+        assert_eq!(hand.len(), 2);
+
+        assert_eq!(hand[0], Card::new(Value::Jack, Suit::Spade));
+        assert_eq!(hand[1], Card::new(Value::Jack, Suit::Heart));
+
+        hand.truncate(0);
+
+        assert_eq!(hand.len(), 0);
+        assert!(hand.is_empty());
+        assert_eq!(hand[0..], []);
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut hand = FlatHand::new_with_cards(vec![
+            Card::new(Value::Jack, Suit::Spade),
+            Card::new(Value::Jack, Suit::Heart),
+        ]);
+
+        assert_eq!(hand.len(), 2);
+
+        hand.extend(vec![
+            Card::new(Value::Queen, Suit::Diamond),
+            Card::new(Value::King, Suit::Club),
+        ]);
+
+        assert_eq!(hand.len(), 4);
+
+        assert_eq!(hand[0], Card::new(Value::Jack, Suit::Spade));
+        assert_eq!(hand[1], Card::new(Value::Jack, Suit::Heart));
+        assert_eq!(hand[2], Card::new(Value::Queen, Suit::Diamond));
+        assert_eq!(hand[3], Card::new(Value::King, Suit::Club));
+    }
 }

--- a/src/core/hand.rs
+++ b/src/core/hand.rs
@@ -220,4 +220,51 @@ mod tests {
             assert!(!hand3.contains(&c));
         }
     }
+
+    #[test]
+    fn test_bit_and_assign() {
+        let mut hand1 = Hand::new();
+        let mut hand2 = Hand::new();
+
+        for i in 1..7 {
+            let c = Card::from(i);
+            hand1.insert(c);
+        }
+
+        for i in 4..10 {
+            let c = Card::from(i);
+            hand2.insert(c);
+        }
+        hand1 &= hand2;
+        assert_eq!(hand1.count(), 3);
+        for i in 4..7 {
+            let c = Card::from(i);
+            assert!(hand1.contains(&c));
+        }
+        for i in 1..4 {
+            let c = Card::from(i);
+            assert!(!hand1.contains(&c));
+        }
+    }
+
+    #[test]
+    fn test_remove_return() {
+        let mut hand = Hand::new();
+        hand.insert(Card::from(1));
+        hand.insert(Card::from(2));
+
+        assert_eq!(hand.count(), 2);
+
+        assert!(hand.remove(&Card::from(1)));
+        // It's already removed so this should return false
+        assert!(!hand.remove(&Card::from(1)));
+
+        // Now remove the other card
+        assert!(hand.remove(&Card::from(2)));
+        // I already removed it so this should return false
+        assert!(!hand.remove(&Card::from(2)));
+
+        assert!(hand.is_empty());
+        assert_eq!(hand.count(), 0);
+    }
 }

--- a/src/core/player_bit_set.rs
+++ b/src/core/player_bit_set.rs
@@ -280,4 +280,22 @@ mod tests {
 
         assert_eq!("[AA_AAA__________]", format!("{}", s))
     }
+
+    #[test]
+    fn test_get() {
+        let mut s = PlayerBitSet::default();
+
+        s.enable(0);
+        s.enable(2);
+
+        assert!(s.get(0));
+        assert!(!s.get(1));
+        assert!(s.get(2));
+
+        s.disable(0);
+
+        assert!(!s.get(0));
+        assert!(!s.get(1));
+        assert!(s.get(2));
+    }
 }


### PR DESCRIPTION
Summary:
These are tests for `src/core` structs that cargo mutants show are
missing. I didn't include Rank since it's pretty well tested, but the
bit operations are mostly on exclusive bitfields

Test Plan:
These are the tests you're looking for
