### PR TITLE
fix: unify CI caching into single actions/cache step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
             ~/.rustup/settings.toml
             ~/.cargo/registry
             ~/.cargo/git
-          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', '**/Cargo.lock') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', 'mise.lock', '**/Cargo.lock') }}
           restore-keys: |
             rust-${{ runner.os }}-
 

--- a/.github/workflows/prod_compile.yml
+++ b/.github/workflows/prod_compile.yml
@@ -27,7 +27,7 @@ jobs:
             ~/.rustup/settings.toml
             ~/.cargo/registry
             ~/.cargo/git
-          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', '**/Cargo.lock') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('mise.toml', 'mise.lock', '**/Cargo.lock') }}
           restore-keys: |
             rust-${{ runner.os }}-
 


### PR DESCRIPTION
## Summary
- Disable mise-action's built-in cache (`cache: false`) and manage all caching through a single `actions/cache` step
- Cache `~/.local/share/mise`, `~/.rustup`, and `~/.cargo` together under one key so all state is always coherent
- Key on `mise.toml` + `mise.lock` + `Cargo.lock` so the cache invalidates when toolchain versions or dependencies change

## Why
Previously mise-action cached `~/.local/share/mise` independently from `~/.rustup`. When mise's cache hit, it skipped reinstalling rust — but `~/.rustup` (with nightly clippy/rustfmt) wasn't in that cache, causing missing component errors. Having two independent caches with different keys meant they could always drift apart.

## Test plan
- [ ] CI passes on first run (cold cache, full install)
- [ ] Subsequent runs restore cache and still find clippy/rustfmt
- [ ] Changing `mise.toml` or `mise.lock` invalidates the cache