### PR TITLE
fix: use actions/cache for rustup instead of invalid cache_paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.rustup/settings.toml
             ~/.cargo/registry
             ~/.cargo/git
-          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', '**/Cargo.lock') }}
           restore-keys: |
             rust-${{ runner.os }}-
 

--- a/.github/workflows/prod_compile.yml
+++ b/.github/workflows/prod_compile.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.rustup/settings.toml
             ~/.cargo/registry
             ~/.cargo/git
-          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', '**/Cargo.lock') }}
           restore-keys: |
             rust-${{ runner.os }}-
 


### PR DESCRIPTION
## Summary
- `cache_paths` was never a valid input for `jdx/mise-action` — it was silently ignored
- mise-action only caches `~/.local/share/mise` by default, NOT `~/.rustup`
- When mise's cache hit, it skipped reinstalling rust, but `~/.rustup` (with nightly clippy/rustfmt) wasn't cached → missing component errors
- Fix: use `actions/cache@v4` to cache `~/.rustup` toolchains and `~/.cargo`, keyed on `mise.toml` so it invalidates when the rust toolchain config changes
- Applied to both `main.yml` and `prod_compile.yml`

## Test plan
- [ ] CI passes with fresh caches (all stale caches were purged)
- [ ] Subsequent runs restore cache and still find clippy/rustfmt