### PR TITLE
Make `StateStore` and `CFRState` `Send + Sync`

### DIFF
--- a/src/arena/cfr/action_generator.rs
+++ b/src/arena/cfr/action_generator.rs
@@ -1,4 +1,4 @@
-use std::cell::Ref;
+use std::sync::MappedRwLockReadGuard;
 
 use tracing::event;
 
@@ -62,7 +62,7 @@ impl BasicCFRActionGenerator {
         }
     }
 
-    fn get_target_node(&self) -> Option<Ref<'_, Node>> {
+    fn get_target_node(&self) -> Option<MappedRwLockReadGuard<'_, Node>> {
         let from_node_idx = self.traversal_state.node_idx();
         let from_child_idx = self.traversal_state.chosen_child_idx();
         self.cfr_state

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -1,4 +1,4 @@
-use std::cell::RefMut;
+use std::sync::MappedRwLockWriteGuard;
 
 use little_sorry::RegretMatcher;
 use ndarray::ArrayView1;
@@ -155,7 +155,7 @@ where
             .get_child(from_child_idx)
     }
 
-    fn get_mut_target_node(&mut self) -> RefMut<'_, super::Node> {
+    fn get_mut_target_node(&mut self) -> MappedRwLockWriteGuard<'_, super::Node> {
         let target_node_idx = self.target_node_idx().unwrap();
         self.cfr_state.get_mut(target_node_idx).unwrap()
     }

--- a/src/arena/cfr/export.rs
+++ b/src/arena/cfr/export.rs
@@ -135,7 +135,7 @@ pub fn generate_dot(state: &CFRState) -> String {
     output.push_str("  {rank=source; node_0;}\n");
 
     let inner_state = state.internal_state();
-    let nodes = &inner_state.borrow().nodes;
+    let nodes = &inner_state.read().unwrap().nodes;
 
     // Process nodes
     for node in nodes {

--- a/src/arena/cfr/state.rs
+++ b/src/arena/cfr/state.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{
+    Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
+};
 
 use crate::arena::GameState;
 
@@ -31,8 +33,8 @@ pub struct CFRStateInternal {
 /// tree is built lazily as actions are taken in the game. Each node in the tree
 /// represents a game state and stores regret values used by the CFR algorithm.
 ///
-/// The state is wrapped in an atomically reference-counted readers-writer lock (Arc<RwLock<>>) to allow
-/// sharing between the agent and historian components:
+/// The state is wrapped in an atomically reference-counted readers-writer lock
+/// (Arc<RwLock<>>) to allow sharing between the agent and historian components:
 ///
 /// - The agent needs mutable access to update regret values during simulations
 /// - The historian needs read access to traverse the tree and record actions

--- a/src/arena/cfr/state.rs
+++ b/src/arena/cfr/state.rs
@@ -1,7 +1,4 @@
-use std::{
-    cell::{Ref, RefCell, RefMut},
-    rc::Rc,
-};
+use std::sync::{Arc, MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::arena::GameState;
 
@@ -34,7 +31,7 @@ pub struct CFRStateInternal {
 /// tree is built lazily as actions are taken in the game. Each node in the tree
 /// represents a game state and stores regret values used by the CFR algorithm.
 ///
-/// The state is wrapped in a reference-counted cell (Rc<RefCell<>>) to allow
+/// The state is wrapped in an atomically reference-counted readers-writer lock (Arc<RwLock<>>) to allow
 /// sharing between the agent and historian components:
 ///
 /// - The agent needs mutable access to update regret values during simulations
@@ -56,13 +53,13 @@ pub struct CFRStateInternal {
 /// ```
 #[derive(Debug, Clone)]
 pub struct CFRState {
-    inner_state: Rc<RefCell<CFRStateInternal>>,
+    inner_state: Arc<RwLock<CFRStateInternal>>,
 }
 
 impl CFRState {
     pub fn new(game_state: GameState) -> Self {
         CFRState {
-            inner_state: Rc::new(RefCell::new(CFRStateInternal {
+            inner_state: Arc::new(RwLock::new(CFRStateInternal {
                 nodes: vec![Node::new_root()],
                 starting_game_state: game_state.clone(),
                 next_node_idx: 1,
@@ -71,11 +68,11 @@ impl CFRState {
     }
 
     pub fn starting_game_state(&self) -> GameState {
-        self.inner_state.borrow().starting_game_state.clone()
+        self.inner_state.read().unwrap().starting_game_state.clone()
     }
 
     pub fn add(&mut self, parent_idx: usize, child_idx: usize, data: NodeData) -> usize {
-        let mut state = self.inner_state.borrow_mut();
+        let mut state = self.inner_state.write().unwrap();
 
         let idx = state.next_node_idx;
         state.next_node_idx += 1;
@@ -89,16 +86,16 @@ impl CFRState {
         idx
     }
 
-    pub fn get(&self, idx: usize) -> Option<Ref<'_, Node>> {
-        let inner_ref = self.inner_state.borrow();
+    pub fn get(&self, idx: usize) -> Option<MappedRwLockReadGuard<'_, Node>> {
+        let inner_read_guard = self.inner_state.read().unwrap();
 
-        Ref::filter_map(inner_ref, |state| state.nodes.get(idx)).ok()
+        RwLockReadGuard::filter_map(inner_read_guard, |state| state.nodes.get(idx)).ok()
     }
 
-    pub fn get_mut(&mut self, idx: usize) -> Option<RefMut<'_, Node>> {
-        let inner_ref = self.inner_state.borrow_mut();
+    pub fn get_mut(&mut self, idx: usize) -> Option<MappedRwLockWriteGuard<'_, Node>> {
+        let inner_write_guard = self.inner_state.write().unwrap();
 
-        RefMut::filter_map(inner_ref, |state| state.nodes.get_mut(idx)).ok()
+        RwLockWriteGuard::filter_map(inner_write_guard, |state| state.nodes.get_mut(idx)).ok()
     }
 
     /// Access the internal state of the CFR state structure.
@@ -108,8 +105,8 @@ impl CFRState {
     ///
     /// # Returns
     ///
-    /// A reference to the internal state wrapped in Rc<RefCell<>>
-    pub fn internal_state(&self) -> &Rc<RefCell<CFRStateInternal>> {
+    /// A reference to the internal state wrapped in Arc<RwLock<>>
+    pub fn internal_state(&self) -> &Arc<RwLock<CFRStateInternal>> {
         &self.inner_state
     }
 }
@@ -133,15 +130,23 @@ pub struct TraversalStateInternal {
     pub player_idx: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct TraversalState {
-    inner_state: Rc<RefCell<TraversalStateInternal>>,
+    inner_state: Arc<RwLock<TraversalStateInternal>>,
 }
+
+impl PartialEq for TraversalState {
+    fn eq(&self, other: &Self) -> bool {
+        *self.inner_state.read().unwrap() == *other.inner_state.read().unwrap()
+    }
+}
+
+impl Eq for TraversalState {}
 
 impl TraversalState {
     pub fn new(node_idx: usize, chosen_child_idx: usize, player_idx: usize) -> Self {
         TraversalState {
-            inner_state: Rc::new(RefCell::new(TraversalStateInternal {
+            inner_state: Arc::new(RwLock::new(TraversalStateInternal {
                 node_idx,
                 chosen_child_idx,
                 player_idx,
@@ -154,20 +159,20 @@ impl TraversalState {
     }
 
     pub fn node_idx(&self) -> usize {
-        self.inner_state.borrow().node_idx
+        self.inner_state.read().unwrap().node_idx
     }
 
     pub fn player_idx(&self) -> usize {
-        self.inner_state.borrow().player_idx
+        self.inner_state.read().unwrap().player_idx
     }
 
     pub fn chosen_child_idx(&self) -> usize {
-        self.inner_state.borrow().chosen_child_idx
+        self.inner_state.read().unwrap().chosen_child_idx
     }
 
     pub fn move_to(&mut self, node_idx: usize, chosen_child_idx: usize) {
-        self.inner_state.borrow_mut().node_idx = node_idx;
-        self.inner_state.borrow_mut().chosen_child_idx = chosen_child_idx;
+        self.inner_state.write().unwrap().node_idx = node_idx;
+        self.inner_state.write().unwrap().chosen_child_idx = chosen_child_idx;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@
 //! let _first_results = competition.run(100).unwrap();
 //! ```
 #![feature(assert_matches)]
+#![feature(mapped_lock_guards)]
 #![deny(clippy::all)]
 
 extern crate rand;


### PR DESCRIPTION
/claim #201

This PR makes `StateStore` and `CFRState` thread-safe by replacing `Rc<RefCell<>>` usage with `Arc<RwLock<>>`. Updated consumers of these classes to accept `RwLockReadGuard`/`RwLockWriteGuard` instead of `Ref`/`RefMut`. Updated documentation to reflect this.

Confirmation of the `Send + Sync` Auto Trait Implementations for `StateStore` and `CFRState` can be found in the automatically generated documentation under the "Auto Trait Implementations" section on the left.

Note: [`filter_map` for lock guards is a nightly-only experimental API](https://github.com/rust-lang/rust/issues/117108) requiring `#![feature(mapped_lock_guards)]` to be added to the crate features.