### PR TITLE
refactor: add player_idx as an arg to AgentGenerator

### DIFF
--- a/src/arena/agent/all_in.rs
+++ b/src/arena/agent/all_in.rs
@@ -19,7 +19,7 @@ impl Agent for AllInAgent {
 pub struct AllInAgentGenerator;
 
 impl AgentGenerator for AllInAgentGenerator {
-    fn generate(&self, _game_state: &GameState) -> Box<dyn Agent> {
+    fn generate(&self, _player_idx: usize, _game_state: &GameState) -> Box<dyn Agent> {
         Box::new(AllInAgent)
     }
 }

--- a/src/arena/agent/calling.rs
+++ b/src/arena/agent/calling.rs
@@ -19,7 +19,7 @@ impl Agent for CallingAgent {
 pub struct CallingAgentGenerator;
 
 impl AgentGenerator for CallingAgentGenerator {
-    fn generate(&self, _game_state: &GameState) -> Box<dyn Agent> {
+    fn generate(&self, _player_idx: usize, _game_state: &GameState) -> Box<dyn Agent> {
         Box::new(CallingAgent)
     }
 }

--- a/src/arena/agent/folding.rs
+++ b/src/arena/agent/folding.rs
@@ -22,7 +22,7 @@ impl Agent for FoldingAgent {
 pub struct FoldingAgentGenerator;
 
 impl AgentGenerator for FoldingAgentGenerator {
-    fn generate(&self, _game_state: &GameState) -> Box<dyn Agent> {
+    fn generate(&self, _player_idx: usize, _game_state: &GameState) -> Box<dyn Agent> {
         Box::new(FoldingAgent)
     }
 }

--- a/src/arena/agent/mod.rs
+++ b/src/arena/agent/mod.rs
@@ -31,7 +31,8 @@ pub trait Agent {
 /// where each simulation needs a new agent.
 pub trait AgentGenerator {
     /// This method is called before each game to build a new agent.
-    fn generate(&self, game_state: &GameState) -> Box<dyn Agent>;
+    /// The `player_idx` parameter indicates which player position this agent is for.
+    fn generate(&self, player_idx: usize, game_state: &GameState) -> Box<dyn Agent>;
 }
 
 pub trait CloneAgent: Agent {
@@ -64,7 +65,7 @@ impl<T> AgentGenerator for CloneAgentGenerator<T>
 where
     T: CloneAgent,
 {
-    fn generate(&self, _game_state: &GameState) -> Box<dyn Agent> {
+    fn generate(&self, _player_idx: usize, _game_state: &GameState) -> Box<dyn Agent> {
         self.agent.clone_box()
     }
 }

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -97,7 +97,7 @@ pub struct RandomAgentGenerator {
 }
 
 impl AgentGenerator for RandomAgentGenerator {
-    fn generate(&self, _game_state: &GameState) -> Box<dyn Agent> {
+    fn generate(&self, _player_idx: usize, _game_state: &GameState) -> Box<dyn Agent> {
         Box::new(RandomAgent::new(
             self.percent_fold.clone(),
             self.percent_call.clone(),

--- a/src/arena/competition/sim_iterator.rs
+++ b/src/arena/competition/sim_iterator.rs
@@ -37,7 +37,8 @@ where
         let agents = self
             .agent_generators
             .iter()
-            .map(|g| g.generate(&game_state))
+            .enumerate()
+            .map(|(idx, g)| g.generate(idx, &game_state))
             .collect();
         let historians = self
             .historian_generators

--- a/src/arena/competition/tournament.rs
+++ b/src/arena/competition/tournament.rs
@@ -150,7 +150,8 @@ impl SingleTableTournament {
             let agents = self
                 .agent_generators
                 .iter()
-                .map(|builder| builder.generate(&game_state))
+                .enumerate()
+                .map(|(idx, builder)| builder.generate(idx, &game_state))
                 .collect::<Vec<_>>();
             let historians = self
                 .historian_generators


### PR DESCRIPTION
Summary:
The agent needs to know what player it's representing

Test Plan:
mise check
