### PR TITLE
bench: add CardBitSet::sample_one benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,10 @@ name = "node_arena"
 harness = false
 required-features = ["arena"]
 
+[[bench]]
+name = "sample_one"
+harness = false
+
 [[example]]
 name = "agent_comparison"
 required-features = ["arena-comparison"]

--- a/benches/sample_one.rs
+++ b/benches/sample_one.rs
@@ -1,0 +1,44 @@
+#[macro_use]
+extern crate criterion;
+extern crate rs_poker;
+
+use criterion::{BenchmarkId, Criterion};
+use rand::rng;
+use rs_poker::core::{CardBitSet, Deck};
+
+fn sample_one_by_deck_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sample_one");
+
+    for num_cards in [1, 2, 5, 13, 26, 45, 52] {
+        group.bench_with_input(
+            BenchmarkId::new("cards_remaining", num_cards),
+            &num_cards,
+            |b, &num_cards| {
+                let mut rng = rng();
+                // Build a CardBitSet with exactly num_cards cards
+                let mut cards = CardBitSet::new();
+                for card in Deck::default().into_iter().take(num_cards) {
+                    cards.insert(card);
+                }
+                b.iter(|| std::hint::black_box(cards.sample_one(&mut rng)));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn deal_all_cards_bitset(c: &mut Criterion) {
+    c.bench_function("deal all 52 via sample_one", |b| {
+        let mut rng = rng();
+        b.iter(|| {
+            let mut cards = CardBitSet::default();
+            while !cards.is_empty() {
+                let card = cards.sample_one(&mut rng).unwrap();
+                cards.remove(card);
+            }
+        });
+    });
+}
+
+criterion_group!(benches, sample_one_by_deck_size, deal_all_cards_bitset);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Add criterion benchmarks for `CardBitSet::sample_one` across 7 deck sizes (1, 2, 5, 13, 26, 45, 52 cards)
- Add a "deal all 52" benchmark that measures dealing an entire deck via repeated `sample_one` + `remove`

These benchmarks enable tracking performance of `sample_one` as we optimize it (e.g. binary search over popcount, PDEP+TZCNT on BMI2 targets).

## Test plan

- [x] `cargo bench --bench sample_one` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)