### PR TITLE
test: keep fuzzing from hitting fp32 division issues with sb and bb

### DIFF
--- a/fuzz/fuzz_targets/multi_replay_agent.rs
+++ b/fuzz/fuzz_targets/multi_replay_agent.rs
@@ -21,6 +21,8 @@ HoldemSimulationBuilder,
 
 use libfuzzer_sys::fuzz_target;
 
+const MIN_BLIND: f32 = 1e-15;
+
 #[derive(Debug, Clone, arbitrary::Arbitrary)]
 struct PlayerInput {
     pub stack: f32,
@@ -69,7 +71,7 @@ fn input_good(input: &MultiInput) -> bool {
         || input.sb.is_infinite()
         || input.sb < input.ante
         || input.sb < 0.00
-        || (input.sb > 0.0 && input.sb < 1e-10)
+        || (input.sb > 0.0 && input.sb < MIN_BLIND)
     {
         return false;
     }
@@ -78,7 +80,7 @@ fn input_good(input: &MultiInput) -> bool {
         || input.bb.is_infinite()
         || input.bb < input.sb
         || input.bb < 1.0
-        || (input.bb > 0.0 && input.bb < 1e-10)
+        || (input.bb > 0.0 && input.bb < MIN_BLIND)
     {
         return false;
     }

--- a/fuzz/fuzz_targets/multi_replay_agent.rs
+++ b/fuzz/fuzz_targets/multi_replay_agent.rs
@@ -69,6 +69,7 @@ fn input_good(input: &MultiInput) -> bool {
         || input.sb.is_infinite()
         || input.sb < input.ante
         || input.sb < 0.00
+        || (input.sb > 0.0 && input.sb < 1e-10)
     {
         return false;
     }
@@ -77,6 +78,7 @@ fn input_good(input: &MultiInput) -> bool {
         || input.bb.is_infinite()
         || input.bb < input.sb
         || input.bb < 1.0
+        || (input.bb > 0.0 && input.bb < 1e-10)
     {
         return false;
     }
@@ -131,7 +133,7 @@ fuzz_target!(|input: MultiInput| {
     let stacks: Vec<f32> = input
         .players
         .iter()
-        .map(|pi| (pi.stack).clamp(0.0, 1_000_000.0))
+        .map(|pi| (pi.stack).clamp(0.0, 100_000_000.0))
         .collect();
 
     let agents: Vec<Box<dyn Agent>> = input


### PR DESCRIPTION
Summary:
When multiway pots are just the big blind then they have to be split. If
the big blind or folded small blind are so small that the division of
them breaks floating point then we are just testing the epsilon limits.

Test Plan:
- This doesn't break
