### PR TITLE
refactor: remove assert_matches! to revert to stable

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,0 @@
-format_code_in_doc_comments = true
-wrap_comments = true
-comment_width = 80
-normalize_comments = true
-normalize_doc_attributes = true

--- a/mise.lock
+++ b/mise.lock
@@ -3,7 +3,7 @@ version = "0.9.115"
 backend = "cargo:cargo-nextest"
 
 [[tools.rust]]
-version = "nightly"
+version = "stable"
 backend = "core:rust"
 
 [[tools.taplo]]

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 "cargo:cargo-nextest" = "latest"
-"rust" = { version = "nightly", profile = "default", components = "rust-src,llvm-tools,rustfmt,clippy" }
+"rust" = { version = "stable", profile = "default", components = "rust-src,llvm-tools,rustfmt,clippy" }
 taplo = "latest"
 
 [tasks.'check:fmt']

--- a/src/arena/test_util.rs
+++ b/src/arena/test_util.rs
@@ -1,5 +1,3 @@
-use std::assert_matches::assert_matches;
-
 use approx::assert_relative_eq;
 
 use crate::arena::game_state::Round;
@@ -84,7 +82,11 @@ pub fn assert_valid_history(history_storage: &[HistoryRecord]) {
     assert!(!history_storage.is_empty());
 
     // The first action should always be a game start
-    assert_matches!(history_storage[0].action, Action::GameStart(_));
+    assert!(
+        matches!(history_storage[0].action, Action::GameStart(_)),
+        "First action should be GameStart, but was: {:?}",
+        history_storage[0].action
+    );
 
     // History should include round advance to complete
     assert_advances_to_complete(history_storage);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,6 @@
 //! let mut competition = HoldemCompetition::new(sim_gen);
 //! let _first_results = competition.run(100).unwrap();
 //! ```
-#![cfg_attr(feature = "arena", feature(assert_matches))]
 #![deny(clippy::all)]
 
 extern crate rand;


### PR DESCRIPTION
Summary:
Stable rust is nice. This is the only thing left. So lets go back to
stable.

Test Plan:
- mise check
