### PR TITLE
build: split release compile into own workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-
 name: "Test Suite"
 on:
   push:
@@ -24,4 +23,3 @@ jobs:
       - run: cargo test --all-features
       - run: cargo fmt --check --all --verbose
       - run: cargo clippy --all-targets --all-features -- -D warnings
-      - run: cargo build --release --all --all-targets

--- a/.github/workflows/prod_compile.yml
+++ b/.github/workflows/prod_compile.yml
@@ -1,0 +1,23 @@
+name: "Prod Compile"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions: {}
+
+jobs:
+  prod_compile:
+      name: cargo prod compile
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+         components: rust-src
+      - run: cargo build --release --all --all-targets


### PR DESCRIPTION
Summary:
This PR moves cargo release compile into its own file so that runs in parallel with the test
