### PR TITLE
refactor: allow agents to add their own historians in HoldemSimulationBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,18 +153,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -367,9 +367,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
 dependencies = [
  "jiff-static",
  "log",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -413,9 +413,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "linux-raw-sys"
@@ -621,13 +621,12 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy",
 ]
 
 [[package]]
@@ -731,7 +730,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rs_poker"
-version = "3.0.4"
+version = "4.0.0-alpha.0"
 dependencies = [
  "approx",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_poker"
-version = "3.0.4"
+version = "4.0.0-alpha.0"
 authors = ["Elliott Clark <eclark@apache.org>"]
 keywords = ["cards", "poker"]
 categories = ["games"]

--- a/examples/cfr_hand_demo.rs
+++ b/examples/cfr_hand_demo.rs
@@ -41,10 +41,7 @@ fn run_simulation(num_agents: usize, export_path: Option<std::path::PathBuf>) {
         })
         .collect();
 
-    let mut historians: Vec<Box<dyn Historian>> = agents
-        .iter()
-        .map(|a| Box::new(a.historian()) as Box<dyn Historian>)
-        .collect();
+    let mut historians: Vec<Box<dyn Historian>> = Vec::new();
 
     if let Some(path) = export_path.clone() {
         // If a path is provided, we create a directory historian

--- a/src/arena/agent/mod.rs
+++ b/src/arena/agent/mod.rs
@@ -8,7 +8,7 @@ mod folding;
 mod random;
 mod replay;
 
-use super::{action::AgentAction, game_state::GameState};
+use super::{Historian, action::AgentAction, game_state::GameState};
 /// This is the trait that you need to implement in order to implenet
 /// different strategies. It's up to you to to implement the logic and state.
 ///
@@ -18,6 +18,13 @@ use super::{action::AgentAction, game_state::GameState};
 pub trait Agent {
     /// This is the method that will be called by the game to get the action
     fn act(&mut self, id: u128, game_state: &GameState) -> AgentAction;
+
+    // Some Agents may need to be able to see the changes in the game
+    // state. This is the method that will be called to create historians
+    // when starting a new simulation game.
+    fn historian(&self) -> Option<Box<dyn Historian>> {
+        None
+    }
 }
 
 /// AgentBuilder is a trait that is used to build agents for tournaments

--- a/src/arena/cfr/mod.rs
+++ b/src/arena/cfr/mod.rs
@@ -66,9 +66,7 @@ mod tests {
     use crate::arena::cfr::{BasicCFRActionGenerator, FixedGameStateIteratorGen, state_store};
     use crate::arena::game_state::{Round, RoundData};
 
-    use crate::arena::{
-        Agent, GameState, Historian, HoldemSimulation, HoldemSimulationBuilder, test_util,
-    };
+    use crate::arena::{Agent, GameState, HoldemSimulation, HoldemSimulationBuilder, test_util};
     use crate::core::{Hand, PlayerBitSet};
 
     use super::CFRAgent;
@@ -239,11 +237,6 @@ mod tests {
             })
             .collect();
 
-        let historians: Vec<Box<dyn Historian>> = agents
-            .iter()
-            .map(|a| Box::new(a.historian()) as Box<dyn Historian>)
-            .collect();
-
         let dyn_agents = agents.into_iter().map(|a| a as Box<dyn Agent>).collect();
 
         let mut rng = rand::rng();
@@ -251,7 +244,6 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(dyn_agents)
-            .historians(historians)
             .build()
             .unwrap();
 

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -141,6 +141,16 @@ impl HoldemSimulationBuilder {
             .agents
             .unwrap_or_else(|| build_agents(game_state.hands.len()));
 
+        let agent_historians = agents.iter().filter_map(|a| a.historian());
+
+        // Add the agent historians to the simulation
+        // historians.
+        let historians: Vec<_> = self
+            .historians
+            .into_iter()
+            .chain(agent_historians)
+            .collect();
+
         let deck = self.deck.unwrap_or_else(|| build_deck(&game_state));
 
         // Create a new simulation id.
@@ -154,7 +164,7 @@ impl HoldemSimulationBuilder {
             game_state,
             deck,
             id,
-            historians: self.historians,
+            historians,
             panic_on_historian_error: self.panic_on_historian_error,
         })
     }


### PR DESCRIPTION
Summary:
- Add `historian` method to `Agent`
- Change CFRAgent to handle this
- Bump Major Version

NOTE: This is a breaking change as you should not include CFR agents'
historians in your HoldemSimulationBuilder.

Test Plan:
- CI
