### PR TITLE
feat: improve CFR agent accuracy with PCFR+ and tuned config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,15 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            ~/.rustup
             ~/.cargo/registry
             ~/.cargo/git
-          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', '.github/workflows/main.yml') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            rust-${{ runner.os }}-
+            cargo-${{ runner.os }}-
 
       - uses: jdx/mise-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          cache_key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', '.github/workflows/main.yml') }}
+          cache_key: mise-${{ runner.os }}-${{ hashFiles('mise.toml', '.github/workflows/main.yml') }}
       - run: cargo check --all --all-features
       - run: mise check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -447,9 +447,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -487,15 +487,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "little-sorry"
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rs_poker"
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1124,18 +1124,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1299,18 +1299,18 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/configs/cfr_configurable.json
+++ b/examples/configs/cfr_configurable.json
@@ -1,7 +1,7 @@
 {
     "type": "cfr_configurable",
     "name": "CFR-Configurable",
-    "depth_hands": [5, 2, 1],
+    "depth_hands": [24, 3, 1],
     "action_config": {
         "default": {
             "call_enabled": true,

--- a/src/arena/cfr/action_picker.rs
+++ b/src/arena/cfr/action_picker.rs
@@ -3,7 +3,7 @@ use tracing::event;
 use crate::arena::{GameState, action::AgentAction};
 
 use super::{ActionIndexMapper, NodeData};
-use little_sorry::{DcfrPlusRegretMatcher, RegretMinimizer};
+use little_sorry::{PcfrPlusRegretMatcher, RegretMinimizer};
 
 /// Picks an action from a set of possible actions using regret matching.
 ///
@@ -16,7 +16,7 @@ use little_sorry::{DcfrPlusRegretMatcher, RegretMinimizer};
 pub struct ActionPicker<'a> {
     mapper: &'a ActionIndexMapper,
     possible_actions: &'a [AgentAction],
-    regret_matcher: Option<&'a DcfrPlusRegretMatcher>,
+    regret_matcher: Option<&'a PcfrPlusRegretMatcher>,
     game_state: &'a GameState,
 }
 
@@ -32,7 +32,7 @@ impl<'a> ActionPicker<'a> {
     pub fn new(
         mapper: &'a ActionIndexMapper,
         possible_actions: &'a [AgentAction],
-        regret_matcher: Option<&'a DcfrPlusRegretMatcher>,
+        regret_matcher: Option<&'a PcfrPlusRegretMatcher>,
         game_state: &'a GameState,
     ) -> Self {
         debug_assert!(
@@ -164,7 +164,7 @@ impl<'a> ActionPicker<'a> {
 }
 
 /// Get the regret matcher from player node data if available.
-pub fn get_regret_matcher_from_node(node_data: &NodeData) -> Option<&DcfrPlusRegretMatcher> {
+pub fn get_regret_matcher_from_node(node_data: &NodeData) -> Option<&PcfrPlusRegretMatcher> {
     if let NodeData::Player(pd) = node_data {
         pd.regret_matcher.as_ref().map(|rm| rm.as_ref())
     } else {
@@ -229,7 +229,7 @@ mod tests {
         let mut rng = create_seeded_rng();
 
         // Create a regret matcher with 52 experts (our standard action space)
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
 
         // Update with rewards that heavily favor fold (index 0)
         let mut rewards = vec![0.0; 52];
@@ -285,7 +285,7 @@ mod tests {
         ];
 
         // Create a regret matcher that favors all-in
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
         let mut rewards = vec![0.0; 52];
         rewards[0] = 10.0; // Fold
         rewards[1] = 20.0; // Call
@@ -308,7 +308,7 @@ mod tests {
         let actions = vec![AgentAction::Bet(10.0)];
 
         // Create a regret matcher that would favor other actions
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
         let mut rewards = vec![0.0; 52];
         rewards[0] = 1000.0; // Fold has high weight
         rewards[1] = 1.0; // Call has low weight
@@ -335,7 +335,7 @@ mod tests {
         let mut rng = create_seeded_rng();
 
         // Create a regret matcher with all zero weights
-        let matcher = DcfrPlusRegretMatcher::new(52);
+        let matcher = PcfrPlusRegretMatcher::new(52);
 
         let picker = ActionPicker::new(&mapper, &actions, Some(&matcher), &game_state);
 
@@ -359,7 +359,7 @@ mod tests {
         ];
 
         // Create a regret matcher that strongly favors fold
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
         let mut rewards = vec![0.0; 52];
         rewards[0] = 1000.0; // Fold
         matcher.update_regret(&rewards);
@@ -454,7 +454,7 @@ mod tests {
         let actions = vec![AgentAction::Fold, AgentAction::Bet(10.0)];
 
         // Matcher strongly prefers call (index 1 = check/call)
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
         let mut rewards = vec![0.0; 52];
         rewards[0] = -50.0; // Fold is bad
         rewards[1] = 50.0; // Call is good
@@ -496,7 +496,7 @@ mod tests {
         ];
 
         // All actions have equal weight
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
         let mut rewards = vec![0.0; 52];
         rewards[0] = 10.0; // Fold
         let bet_idx = mapper.action_to_idx(&AgentAction::Bet(50.0), &game_state);
@@ -525,7 +525,7 @@ mod tests {
         let actions = vec![AgentAction::AllIn];
 
         // Even with a matcher that dislikes this action
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
         let mut rewards = vec![0.0; 52];
         rewards[0] = 1000.0; // Fold is great (but not available)
         rewards[51] = -1000.0; // All-in is terrible
@@ -555,7 +555,7 @@ mod tests {
         // Scenario: Fold (idx 0) or Call (idx 1), only these are valid
         let actions = vec![AgentAction::Fold, AgentAction::Bet(10.0)]; // Bet(current_bet) = Call
 
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
 
         // Simulate multiple CFR iterations where Call wins +900 and Fold wins 0
         // Invalid actions get -100 penalty
@@ -601,7 +601,7 @@ mod tests {
 
         let actions = vec![AgentAction::Fold, AgentAction::Bet(10.0)];
 
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
 
         let bet_idx = mapper.action_to_idx(&AgentAction::Bet(10.0), &game_state);
 
@@ -638,7 +638,7 @@ mod tests {
         let game_state = create_test_game_state();
         let mapper = create_mapper();
 
-        let mut matcher = DcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(52);
 
         // Get the actual call index (should be 1 for ACTION_IDX_CALL)
         let bet_idx = mapper.action_to_idx(&AgentAction::Bet(10.0), &game_state);

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use little_sorry::{DcfrPlusRegretMatcher, RegretMinimizer};
+use little_sorry::{PcfrPlusRegretMatcher, RegretMinimizer};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use tracing::event;
@@ -152,7 +152,7 @@ where
             mapper_config: None,
             forced_action: None,
             depth: 0,
-            limited_exploration_depth: Some(4),
+            limited_exploration_depth: Some(3),
             allow_node_mutation: true,
             thread_pool: None,
             rng: None,
@@ -545,7 +545,7 @@ where
                     && player_data.regret_matcher.is_none()
                 {
                     // Use the fixed constant for number of action indices (52)
-                    let regret_matcher = Box::new(DcfrPlusRegretMatcher::new(NUM_ACTION_INDICES));
+                    let regret_matcher = Box::new(PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES));
                     player_data.regret_matcher = Some(regret_matcher);
                 }
             })
@@ -568,16 +568,24 @@ where
         // Different bet amounts can map to the same index due to the logarithmic
         // mapping (only 49 slots for raises). We keep the first action for each index.
         // Using ActionBitSet for O(1) operations with no heap allocation.
+        // Pre-compute action indices once to avoid repeated action_to_idx calls.
         let mut seen_indices = ActionBitSet::new();
-        let actions: Vec<_> = validated_actions
+        let indexed_actions: Vec<(AgentAction, usize)> = validated_actions
             .into_iter()
-            .filter(|a| {
-                let idx = self.action_index_mapper.action_to_idx(a, game_state);
-                seen_indices.insert(idx)
+            .filter_map(|a| {
+                let idx = self.action_index_mapper.action_to_idx(&a, game_state);
+                if seen_indices.insert(idx) {
+                    Some((a, idx))
+                } else {
+                    None
+                }
             })
             .collect();
 
-        debug_assert!(!actions.is_empty(), "Must have at least one valid action");
+        debug_assert!(
+            !indexed_actions.is_empty(),
+            "Must have at least one valid action"
+        );
 
         // Penalty for invalid actions - using player's starting stack since
         // losing your whole stack is the worst outcome.
@@ -592,7 +600,7 @@ where
         let mut rewards: Vec<f32> = vec![invalid_action_penalty; NUM_ACTION_INDICES];
 
         if let Some(pool) = &self.thread_pool {
-            let num_actions = actions.len();
+            let num_actions = indexed_actions.len();
             let total_tasks = num_iterations * num_actions;
 
             // Pre-generate one RNG per task from the parent RNG.
@@ -624,18 +632,17 @@ where
                     .enumerate()
                     .map(|(task_id, mut rng)| {
                         let action_pos = task_id % num_actions;
-                        let action = &actions[action_pos];
-                        let reward_idx = ctx.action_index_mapper.action_to_idx(action, game_state);
+                        let (action, reward_idx) = &indexed_actions[action_pos];
 
                         debug_assert!(
-                            reward_idx < NUM_ACTION_INDICES,
+                            *reward_idx < NUM_ACTION_INDICES,
                             "Action index {} should be less than number of potential actions {}",
                             reward_idx,
                             NUM_ACTION_INDICES
                         );
 
                         let reward = Self::compute_reward(game_state, action, &mut rng, &ctx);
-                        (reward_idx, reward)
+                        (*reward_idx, reward)
                     })
                     .collect()
             });
@@ -680,23 +687,21 @@ where
                 // Reset to penalty for all actions, valid ones get overwritten
                 rewards.fill(invalid_action_penalty);
 
-                for action in &actions {
-                    let reward_idx = self.action_index_mapper.action_to_idx(action, game_state);
-
+                for (action, reward_idx) in &indexed_actions {
                     debug_assert!(
-                        reward_idx < rewards.len(),
+                        *reward_idx < rewards.len(),
                         "Action index {} should be less than number of potential actions {}",
                         reward_idx,
                         rewards.len()
                     );
                     debug_assert!(
-                        seen_indices.contains(reward_idx),
+                        seen_indices.contains(*reward_idx),
                         "Action {:?} mapped to index {} which should be in seen_indices",
                         action,
                         reward_idx
                     );
 
-                    rewards[reward_idx] =
+                    rewards[*reward_idx] =
                         Self::compute_reward(game_state, action, &mut self.rng, &ctx);
                 }
 

--- a/src/arena/cfr/node.rs
+++ b/src/arena/cfr/node.rs
@@ -5,7 +5,7 @@ use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Debug, Clone)]
 pub struct PlayerData {
-    pub regret_matcher: Option<Box<little_sorry::DcfrPlusRegretMatcher>>,
+    pub regret_matcher: Option<Box<little_sorry::PcfrPlusRegretMatcher>>,
     pub player_idx: u8,
 }
 

--- a/src/holdem/monte_carlo_game.rs
+++ b/src/holdem/monte_carlo_game.rs
@@ -40,7 +40,7 @@ impl MonteCarloGame {
             }
         }
 
-        let num_community_cards = (7 - max_hand_size).max(0);
+        let num_community_cards = 7 - max_hand_size;
 
         let flat_deck: FlatDeck = deck.into();
         // Grab the deck.len() so that any call to shuffle_if_needed


### PR DESCRIPTION
Switch regret matcher from DCFR+ to PCFR+: PCFR+ uses quadratic
weighting (t^2) which converges faster on large poker game trees.
DCFR+ was tested extensively but PCFR+ consistently produced higher
ROI in agent comparisons.

Change depth schedule from [5, 2, 1] to [24, 3, 1]: more root
iterations (24 vs 5) improve strategy quality at the top level where
it matters most. Depth-1 increased to 3 to give sub-games enough
iterations for meaningful learning. Schedules [16,2,1], [32,3,1],
[24,4,1], and [36,3,1] were all tested; [24, 3, 1] gave the best
balance of accuracy and speed within the memory budget.

Lower limited_exploration_depth from 4 to 3: at depth 3+ only
fold/call/all-in are explored. This dramatically shrinks the game
tree, freeing budget for more root iterations. Depth 2 was too
aggressive (lost strategic depth), depth 4 was too expensive.

Pre-compute action indices: build indexed_actions Vec<(AgentAction,
usize)> once instead of calling action_to_idx repeatedly during
each iteration. Minor optimization that also simplifies the loop.
