### PR TITLE
refactor: introduce TraversalSet and optimize CFR simulation hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,15 +102,15 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cast"
@@ -120,9 +120,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -310,9 +310,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -447,9 +447,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
 dependencies = [
  "jiff-static",
  "log",
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "d36139f1c97c42c0c86a411910b04e48d4939a0376e6e0f989420cbdee0120e5"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -487,15 +487,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linux-raw-sys"
@@ -505,14 +499,11 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "little-sorry"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddbc66479419719a7649f3a880a30a0696e3b4984c31aee0004665fbacd78cf"
+checksum = "69f9cae3d924359f1e8e6166976420bccadfee81d6a77ac3ad7d3adec0127c4a"
 dependencies = [
- "ndarray",
  "rand",
- "rand_distr",
- "thiserror",
 ]
 
 [[package]]
@@ -531,35 +522,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nu-ansi-term"
@@ -571,31 +537,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -652,15 +599,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -728,22 +675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
-dependencies = [
- "num-traits",
- "rand",
-]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -777,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -788,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rs_poker"
@@ -804,7 +735,6 @@ dependencies = [
  "env_logger",
  "itertools 0.14.0",
  "little-sorry",
- "ndarray",
  "rand",
  "serde",
  "serde_json",
@@ -915,9 +845,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1072,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -1109,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "9ff9c7baef35ac3c0e17d8bfc9ad75eb62f85a2f02bccc906699dadb0aa9c622"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1122,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "39455e84ad887a0bbc93c116d72403f1bb0a39e37dd6f235a43e2128a0c7f1fd"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1132,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "dff4761f60b0b51fd13fec8764167b7bbcc34498ce3e52805fe1db6f2d56b6d6"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1145,18 +1075,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "bc6a171c53d98021a93a474c4a4579d76ba97f9517d871bc12e27640f218b6dd"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "668fa5d00434e890a452ab060d24e3904d1be93f7bb01b70e5603baa2b8ab23b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1320,18 +1250,18 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1340,6 +1270,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ tracing = { version = "~0.1.41", optional = true, features = [
   "release_max_level_info",
 ] }
 approx = { version = "~0.5.1", optional = true }
-little-sorry = { version = "~1.1.0", optional = true, features = [] }
-ndarray = { version = "~0.16.1", optional = true }
+little-sorry = { version = "~2.0.0", optional = true, features = [] }
 chrono = { version = "~0.4.41", optional = true, features = ["serde"] }
 itertools = { version = "~0.14.0", optional = true }
 
@@ -47,13 +46,7 @@ tikv-jemallocator = { version = "~0.6.0", features = [
 [features]
 default = ["arena", "serde"]
 serde = ["dep:serde", "dep:serde_json"]
-arena = [
-  "dep:tracing",
-  "dep:little-sorry",
-  "dep:ndarray",
-  "dep:itertools",
-  "dep:approx",
-]
+arena = ["dep:tracing", "dep:little-sorry", "dep:itertools", "dep:approx"]
 arena-comparison = ["arena", "open-hand-history"]
 arena-test-util = ["arena", "dep:approx"]
 open-hand-history = ["serde", "dep:chrono", "dep:approx"]

--- a/examples/configs/preflop_6max_rfi.not-json
+++ b/examples/configs/preflop_6max_rfi.not-json
@@ -1,7 +1,7 @@
 {
   "type": "cfr_preflop_chart",
   "name": "6Max-RFI-GTO",
-  "depth_hands": [20, 5, 1],
+  "depth_hands": [7, 2, 1],
   "preflop_config": {
     "raise_size_bb": 2.5,
     "three_bet_multiplier": 3.0,
@@ -3703,7 +3703,7 @@
   "postflop_config": {
     "default": {
       "call_enabled": true,
-      "raise_mult": [1.0, 2.0],
+      "raise_mult": [3.0],
       "pot_mult": [0.5, 1.0],
       "setup_shove": false,
       "all_in": true

--- a/fuzz/fuzz_targets/multi_replay_agent.rs
+++ b/fuzz/fuzz_targets/multi_replay_agent.rs
@@ -15,7 +15,7 @@ use rs_poker::arena::{
     test_util::assert_valid_game_state,
     test_util::assert_valid_round_data,
     Agent,
-    GameState,
+    GameStateBuilder,
     HoldemSimulation,
     HoldemSimulationBuilder,
 };

--- a/fuzz/fuzz_targets/replay_agent.rs
+++ b/fuzz/fuzz_targets/replay_agent.rs
@@ -15,7 +15,7 @@ use rs_poker::arena::{
     game_state::Round,
     historian::{self, OpenHandHistoryVecHistorian},
     test_util::{assert_valid_game_state, assert_valid_history, assert_valid_round_data},
-    Agent, GameState, HoldemSimulation, HoldemSimulationBuilder,
+    Agent, GameStateBuilder, HoldemSimulation, HoldemSimulationBuilder,
 };
 use rs_poker::open_hand_history::{
     assert_open_hand_history_matches_game_state,

--- a/src/arena/agent/mod.rs
+++ b/src/arena/agent/mod.rs
@@ -36,7 +36,7 @@ pub trait Agent {
 pub use all_in::{AllInAgent, AllInAgentGenerator};
 pub use calling::{CallingAgent, CallingAgentGenerator};
 pub use clone::{CloneAgent, CloneAgentGenerator};
-pub use config::{AgentConfig, AgentConfigError, ConfigAgentGenerator};
+pub use config::{AgentConfig, AgentConfigError, ConfigAgentBuilder};
 pub use folding::{FoldingAgent, FoldingAgentGenerator};
 pub use generator::AgentGenerator;
 pub use random::{RandomAgent, RandomAgentGenerator, RandomPotControlAgent};

--- a/src/arena/cfr/action_generator/basic.rs
+++ b/src/arena/cfr/action_generator/basic.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::arena::{GameState, action::AgentAction};
 
 use super::super::{CFRState, TraversalState};
@@ -24,7 +26,7 @@ impl BasicCFRActionGenerator {
 impl ActionGenerator for BasicCFRActionGenerator {
     type Config = ();
 
-    fn new(cfr_state: CFRState, traversal_state: TraversalState, _config: ()) -> Self {
+    fn new(cfr_state: CFRState, traversal_state: TraversalState, _config: Arc<()>) -> Self {
         BasicCFRActionGenerator {
             cfr_state,
             traversal_state,

--- a/src/arena/cfr/action_generator/configurable.rs
+++ b/src/arena/cfr/action_generator/configurable.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::arena::{GameState, action::AgentAction, game_state::Round};
 
 use super::super::{CFRState, TraversalState};
@@ -132,7 +134,7 @@ impl ConfigurableActionConfig {
 pub struct ConfigurableActionGenerator {
     cfr_state: CFRState,
     traversal_state: TraversalState,
-    config: ConfigurableActionConfig,
+    config: Arc<ConfigurableActionConfig>,
 }
 
 impl ConfigurableActionGenerator {
@@ -145,7 +147,7 @@ impl ConfigurableActionGenerator {
         ConfigurableActionGenerator {
             cfr_state,
             traversal_state,
-            config,
+            config: Arc::new(config),
         }
     }
 }
@@ -153,8 +155,16 @@ impl ConfigurableActionGenerator {
 impl ActionGenerator for ConfigurableActionGenerator {
     type Config = ConfigurableActionConfig;
 
-    fn new(cfr_state: CFRState, traversal_state: TraversalState, config: Self::Config) -> Self {
-        ConfigurableActionGenerator::new_with_config(cfr_state, traversal_state, config)
+    fn new(
+        cfr_state: CFRState,
+        traversal_state: TraversalState,
+        config: Arc<Self::Config>,
+    ) -> Self {
+        ConfigurableActionGenerator {
+            cfr_state,
+            traversal_state,
+            config,
+        }
     }
 
     fn config(&self) -> &Self::Config {

--- a/src/arena/cfr/action_generator/mod.rs
+++ b/src/arena/cfr/action_generator/mod.rs
@@ -3,6 +3,8 @@ mod configurable;
 mod preflop_chart;
 mod simple;
 
+use std::sync::Arc;
+
 use crate::arena::{GameState, action::AgentAction};
 
 use super::{CFRState, TraversalState};
@@ -30,9 +32,10 @@ pub trait ActionGenerator {
 
     /// Create a new action generator
     ///
-    /// This is used by the Agent to create identical
-    /// action generators for the historians it uses.
-    fn new(cfr_state: CFRState, traversal_state: TraversalState, config: Self::Config) -> Self;
+    /// Config is passed as `Arc` to allow cheap cloning when constructing
+    /// many sub-agents during CFR tree traversal.
+    fn new(cfr_state: CFRState, traversal_state: TraversalState, config: Arc<Self::Config>)
+    -> Self;
 
     /// Get a reference to the configuration
     fn config(&self) -> &Self::Config;

--- a/src/arena/cfr/action_generator/simple.rs
+++ b/src/arena/cfr/action_generator/simple.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::arena::{GameState, action::AgentAction};
 
 use super::super::{CFRState, TraversalState};
@@ -25,7 +27,7 @@ impl SimpleActionGenerator {
 impl ActionGenerator for SimpleActionGenerator {
     type Config = ();
 
-    fn new(cfr_state: CFRState, traversal_state: TraversalState, _config: ()) -> Self {
+    fn new(cfr_state: CFRState, traversal_state: TraversalState, _config: Arc<()>) -> Self {
         SimpleActionGenerator::new(cfr_state, traversal_state)
     }
 

--- a/src/arena/cfr/gamestate_iterator_gen.rs
+++ b/src/arena/cfr/gamestate_iterator_gen.rs
@@ -22,6 +22,13 @@ pub trait GameStateIteratorGen {
     /// Get this iterator generator's configuration.
     fn config(&self) -> &Self::Config;
 
+    /// Return the number of game state iterations that `generate()` would produce.
+    ///
+    /// This allows callers to loop without materializing cloned game states,
+    /// which is more efficient when the caller already has a reference to the
+    /// original game state (e.g., in `explore_all_actions`).
+    fn num_iterations(&self) -> usize;
+
     /// Check if exploration should occur at the given depth.
     ///
     /// Returns `false` if the depth equals or exceeds the configured maximum.
@@ -57,7 +64,7 @@ pub struct DepthBasedIteratorGenConfig {
 impl Default for DepthBasedIteratorGenConfig {
     fn default() -> Self {
         Self {
-            depth_hands: vec![10, 5, 1],
+            depth_hands: vec![10, 2, 1],
         }
     }
 }
@@ -140,6 +147,10 @@ impl GameStateIteratorGen for DepthBasedIteratorGen {
         (0..self.num_hands).map(|_| game_state.clone())
     }
 
+    fn num_iterations(&self) -> usize {
+        self.num_hands
+    }
+
     fn new(config: &Self::Config, depth: usize) -> Self {
         Self::new(config.clone(), depth)
     }
@@ -177,7 +188,7 @@ mod tests {
     #[test]
     fn test_config_default() {
         let config = DepthBasedIteratorGenConfig::default();
-        assert_eq!(config.depth_hands, vec![10, 5, 1]);
+        assert_eq!(config.depth_hands, vec![10, 2, 1]);
     }
 
     #[test]
@@ -217,7 +228,7 @@ mod tests {
     #[test]
     fn test_depth_based_default() {
         let iter_gen = DepthBasedIteratorGen::default();
-        // Default config is [10, 5, 1], default depth is 0
+        // Default config is [10, 2, 1], default depth is 0
         assert_eq!(iter_gen.num_hands(), 10);
     }
 

--- a/src/arena/cfr/node.rs
+++ b/src/arena/cfr/node.rs
@@ -2,7 +2,7 @@ use std::num::{NonZeroU8, NonZeroU32};
 
 #[derive(Debug, Clone)]
 pub struct PlayerData {
-    pub regret_matcher: Option<Box<little_sorry::RegretMatcher>>,
+    pub regret_matcher: Option<Box<little_sorry::DcfrPlusRegretMatcher>>,
     pub player_idx: u8,
 }
 

--- a/src/arena/cfr/state_store.rs
+++ b/src/arena/cfr/state_store.rs
@@ -2,25 +2,18 @@ use std::sync::{Arc, RwLock};
 
 use crate::arena::GameState;
 
-use super::{CFRState, TraversalState};
+use super::CFRState;
 
 #[derive(Debug, Clone)]
 struct StateStoreInternal {
     // The tree structure of counter factual regret.
     pub cfr_states: Vec<CFRState>,
-
-    // The current place in the tree that each player is at. This is used as a stack
-    pub traversal_states: Vec<Vec<TraversalState>>,
 }
 
 impl StateStoreInternal {
     /// Check if a player has CFR state initialized.
     fn has_player_state(&self, player_idx: usize) -> bool {
         self.cfr_states.get(player_idx).is_some()
-            && self
-                .traversal_states
-                .get(player_idx)
-                .is_some_and(|ts| !ts.is_empty())
     }
 
     /// Ensure vectors are large enough to accommodate player_idx.
@@ -30,10 +23,6 @@ impl StateStoreInternal {
         while self.cfr_states.len() <= player_idx {
             // Add placeholder states that will be replaced when actually used
             self.cfr_states.push(CFRState::new(game_state.clone()));
-        }
-        while self.traversal_states.len() <= player_idx {
-            // Add empty traversal state vectors as placeholders
-            self.traversal_states.push(Vec::new());
         }
     }
 
@@ -50,15 +39,14 @@ impl StateStoreInternal {
     fn init_player_state(&mut self, game_state: &GameState, player_idx: usize) {
         self.ensure_capacity(player_idx, game_state);
         self.cfr_states[player_idx] = CFRState::new(game_state.clone());
-        self.traversal_states[player_idx] = vec![TraversalState::new_root(player_idx as u8)];
     }
 }
 
-/// `StateStore` is a structure to hold all CFR states and other data needed for
-/// a single game that is being solved. Since all players use the same store it
-/// enables reuse of the memory and regret matchers of all players.
+/// `StateStore` is a structure to hold all CFR states for a single game that
+/// is being solved. Since all players use the same store it enables reuse of
+/// the memory and regret matchers of all players.
 ///
-/// This state store is not thread safe so it has to be used in a single thread.
+/// Traversal state is managed separately via `TraversalSet`.
 #[derive(Debug, Clone)]
 pub struct StateStore {
     inner: Arc<RwLock<StateStoreInternal>>,
@@ -68,7 +56,7 @@ impl StateStore {
     /// Create a new StateStore initialized for all players in the game.
     ///
     /// This is the preferred way to create a StateStore for CFR simulations.
-    /// The store is initialized with CFR state and traversal state for all players,
+    /// The store is initialized with CFR state for all players,
     /// making it ready to be shared across all CFR agents.
     ///
     /// # Example
@@ -87,7 +75,6 @@ impl StateStore {
         let mut store = StateStore {
             inner: Arc::new(RwLock::new(StateStoreInternal {
                 cfr_states: Vec::new(),
-                traversal_states: Vec::new(),
             })),
         };
         store.ensure_all_players(game_state.clone(), game_state.num_players);
@@ -121,6 +108,14 @@ impl StateStore {
             .cloned()
     }
 
+    /// Get clones of all CFR states in a single lock acquisition.
+    ///
+    /// This is more efficient than calling `get_cfr_state` N times
+    /// when you need states for all players (e.g., in CFR sub-agent construction).
+    pub fn get_all_cfr_states(&self) -> Vec<CFRState> {
+        self.inner.read().unwrap().cfr_states.clone()
+    }
+
     /// Get the mapper configuration from player 0's CFR state.
     ///
     /// All players share the same mapper configuration since it's derived
@@ -130,7 +125,6 @@ impl StateStore {
     }
 
     /// Check if a player has CFR state initialized.
-    /// Returns true if the player has both CFR state and traversal state.
     pub fn has_player_state(&self, player_idx: usize) -> bool {
         self.inner.read().unwrap().has_player_state(player_idx)
     }
@@ -141,64 +135,6 @@ impl StateStore {
             .write()
             .unwrap()
             .ensure_all_players(&game_state, num_players);
-    }
-
-    pub fn traversal_len(&self, player_idx: usize) -> usize {
-        self.inner
-            .read()
-            .unwrap()
-            .traversal_states
-            .get(player_idx)
-            .map_or(0, |traversal| traversal.len())
-    }
-
-    pub fn peek_traversal(&self, player_idx: usize) -> Option<TraversalState> {
-        self.inner
-            .read()
-            .unwrap()
-            .traversal_states
-            .get(player_idx)
-            .and_then(|traversal| traversal.last().cloned())
-    }
-
-    /// Push a new traversal state onto the stack for a player.
-    /// Returns clones of the CFR state and the new traversal state.
-    pub fn push_traversal(&mut self, player_idx: usize) -> (CFRState, TraversalState) {
-        let mut inner = self.inner.write().unwrap();
-
-        let traversal_states = inner
-            .traversal_states
-            .get_mut(player_idx)
-            .unwrap_or_else(|| panic!("Traversal state for player {player_idx} not found"));
-
-        let last = traversal_states.last().expect("No traversal state found");
-
-        // Use get_all() to get all fields in a single lock acquisition
-        let (node_idx, chosen_child_idx, last_player_idx) = last.get_all();
-        let new_traversal_state = TraversalState::new(node_idx, chosen_child_idx, last_player_idx);
-
-        traversal_states.push(new_traversal_state.clone());
-
-        let cfr_state = inner
-            .cfr_states
-            .get(player_idx)
-            .unwrap_or_else(|| panic!("State for player {player_idx} not found"))
-            .clone();
-
-        (cfr_state, new_traversal_state)
-    }
-
-    pub fn pop_traversal(&mut self, player_idx: usize) {
-        let mut inner = self.inner.write().unwrap();
-        let traversal_states = inner
-            .traversal_states
-            .get_mut(player_idx)
-            .expect("Traversal state for player not found");
-        assert!(
-            !traversal_states.is_empty(),
-            "No traversal state to pop for player {player_idx}"
-        );
-        traversal_states.pop();
     }
 }
 
@@ -224,32 +160,6 @@ mod tests {
     }
 
     #[test]
-    fn test_push_traversal() {
-        let game_state = GameStateBuilder::new()
-            .num_players_with_stack(3, 100.0)
-            .blinds(10.0, 5.0)
-            .build()
-            .unwrap();
-        let mut state_store = StateStore::new(game_state.clone());
-
-        // Initial traversal stack should have 1 entry per player
-        assert_eq!(state_store.traversal_len(0), 1);
-
-        // Push a new traversal state
-        let (state, _traversal) = state_store.push_traversal(0);
-        assert_eq!(state_store.traversal_len(0), 2);
-        assert_eq!(
-            state.starting_game_state(),
-            game_state,
-            "State should match the game state"
-        );
-
-        // Pop and verify
-        state_store.pop_traversal(0);
-        assert_eq!(state_store.traversal_len(0), 1);
-    }
-
-    #[test]
     fn test_num_players() {
         let game_state = GameStateBuilder::new()
             .num_players_with_stack(3, 100.0)
@@ -258,31 +168,5 @@ mod tests {
             .unwrap();
         let state_store = StateStore::new(game_state);
         assert_eq!(state_store.num_players(), 3);
-    }
-
-    #[test]
-    fn test_peeked_traversal_shares_arc() {
-        let game_state = GameStateBuilder::new()
-            .num_players_with_stack(2, 100.0)
-            .blinds(10.0, 5.0)
-            .build()
-            .unwrap();
-        let state_store = StateStore::new(game_state);
-
-        // Get two references to the same player's traversal state
-        let traversal1 = state_store.peek_traversal(0).unwrap();
-        let traversal2 = state_store.peek_traversal(0).unwrap();
-
-        // Both should be at the same position
-        assert_eq!(traversal1.node_idx(), traversal2.node_idx());
-        assert_eq!(traversal1.chosen_child_idx(), traversal2.chosen_child_idx());
-
-        // Move the first one
-        let mut traversal1_mut = traversal1;
-        traversal1_mut.move_to(5, 3);
-
-        // The second one should also have moved (Arc sharing)
-        assert_eq!(traversal2.node_idx(), 5);
-        assert_eq!(traversal2.chosen_child_idx(), 3);
     }
 }

--- a/src/arena/cfr/traversal_state.rs
+++ b/src/arena/cfr/traversal_state.rs
@@ -1,0 +1,430 @@
+use std::sync::{Arc, RwLock};
+
+/// The internal state for tracking traversal through the CFR tree.
+///
+/// This struct holds the mutable state that gets shared between clones
+/// of `TraversalState` via `Arc<RwLock<>>`. It tracks:
+/// - Current position in the tree (node index)
+/// - Which branch we're traversing (child index)
+/// - Which player this traversal belongs to
+#[derive(Debug, PartialEq)]
+pub struct TraversalStateInternal {
+    // What node are we at
+    pub node_idx: usize,
+    // Which branch of the children are we currently going down?
+    //
+    // After a card is dealt or a player acts this will be set to the
+    // index of the child node we are going down. This allows us to
+    // lazily create the next node in the tree.
+    //
+    // For root nodes we assume that the first child is always taken.
+    // So we will go down index 0 in the children array for all root nodes.
+    pub chosen_child_idx: usize,
+    // What player are we
+    // This allows us to ignore
+    // starting hands for others.
+    pub player_idx: u8,
+}
+
+/// State for tracking position during CFR tree traversal.
+///
+/// This struct wraps the internal state in an `Arc<RwLock<>>` so that
+/// clones share the same underlying state. This is important because
+/// both the agent and historian need to track the same position in
+/// the tree during a simulation.
+///
+/// # Examples
+///
+/// ```
+/// use rs_poker::arena::cfr::TraversalState;
+///
+/// // Create a new traversal starting at the root for player 0
+/// let mut traversal = TraversalState::new_root(0);
+///
+/// assert_eq!(traversal.node_idx(), 0);
+/// assert_eq!(traversal.chosen_child_idx(), 0);
+/// assert_eq!(traversal.player_idx(), 0);
+///
+/// // Move to a new position
+/// traversal.move_to(5, 2);
+///
+/// assert_eq!(traversal.node_idx(), 5);
+/// assert_eq!(traversal.chosen_child_idx(), 2);
+/// ```
+///
+/// Cloned traversal states share the same position:
+///
+/// ```
+/// use rs_poker::arena::cfr::TraversalState;
+///
+/// let mut traversal = TraversalState::new_root(0);
+/// let cloned = traversal.clone();
+///
+/// traversal.move_to(10, 3);
+///
+/// // Both see the new position
+/// assert_eq!(traversal.node_idx(), 10);
+/// assert_eq!(cloned.node_idx(), 10);
+/// ```
+#[derive(Debug, Clone)]
+pub struct TraversalState {
+    inner_state: Arc<RwLock<TraversalStateInternal>>,
+}
+
+impl PartialEq for TraversalState {
+    fn eq(&self, other: &Self) -> bool {
+        *self.inner_state.read().unwrap() == *other.inner_state.read().unwrap()
+    }
+}
+
+impl Eq for TraversalState {}
+
+impl TraversalState {
+    /// Create a new traversal state at a specific position.
+    ///
+    /// # Arguments
+    ///
+    /// * `node_idx` - The index of the current node in the tree
+    /// * `chosen_child_idx` - The index of the child branch being traversed
+    /// * `player_idx` - The player this traversal belongs to
+    pub fn new(node_idx: usize, chosen_child_idx: usize, player_idx: u8) -> Self {
+        TraversalState {
+            inner_state: Arc::new(RwLock::new(TraversalStateInternal {
+                node_idx,
+                chosen_child_idx,
+                player_idx,
+            })),
+        }
+    }
+
+    /// Create a new traversal state at the root node for a specific player.
+    ///
+    /// This initializes the traversal at node index 0 with child index 0.
+    ///
+    /// # Arguments
+    ///
+    /// * `player_idx` - The player this traversal belongs to
+    pub fn new_root(player_idx: u8) -> Self {
+        TraversalState::new(0, 0, player_idx)
+    }
+
+    /// Get the current node index in the tree.
+    pub fn node_idx(&self) -> usize {
+        self.inner_state.read().unwrap().node_idx
+    }
+
+    /// Get the player index this traversal belongs to.
+    pub fn player_idx(&self) -> u8 {
+        self.inner_state.read().unwrap().player_idx
+    }
+
+    /// Get the index of the child branch currently being traversed.
+    pub fn chosen_child_idx(&self) -> usize {
+        self.inner_state.read().unwrap().chosen_child_idx
+    }
+
+    /// Move the traversal to a new position in the tree.
+    ///
+    /// # Arguments
+    ///
+    /// * `node_idx` - The new node index
+    /// * `chosen_child_idx` - The new child index being traversed
+    pub fn move_to(&mut self, node_idx: usize, chosen_child_idx: usize) {
+        let mut state = self.inner_state.write().unwrap();
+        state.node_idx = node_idx;
+        state.chosen_child_idx = chosen_child_idx;
+    }
+
+    /// Get all traversal state fields in a single lock acquisition.
+    ///
+    /// This is more efficient than calling `node_idx()`, `chosen_child_idx()`,
+    /// and `player_idx()` separately when you need multiple values.
+    ///
+    /// Returns (node_idx, chosen_child_idx, player_idx).
+    #[inline]
+    pub fn get_all(&self) -> (usize, usize, u8) {
+        let state = self.inner_state.read().unwrap();
+        (state.node_idx, state.chosen_child_idx, state.player_idx)
+    }
+
+    /// Get node_idx and chosen_child_idx in a single lock acquisition.
+    ///
+    /// This is more efficient than calling both getters separately.
+    ///
+    /// Returns (node_idx, chosen_child_idx).
+    #[inline]
+    pub fn get_position(&self) -> (usize, usize) {
+        let state = self.inner_state.read().unwrap();
+        (state.node_idx, state.chosen_child_idx)
+    }
+}
+
+/// A set of traversal states for all players in a game.
+///
+/// `TraversalSet` holds one `TraversalState` per player. Since `TraversalState`
+/// uses `Arc<RwLock<>>` internally:
+/// - **`clone()`** is shallow (Arc-clone): the clone shares the same underlying
+///   state. This is used so that the agent, historian, and sim builder all
+///   track the same positions.
+/// - **`fork()`** creates a deep copy: new independent `TraversalState` Arcs
+///   at the same positions. Used for sub-simulation isolation (replaces the
+///   old push/pop traversal stack).
+///
+/// # Examples
+///
+/// ```
+/// use rs_poker::arena::cfr::TraversalSet;
+///
+/// let set = TraversalSet::new(3);
+/// assert_eq!(set.num_players(), 3);
+///
+/// // Each player starts at root (node 0, child 0)
+/// let ts = set.get(0);
+/// assert_eq!(ts.node_idx(), 0);
+/// ```
+///
+/// Forking creates independent copies:
+///
+/// ```
+/// use rs_poker::arena::cfr::TraversalSet;
+///
+/// let set = TraversalSet::new(2);
+/// let forked = set.fork();
+///
+/// // Mutating the fork doesn't affect the original
+/// forked.get(0).move_to(10, 3);
+/// assert_eq!(set.get(0).node_idx(), 0);
+/// assert_eq!(forked.get(0).node_idx(), 10);
+/// ```
+#[derive(Debug, Clone)]
+pub struct TraversalSet {
+    states: Vec<TraversalState>,
+}
+
+impl TraversalSet {
+    /// Create a new `TraversalSet` with one root traversal state per player.
+    pub fn new(num_players: usize) -> Self {
+        let states = (0..num_players)
+            .map(|i| TraversalState::new_root(i as u8))
+            .collect();
+        TraversalSet { states }
+    }
+
+    /// Get the traversal state for a specific player.
+    ///
+    /// This returns a clone of the `TraversalState`, which shares the same
+    /// underlying `Arc<RwLock<>>` — mutations through either handle are visible
+    /// to both.
+    pub fn get(&self, player_idx: usize) -> TraversalState {
+        self.states[player_idx].clone()
+    }
+
+    /// Create a deep copy (fork) of this traversal set.
+    ///
+    /// Each player gets a new independent `TraversalState` initialized at the
+    /// same position as the original. Changes to the fork do not affect the
+    /// original, and vice versa.
+    ///
+    /// This is used for sub-simulation isolation: before running a
+    /// sub-simulation, fork the set so the sub-sim can freely mutate positions
+    /// without affecting the parent.
+    pub fn fork(&self) -> TraversalSet {
+        let states = self
+            .states
+            .iter()
+            .map(|ts| {
+                let (node_idx, chosen_child_idx, player_idx) = ts.get_all();
+                TraversalState::new(node_idx, chosen_child_idx, player_idx)
+            })
+            .collect();
+        TraversalSet { states }
+    }
+
+    /// Return the number of players in this set.
+    pub fn num_players(&self) -> usize {
+        self.states.len()
+    }
+
+    /// Iterate over references to the traversal states.
+    pub fn iter(&self) -> impl Iterator<Item = &TraversalState> {
+        self.states.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TraversalSet, TraversalState};
+
+    #[test]
+    fn test_new_and_getters() {
+        let traversal = TraversalState::new(5, 10, 2);
+
+        assert_eq!(traversal.node_idx(), 5);
+        assert_eq!(traversal.chosen_child_idx(), 10);
+        assert_eq!(traversal.player_idx(), 2);
+    }
+
+    #[test]
+    fn test_new_root() {
+        let traversal = TraversalState::new_root(3);
+
+        assert_eq!(traversal.node_idx(), 0);
+        assert_eq!(traversal.chosen_child_idx(), 0);
+        assert_eq!(traversal.player_idx(), 3);
+    }
+
+    #[test]
+    fn test_move_to() {
+        let mut traversal = TraversalState::new_root(0);
+
+        assert_eq!(traversal.node_idx(), 0);
+        assert_eq!(traversal.chosen_child_idx(), 0);
+
+        traversal.move_to(42, 7);
+
+        assert_eq!(traversal.node_idx(), 42);
+        assert_eq!(traversal.chosen_child_idx(), 7);
+        // player_idx should remain unchanged
+        assert_eq!(traversal.player_idx(), 0);
+    }
+
+    #[test]
+    fn test_cloned_traversal_share_loc() {
+        let mut traversal = TraversalState::new(0, 0, 0);
+        let cloned = traversal.clone();
+
+        assert_eq!(traversal.node_idx(), 0);
+        assert_eq!(traversal.player_idx(), 0);
+        assert_eq!(traversal.chosen_child_idx(), 0);
+
+        assert_eq!(cloned.node_idx(), 0);
+        assert_eq!(cloned.player_idx(), 0);
+        assert_eq!(cloned.chosen_child_idx(), 0);
+
+        // Simulate traversing the tree
+        traversal.move_to(2, 42);
+
+        assert_eq!(traversal.node_idx(), 2);
+        assert_eq!(traversal.chosen_child_idx(), 42);
+
+        // Cloned should have the same values
+        assert_eq!(cloned.node_idx(), 2);
+        assert_eq!(cloned.chosen_child_idx(), 42);
+    }
+
+    /// Verifies TraversalState equality - states with same values should be equal.
+    #[test]
+    fn test_traversal_state_equality() {
+        let state1 = TraversalState::new(5, 10, 2);
+        let state2 = TraversalState::new(5, 10, 2);
+
+        // Equal states should be equal
+        assert_eq!(state1, state2);
+    }
+
+    /// Verifies TraversalState inequality - states with different values should not be equal.
+    #[test]
+    fn test_traversal_state_inequality() {
+        let state1 = TraversalState::new(5, 10, 2);
+        let state_diff_node = TraversalState::new(6, 10, 2);
+        let state_diff_child = TraversalState::new(5, 11, 2);
+        let state_diff_player = TraversalState::new(5, 10, 3);
+
+        // Different states should not be equal
+        assert_ne!(state1, state_diff_node);
+        assert_ne!(state1, state_diff_child);
+        assert_ne!(state1, state_diff_player);
+    }
+
+    #[test]
+    fn test_get_all() {
+        let traversal = TraversalState::new(10, 20, 3);
+
+        let (node_idx, chosen_child_idx, player_idx) = traversal.get_all();
+
+        assert_eq!(node_idx, 10);
+        assert_eq!(chosen_child_idx, 20);
+        assert_eq!(player_idx, 3);
+    }
+
+    #[test]
+    fn test_get_position() {
+        let traversal = TraversalState::new(15, 25, 1);
+
+        let (node_idx, chosen_child_idx) = traversal.get_position();
+
+        assert_eq!(node_idx, 15);
+        assert_eq!(chosen_child_idx, 25);
+    }
+
+    #[test]
+    fn test_get_all_after_move() {
+        let mut traversal = TraversalState::new(0, 0, 2);
+        traversal.move_to(100, 50);
+
+        let (node_idx, chosen_child_idx, player_idx) = traversal.get_all();
+
+        assert_eq!(node_idx, 100);
+        assert_eq!(chosen_child_idx, 50);
+        assert_eq!(player_idx, 2); // Unchanged
+    }
+
+    // TraversalSet tests
+
+    #[test]
+    fn test_traversal_set_new() {
+        let set = TraversalSet::new(3);
+        assert_eq!(set.num_players(), 3);
+
+        for i in 0..3 {
+            let ts = set.get(i);
+            assert_eq!(ts.node_idx(), 0);
+            assert_eq!(ts.chosen_child_idx(), 0);
+            assert_eq!(ts.player_idx(), i as u8);
+        }
+    }
+
+    #[test]
+    fn test_clone_shares_state() {
+        let set = TraversalSet::new(2);
+        let cloned = set.clone();
+
+        // Mutate through the original
+        set.get(0).move_to(10, 3);
+
+        // Clone should see the mutation (Arc sharing)
+        assert_eq!(cloned.get(0).node_idx(), 10);
+        assert_eq!(cloned.get(0).chosen_child_idx(), 3);
+    }
+
+    #[test]
+    fn test_fork_is_independent() {
+        let set = TraversalSet::new(2);
+        // Move player 0 to a non-root position
+        set.get(0).move_to(5, 2);
+
+        let forked = set.fork();
+
+        // Forked should start at the same position
+        assert_eq!(forked.get(0).node_idx(), 5);
+        assert_eq!(forked.get(0).chosen_child_idx(), 2);
+
+        // Mutate the fork
+        forked.get(0).move_to(20, 7);
+
+        // Original should be unaffected
+        assert_eq!(set.get(0).node_idx(), 5);
+        assert_eq!(set.get(0).chosen_child_idx(), 2);
+
+        // Fork should reflect the mutation
+        assert_eq!(forked.get(0).node_idx(), 20);
+        assert_eq!(forked.get(0).chosen_child_idx(), 7);
+    }
+
+    #[test]
+    fn test_traversal_set_iter() {
+        let set = TraversalSet::new(3);
+        let states: Vec<_> = set.iter().collect();
+        assert_eq!(states.len(), 3);
+    }
+}

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -144,7 +144,7 @@ pub mod test_util;
 #[cfg(feature = "open-hand-history")]
 pub mod comparison;
 
-pub use agent::{Agent, AgentGenerator, CloneAgentGenerator, ConfigAgentGenerator};
+pub use agent::{Agent, AgentGenerator, CloneAgentGenerator, ConfigAgentBuilder};
 pub use game_state::{
     CloneGameStateGenerator, GameState, GameStateBuilder, GameStateGenerator,
     RandomGameStateGenerator,


### PR DESCRIPTION
Replace the traversal stack with a dedicated TraversalSet that tracks
each player's position in the CFR tree independently. Convert
ConfigAgentGenerator to a builder pattern.

Optimize CFR simulation hot paths: eliminate redundant GameState clones,
reduce lock acquisitions via cached configs and pre-fetched states, wrap
action/iterator configs in Arc, build sub-agents directly into
Vec<Box<dyn Agent>>, skip historian collection for sub-simulations, and
avoid per-simulation entropy syscalls.

Update little-sorry from v1.1.0 to v2.0.0 which provides a trait-based
RegretMinimizer interface with six CFR variants and a zero-allocation
hot path.

Switch from CfrPlusRegretMatcher to DcfrPlusRegretMatcher (alpha=1.5,
gamma=4.0). Research shows DCFR+ converges 6-400x faster than CFR+ on
poker game trees because it discounts early-iteration regrets from
dominated actions that CFR+ carries forward permanently.

Remove the ndarray dependency which is no longer needed since
little-sorry v2 accepts &[f32] directly instead of ArrayView1.
