### PR TITLE
feat: add `AgentAction::Call` that calls the current bet

### DIFF
--- a/src/arena/action.rs
+++ b/src/arena/action.rs
@@ -9,6 +9,8 @@ use super::game_state::Round;
 pub enum AgentAction {
     /// Folds the current hand.
     Fold,
+    /// Matches the current bet.
+    Call,
     /// Bets the specified amount of money.
     Bet(f32),
     /// Go all-in

--- a/src/arena/agent/replay.rs
+++ b/src/arena/agent/replay.rs
@@ -282,4 +282,34 @@ mod tests {
 
         assert_valid_game_state(&sim.game_state);
     }
+
+    #[test]
+    fn test_call_with_fold() {
+        let agent_zero = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![AgentAction::Call]));
+        let agent_one = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Call,
+            AgentAction::Fold,
+            AgentAction::Fold,
+        ]));
+        let agent_two = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![AgentAction::Call]));
+        let agent_three = Box::<VecReplayAgent>::new(VecReplayAgent::new(vec![
+            AgentAction::Call,
+            AgentAction::Call,
+        ]));
+
+        let stacks = vec![50000.0, 50000.0, 50000.0, 50000.0];
+        let game_state = GameState::new_starting(stacks, 50.0, 3.59e-43, 0.0, 1);
+        let agents: Vec<Box<dyn Agent>> = vec![agent_zero, agent_one, agent_two, agent_three];
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let mut sim: HoldemSimulation = HoldemSimulationBuilder::default()
+            .game_state(game_state)
+            .agents(agents)
+            .build()
+            .unwrap();
+
+        sim.run(&mut rng);
+
+        assert_valid_game_state(&sim.game_state);
+    }
 }

--- a/src/arena/cfr/action_generator.rs
+++ b/src/arena/cfr/action_generator.rs
@@ -156,6 +156,7 @@ impl ActionGenerator for BasicCFRActionGenerator {
             AgentAction::Fold => 0,
             AgentAction::Bet(_) => 1,
             AgentAction::AllIn => 2,
+            _ => panic!("Unexpected action {action:?}"),
         }
     }
 


### PR DESCRIPTION
Summary:
When an agent wants to call the current bet unconditionally they can now
pass the Call variant of the AgentAction enum. This will match the
current bet, putting them all in if the bet is larger than their stack
size.

Test Plan:
- Tests added
