### PR TITLE
feat: add Omaha hand evaluation and rewrite CardIter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ After `mise check` passes, fuzz targets provide good secondary validation:
 - `replay_agent` / `multi_replay_agent` - tests game replay
 - `config_agent` - tests config-driven agents
 - `rank_seven` - tests hand ranking
+- `rank_omaha` - tests Omaha hand ranking
 
 ## Architecture
 
@@ -48,9 +49,10 @@ rs-poker is a Rust poker library
 ### Feature Flags
 
 ```toml
-default = ["arena", "serde"]
+default = ["arena", "serde", "omaha"]
 arena                      # Multi-agent simulation
 serde                      # JSON serialization
+omaha                      # Omaha (PLO4/PLO5/PLO6/PLO7) hand evaluation
 arena-test-util            # Testing helpers with approx comparisons
 open-hand-history          # OHH format support
 open-hand-history-test-util  # OHH testing helpers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ tikv-jemallocator = { version = "~0.6.0", features = [
 ] }
 
 [features]
-default = ["arena", "serde"]
+default = ["arena", "serde", "omaha"]
+omaha = []
 serde = ["dep:serde", "dep:serde_json"]
 arena = [
   "dep:tracing",
@@ -108,6 +109,11 @@ required-features = ["arena"]
 [[bench]]
 name = "sample_one"
 harness = false
+
+[[bench]]
+name = "omaha"
+harness = false
+required-features = ["omaha"]
 
 [[example]]
 name = "agent_comparison"

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -4,7 +4,7 @@ extern crate rand;
 extern crate rs_poker;
 
 use criterion::Criterion;
-use rs_poker::core::{CardIter, FlatDeck};
+use rs_poker::core::{CardBitSet, CardIter, FlatDeck};
 
 fn iter_in_deck(c: &mut Criterion) {
     c.bench_function("Iter all 5 cards hand in deck", |b| {
@@ -17,10 +17,10 @@ fn iter_in_deck(c: &mut Criterion) {
 
 fn iter_hand(c: &mut Criterion) {
     let d: FlatDeck = FlatDeck::default();
-    let hand = d.sample(7);
+    let hand: CardBitSet = d.sample(7).into_iter().collect();
 
     c.bench_function("Iter all 5 cards hand in 7 card hand ", move |b| {
-        b.iter(|| CardIter::new(&hand[..], 5).count())
+        b.iter(|| CardIter::new(hand, 5).count())
     });
 }
 

--- a/benches/omaha.rs
+++ b/benches/omaha.rs
@@ -1,0 +1,38 @@
+#[macro_use]
+extern crate criterion;
+extern crate rs_poker;
+
+use criterion::Criterion;
+use rs_poker::core::Rankable;
+use rs_poker::omaha::OmahaHand;
+
+fn rank_plo4(c: &mut Criterion) {
+    let hand = OmahaHand::new_from_str("AhKhQs9d", "Ts7s6s5d4d").unwrap();
+    c.bench_function("Rank PLO4 hand (4 hole, 5 board)", move |b| {
+        b.iter(|| hand.rank())
+    });
+}
+
+fn rank_plo5(c: &mut Criterion) {
+    let hand = OmahaHand::new_from_str("AhKhQs9d8c", "Ts7s6s5d4d").unwrap();
+    c.bench_function("Rank PLO5 hand (5 hole, 5 board)", move |b| {
+        b.iter(|| hand.rank())
+    });
+}
+
+fn rank_plo6(c: &mut Criterion) {
+    let hand = OmahaHand::new_from_str("AhKhQs9d8c2c", "Ts7s6s5d4d").unwrap();
+    c.bench_function("Rank PLO6 hand (6 hole, 5 board)", move |b| {
+        b.iter(|| hand.rank())
+    });
+}
+
+fn rank_plo4_flop(c: &mut Criterion) {
+    let hand = OmahaHand::new_from_str("AhKhQs9d", "Ts7s6s").unwrap();
+    c.bench_function("Rank PLO4 hand on flop (4 hole, 3 board)", move |b| {
+        b.iter(|| hand.rank())
+    });
+}
+
+criterion_group!(benches, rank_plo4, rank_plo5, rank_plo6, rank_plo4_flop);
+criterion_main!(benches);

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ features = [
   "arena-test-util",
   "open-hand-history",
   "open-hand-history-test-util",
+  "omaha",
 ]
 
 [dependencies]
@@ -78,6 +79,13 @@ bench = false
 [[bin]]
 name = "cfr_mixed_agents"
 path = "fuzz_targets/cfr_mixed_agents.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rank_omaha"
+path = "fuzz_targets/rank_omaha.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/rank_omaha.rs
+++ b/fuzz/fuzz_targets/rank_omaha.rs
@@ -1,0 +1,63 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate rs_poker;
+use rs_poker::core::{CardBitSet, CardIter, Deck, RankFive, Rankable};
+use rs_poker::omaha::OmahaHand;
+
+fuzz_target!(|data: &[u8]| {
+    // Need at least 2 bytes: one for hole count, one for card selection
+    if data.len() < 2 {
+        return;
+    }
+
+    // Determine hole card count (2-7) and board card count (3-5)
+    let hole_count = (data[0] % 6) as usize + 2; // 2..=7
+    let board_count = (data[1] % 3) as usize + 3; // 3..=5
+    let total = hole_count + board_count;
+
+    if data.len() < 2 + total {
+        return;
+    }
+
+    // Use bytes to select cards from the deck without replacement
+    let deck = Deck::default();
+    let all_cards: Vec<_> = deck.into_iter().collect();
+    let mut used = [false; 52];
+    let mut selected = Vec::with_capacity(total);
+
+    for &b in &data[2..2 + total] {
+        let start = (b as usize) % 52;
+        // Find next unused card from start position
+        let mut found = false;
+        for offset in 0..52 {
+            let idx = (start + offset) % 52;
+            if !used[idx] {
+                used[idx] = true;
+                selected.push(all_cards[idx]);
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return;
+        }
+    }
+
+    let hole: CardBitSet = selected[..hole_count].iter().copied().collect();
+    let board: CardBitSet = selected[hole_count..].iter().copied().collect();
+
+    let hand = match OmahaHand::new(hole, board) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+
+    // Oracle: brute-force all C(h,2) * C(b,3) combos
+    let oracle_rank = CardIter::new(hole, 2)
+        .flat_map(|h| CardIter::new(board, 3).map(move |b| (h | b).rank_five()))
+        .max()
+        .unwrap();
+
+    let actual_rank = hand.rank();
+    assert_eq!(oracle_rank, actual_rank);
+});

--- a/fuzz/fuzz_targets/rank_seven.rs
+++ b/fuzz/fuzz_targets/rank_seven.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate rs_poker;
-use rs_poker::core::{CardIter, FlatHand, Rankable};
+use rs_poker::core::{CardBitSet, CardIter, FlatHand, RankFive, Rankable};
 use std::str;
 
 fuzz_target!(|data: &[u8]| {
@@ -10,7 +10,8 @@ fuzz_target!(|data: &[u8]| {
         if let Ok(h) = FlatHand::new_from_str(s) {
             if h.len() == 7 {
                 let r_seven = h.rank();
-                let r_five_max = CardIter::new(&h[..], 5)
+                let cbs: CardBitSet = h.iter().copied().collect();
+                let r_five_max = CardIter::new(cbs, 5)
                     .map(|cv| cv.rank_five())
                     .max()
                     .unwrap();

--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@ env = { RUST_BACKTRACE = "1" }
 usage = """
 flag "--timeout <seconds>" default="60"
 arg "<target>" help="Target fuzz script to run" {
-    choices "fuzzer_script_1" "fuzzer_script_2" "rank_seven" "replay_agent" "multi_replay_agent" "config_agent" "cfr_mixed_agents"
+    choices "fuzzer_script_1" "fuzzer_script_2" "rank_seven" "replay_agent" "multi_replay_agent" "config_agent" "cfr_mixed_agents" "rank_omaha"
 }
 """
 run = '''

--- a/src/core/card_bit_set.rs
+++ b/src/core/card_bit_set.rs
@@ -23,6 +23,39 @@ pub struct CardBitSet {
 
 const FIFTY_TWO_ONES: u64 = (1 << 52) - 1;
 
+/// Parallel bit deposit: scatter bits of `val` into the positions of `mask`.
+///
+/// On x86_64 with BMI2 this is a single `PDEP` instruction.
+/// Otherwise falls back to a software loop.
+#[inline]
+pub(crate) fn pdep(val: u64, mask: u64) -> u64 {
+    #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
+    {
+        unsafe {
+            use core::arch::x86_64::_pdep_u64;
+            return _pdep_u64(val, mask);
+        }
+    }
+
+    #[allow(unreachable_code)]
+    pdep_fallback(val, mask)
+}
+
+/// Software PDEP: deposit bits from `val` into the set-bit positions of `mask`.
+#[inline]
+fn pdep_fallback(mut val: u64, mut mask: u64) -> u64 {
+    let mut result = 0u64;
+    while mask != 0 {
+        let lowest = mask & mask.wrapping_neg();
+        if val & 1 != 0 {
+            result |= lowest;
+        }
+        val >>= 1;
+        mask &= mask - 1;
+    }
+    result
+}
+
 impl CardBitSet {
     /// Create a new empty bitset
     ///
@@ -121,6 +154,16 @@ impl CardBitSet {
         self.cards = 0;
     }
 
+    /// Construct from raw bits. Only the lowest 52 bits are meaningful.
+    pub(crate) fn from_u64(cards: u64) -> Self {
+        Self { cards }
+    }
+
+    /// Return the raw u64 bitmask.
+    pub(crate) fn to_u64(self) -> u64 {
+        self.cards
+    }
+
     /// Sample one card from the bitset
     ///
     /// Returns `None` if the bitset is empty
@@ -163,83 +206,10 @@ impl CardBitSet {
     /// Find the position of the `n`th set bit (0-indexed) in this bitset.
     ///
     /// On x86_64 with BMI2 this compiles to `PDEP` + `TZCNT` (two
-    /// instructions, branchless). Otherwise falls back to a binary search
-    /// over popcount in 6 constant-time steps.
+    /// instructions, branchless). Otherwise falls back to a software PDEP loop.
     #[inline]
     fn nth_set_bit(&self, n: u32) -> u32 {
-        #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
-        {
-            // SAFETY: target_feature = "bmi2" guarantees PDEP is available.
-            // PDEP deposits `1 << n` into the positions of the set bits of
-            // `self.cards`, effectively placing a single 1-bit at the position
-            // of the n-th set bit. TZCNT then reads off that position.
-            unsafe {
-                use core::arch::x86_64::_pdep_u64;
-                return _pdep_u64(1u64 << n, self.cards).trailing_zeros();
-            }
-        }
-
-        #[allow(unreachable_code)]
-        self.nth_set_bit_fallback(n)
-    }
-
-    /// Fallback select implementation using binary search over popcount.
-    ///
-    /// At each step we split the remaining bits into a lower half and an upper
-    /// half, then count the set bits in the lower half:
-    ///
-    /// - If `n` is **less than** that count, the target bit is in the lower
-    ///   half — keep searching there.
-    /// - If `n` is **greater than or equal to** that count, the target bit is
-    ///   in the upper half — subtract the lower count from `n`, shift the upper
-    ///   half down, and advance `pos` by the half-width.
-    #[inline]
-    fn nth_set_bit_fallback(&self, n: u32) -> u32 {
-        let mut n = n;
-        let mut bits = self.cards;
-        let mut pos = 0u32;
-
-        let c = (bits & 0xFFFF_FFFF).count_ones();
-        if n >= c {
-            n -= c;
-            bits >>= 32;
-            pos += 32;
-        }
-
-        let c = (bits & 0x0000_FFFF).count_ones();
-        if n >= c {
-            n -= c;
-            bits >>= 16;
-            pos += 16;
-        }
-
-        let c = (bits & 0x0000_00FF).count_ones();
-        if n >= c {
-            n -= c;
-            bits >>= 8;
-            pos += 8;
-        }
-
-        let c = (bits & 0x0000_000F).count_ones();
-        if n >= c {
-            n -= c;
-            bits >>= 4;
-            pos += 4;
-        }
-
-        let c = (bits & 0x0000_0003).count_ones();
-        if n >= c {
-            n -= c;
-            bits >>= 2;
-            pos += 2;
-        }
-
-        let c = (bits & 0x0000_0001) as u32;
-        if n >= c {
-            pos += 1;
-        }
-
-        pos
+        pdep(1u64 << n, self.cards).trailing_zeros()
     }
 }
 
@@ -257,6 +227,28 @@ impl Default for CardBitSet {
         Self {
             cards: FIFTY_TWO_ONES,
         }
+    }
+}
+
+impl FromIterator<Card> for CardBitSet {
+    fn from_iter<I: IntoIterator<Item = Card>>(iter: I) -> Self {
+        let mut set = Self::new();
+        for card in iter {
+            set.insert(card);
+        }
+        set
+    }
+}
+
+impl From<FlatDeck> for CardBitSet {
+    fn from(deck: FlatDeck) -> Self {
+        deck[..].iter().copied().collect()
+    }
+}
+
+impl From<&FlatDeck> for CardBitSet {
+    fn from(deck: &FlatDeck) -> Self {
+        deck[..].iter().copied().collect()
     }
 }
 
@@ -820,6 +812,37 @@ mod tests {
         let fd: FlatDeck = cbs.into();
 
         assert_eq!(fd.len(), 2);
+    }
+
+    /// Test From<FlatDeck> for CardBitSet preserves the cards.
+    #[test]
+    fn test_from_flat_deck_to_card_bit_set() {
+        let fd = FlatDeck::from(Deck::default());
+        let cbs: CardBitSet = CardBitSet::from(fd);
+        assert_eq!(cbs.count(), 52);
+        for card in Deck::default() {
+            assert!(cbs.contains(card));
+        }
+    }
+
+    /// Test From<&FlatDeck> for CardBitSet preserves the cards.
+    #[test]
+    fn test_from_flat_deck_ref_to_card_bit_set() {
+        let fd = FlatDeck::from(Deck::default());
+        let cbs: CardBitSet = CardBitSet::from(&fd);
+        assert_eq!(cbs.count(), 52);
+        for card in Deck::default() {
+            assert!(cbs.contains(card));
+        }
+    }
+
+    /// Test round-trip: FlatDeck -> CardBitSet -> FlatDeck preserves card count.
+    #[test]
+    fn test_flat_deck_card_bit_set_round_trip() {
+        let fd = FlatDeck::from(Deck::default());
+        let cbs: CardBitSet = CardBitSet::from(&fd);
+        let fd2: FlatDeck = cbs.into();
+        assert_eq!(fd.len(), fd2.len());
     }
 
     /// Test BitOr<Card> for CardBitSet adds cards correctly.

--- a/src/core/card_iter.rs
+++ b/src/core/card_iter.rs
@@ -1,148 +1,184 @@
-use crate::core::{Card, CardBitSet, FlatDeck};
+use super::card_bit_set::pdep;
+use super::{CardBitSet, FlatDeck};
 
-/// Given some cards create sets of possible groups of cards.
+/// Iterates over all k-element subsets of a [`CardBitSet`].
+///
+/// Uses [Gosper's hack](https://en.wikipedia.org/wiki/Combinatorial_number_system#Applications)
+/// to enumerate subsets in lexicographic order over logical bit indices,
+/// then maps each subset to physical card positions via PDEP.
+///
+/// Zero allocation — the entire state is three `u64`-sized fields.
 #[derive(Debug)]
-pub struct CardIter<'a> {
-    /// All the possible cards that can be dealt
-    possible_cards: &'a [Card],
-
-    /// Set of current offsets being used to create card sets.
-    idx: Vec<usize>,
-
-    /// size of card sets requested.
-    num_cards: usize,
+pub struct CardIter {
+    /// The card pool as a raw bitmask.
+    mask: u64,
+    /// Current k-subset of {0..n-1} as a bitmask. Advanced by Gosper's hack.
+    combo: u64,
+    /// One past the maximum valid combo value: `1 << n`.
+    limit: u64,
+    /// Whether the iterator is exhausted.
+    done: bool,
 }
 
-/// `CardIter` is a container for cards and current state.
-impl CardIter<'_> {
-    /// Create a new `CardIter` from a slice of cards.
-    /// `num_cards` represents how many cards should be in the resulting vector.
-    pub fn new(possible_cards: &[Card], num_cards: usize) -> CardIter<'_> {
-        let mut idx: Vec<usize> = (0..num_cards).collect();
-        if num_cards > 1 {
-            idx[num_cards - 1] -= 1;
+impl CardIter {
+    /// Create a new iterator over all `k`-element subsets of `cards`.
+    ///
+    /// Yields [`CardBitSet`] items, each containing exactly `k` cards
+    /// chosen from `cards`. Visits exactly C(n, k) subsets where
+    /// n = `cards.count()`.
+    ///
+    /// # Edge cases
+    /// - `k == 0`: yields one empty `CardBitSet`
+    /// - `k > n`: yields nothing
+    pub fn new(cards: impl Into<CardBitSet>, k: usize) -> Self {
+        let mask = cards.into().to_u64();
+        let n = mask.count_ones() as usize;
+        let k_u32 = k as u32;
+
+        if k == 0 {
+            return Self {
+                mask,
+                combo: 0,
+                limit: 0,
+                done: false,
+            };
         }
-        CardIter {
-            possible_cards,
-            idx,
-            num_cards,
+
+        if k > n {
+            return Self {
+                mask,
+                combo: 0,
+                limit: 0,
+                done: true,
+            };
+        }
+
+        Self {
+            mask,
+            combo: (1u64 << k_u32) - 1,
+            limit: 1u64 << (n as u32),
+            done: false,
         }
     }
 }
 
-/// The actual `Iterator` for `Card`'s.
-impl Iterator for CardIter<'_> {
+impl Iterator for CardIter {
     type Item = CardBitSet;
+
     fn next(&mut self) -> Option<CardBitSet> {
-        // This is a complete hack.
+        if self.done {
+            return None;
+        }
+
+        let combo = self.combo;
+
+        // `combo` is a k-subset of the *logical* indices {0..n-1}, where n is
+        // the popcount of `self.mask`. PDEP scatters these logical positions
+        // into the physical bit positions of the actual cards in `mask`.
         //
-        // Basically if num_cards == 1 then CardIter::new couldn't
-        // set the last index to one less than the starting index,
-        // because doing so would cause the unsigend usize to roll over.
-        // That means that we need this hack here.
-        if self.num_cards == 1 {
-            if self.idx[0] < self.possible_cards.len() {
-                let c = self.possible_cards[self.idx[0]];
-                self.idx[0] += 1;
-                let mut result = CardBitSet::new();
-                result.insert(c);
-                return Some(result);
-            } else {
-                return None;
-            }
-        }
-        // Keep track of where we are mutating
-        let mut current_level: usize = self.num_cards - 1;
+        // Example: mask = cards at physical bits {1, 5, 8, 12, 20}.
+        // combo = 0b01010 selects logical indices 1 and 3, and PDEP maps
+        // those to physical bits 5 and 12, producing the correct CardBitSet.
+        let result = CardBitSet::from_u64(pdep(combo, self.mask));
 
-        while current_level < self.num_cards {
-            // Move the current level forward one.
-            self.idx[current_level] += 1;
-
-            // Now check if moving this level forward means that
-            // We will need more cards to fill out the rest of the hand
-            // then are there.
-            let cards_needed_after = self.num_cards - (current_level + 1);
-            if self.idx[current_level] + cards_needed_after >= self.possible_cards.len() {
-                if current_level == 0 {
-                    return None;
-                }
-                current_level -= 1;
-            } else {
-                // If we aren't at the end then
-                if current_level < self.num_cards - 1 {
-                    self.idx[current_level + 1] = self.idx[current_level];
-                }
-                // Move forward one level
-                current_level += 1;
-            }
+        if self.limit == 0 {
+            self.done = true;
+            return Some(result);
         }
 
-        let mut result = CardBitSet::new();
-        for i in &self.idx {
-            result.insert(self.possible_cards[*i]);
+        if combo == 0 {
+            self.done = true;
+            return Some(result);
         }
+
+        // Gosper's hack: compute the next higher integer with the same
+        // popcount as `combo`. This visits all C(n,k) subsets in order.
+        //
+        // Decompose combo as: ...prefix 1^m 0^n  (m ones then n trailing zeros)
+        // We want:            ...prefix' 1 0^(n+1) 1^(m-1)
+        // i.e., move the highest bit of the lowest run up by one position,
+        // then pack the remaining m-1 bits into the bottom.
+        //
+        // Step 1: Smear the lowest run of ones downward through the trailing
+        // zeros, producing a solid block of (m+n) ones at the bottom.
+        let t = combo | (combo - 1);
+
+        // Step 2: Adding 1 carries through that solid block, clearing all
+        // (m+n) trailing ones and setting the bit just above — this is the
+        // "promoted" bit that moved up one position.
+        //
+        // Step 3: `(!t) & (t+1)` isolates the carry-out bit (position m+n),
+        // so subtracting 1 gives a mask of (m+n) ones. Shifting right by
+        // (n+1) produces exactly (m-1) ones in the lowest positions — the
+        // remaining bits that get packed to the bottom.
+        //
+        // OR-ing the two parts together yields the next k-subset.
+        let next = (t + 1) | ((((!t) & (t + 1)) - 1) >> (combo.trailing_zeros() + 1));
+
+        if next >= self.limit {
+            self.done = true;
+        } else {
+            self.combo = next;
+        }
+
         Some(result)
     }
 }
 
-/// This is useful for trying every possible 5 card hand
-///
-/// Probably not something that's going to be done in real
-/// use cases, but still not bad.
-impl<'a> IntoIterator for &'a FlatDeck {
+impl IntoIterator for &FlatDeck {
     type Item = CardBitSet;
-    type IntoIter = CardIter<'a>;
+    type IntoIter = CardIter;
 
-    fn into_iter(self) -> CardIter<'a> {
-        CardIter::new(&self[..], 5)
+    fn into_iter(self) -> CardIter {
+        CardIter::new(self, 5)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::core::{Deck, FlatHand, Suit, Value};
+    use crate::core::{Card, Deck, FlatDeck, Suit, Value};
 
     use super::*;
 
     #[test]
-    fn test_iter_one() {
-        let mut h = FlatHand::default();
-        h.push(Card {
-            value: Value::Two,
-            suit: Suit::Spade,
-        });
+    fn test_iter_zero() {
+        let mut cbs = CardBitSet::new();
+        cbs.insert(Card::new(Value::Two, Suit::Spade));
+        cbs.insert(Card::new(Value::Three, Suit::Spade));
+        let combos: Vec<_> = CardIter::new(cbs, 0).collect();
+        assert_eq!(1, combos.len());
+        assert_eq!(0, combos[0].count());
+    }
 
-        for cards in CardIter::new(&h[..], 1) {
+    #[test]
+    fn test_iter_k_greater_than_n() {
+        let mut cbs = CardBitSet::new();
+        cbs.insert(Card::new(Value::Two, Suit::Spade));
+        assert_eq!(0, CardIter::new(cbs, 2).count());
+    }
+
+    #[test]
+    fn test_iter_one() {
+        let mut cbs = CardBitSet::new();
+        cbs.insert(Card::new(Value::Two, Suit::Spade));
+
+        for cards in CardIter::new(cbs, 1) {
             assert_eq!(1, cards.count());
         }
-        assert_eq!(1, CardIter::new(&h[..], 1).count());
+        assert_eq!(1, CardIter::new(cbs, 1).count());
     }
 
     #[test]
     fn test_iter_two() {
-        let mut h = FlatHand::default();
-        h.push(Card {
-            value: Value::Two,
-            suit: Suit::Spade,
-        });
-        h.push(Card {
-            value: Value::Three,
-            suit: Suit::Spade,
-        });
-        h.push(Card {
-            value: Value::Four,
-            suit: Suit::Spade,
-        });
+        let mut cbs = CardBitSet::new();
+        cbs.insert(Card::new(Value::Two, Suit::Spade));
+        cbs.insert(Card::new(Value::Three, Suit::Spade));
+        cbs.insert(Card::new(Value::Four, Suit::Spade));
 
-        // Make sure that we get the correct number back.
-        assert_eq!(3, CardIter::new(&h[..], 2).count());
+        assert_eq!(3, CardIter::new(cbs, 2).count());
 
-        // Make sure that everything has two cards and they are different.
-        //
-        for cards in CardIter::new(&h[..], 2) {
+        for cards in CardIter::new(cbs, 2) {
             assert_eq!(2, cards.count());
-            let cards_vec: Vec<Card> = cards.into_iter().collect();
-            assert!(cards_vec[0] != cards_vec[1]);
         }
     }
 
@@ -154,85 +190,98 @@ mod tests {
 
     #[test]
     fn test_iter_returns_cardbitset() {
-        let mut h = FlatHand::default();
-        h.push(Card {
-            value: Value::Two,
-            suit: Suit::Spade,
-        });
-        h.push(Card {
-            value: Value::Three,
-            suit: Suit::Spade,
-        });
-        h.push(Card {
-            value: Value::Four,
-            suit: Suit::Spade,
-        });
+        let mut cbs = CardBitSet::new();
+        cbs.insert(Card::new(Value::Two, Suit::Spade));
+        cbs.insert(Card::new(Value::Three, Suit::Spade));
+        cbs.insert(Card::new(Value::Four, Suit::Spade));
 
-        for combo in CardIter::new(&h[..], 2) {
-            // Verify it's a CardBitSet with exactly 2 cards
+        for combo in CardIter::new(cbs, 2) {
             assert_eq!(2, combo.count());
 
-            // Verify we can use bitwise operations
             let mut combined = combo;
-            combined.insert(Card {
-                value: Value::Five,
-                suit: Suit::Spade,
-            });
+            combined.insert(Card::new(Value::Five, Suit::Spade));
             assert_eq!(3, combined.count());
         }
     }
 
     #[test]
     fn test_iter_contains_correct_cards() {
-        let mut h = FlatHand::default();
-        let card1 = Card {
-            value: Value::Ace,
-            suit: Suit::Heart,
-        };
-        let card2 = Card {
-            value: Value::King,
-            suit: Suit::Heart,
-        };
-        h.push(card1);
-        h.push(card2);
+        let mut cbs = CardBitSet::new();
+        let card1 = Card::new(Value::Ace, Suit::Heart);
+        let card2 = Card::new(Value::King, Suit::Heart);
+        cbs.insert(card1);
+        cbs.insert(card2);
 
-        let combos: Vec<_> = CardIter::new(&h[..], 2).collect();
+        let combos: Vec<_> = CardIter::new(cbs, 2).collect();
         assert_eq!(1, combos.len());
-
-        let combo = combos[0];
-        assert!(combo.contains(card1));
-        assert!(combo.contains(card2));
-        assert_eq!(2, combo.count());
+        assert!(combos[0].contains(card1));
+        assert!(combos[0].contains(card2));
+        assert_eq!(2, combos[0].count());
     }
 
     #[test]
     fn test_iter_bitwise_or_combinations() {
-        let mut h = FlatHand::default();
-        h.push(Card {
-            value: Value::Two,
-            suit: Suit::Spade,
-        });
-        h.push(Card {
-            value: Value::Three,
-            suit: Suit::Spade,
-        });
-        h.push(Card {
-            value: Value::Four,
-            suit: Suit::Spade,
-        });
+        let mut cbs = CardBitSet::new();
+        cbs.insert(Card::new(Value::Two, Suit::Spade));
+        cbs.insert(Card::new(Value::Three, Suit::Spade));
+        cbs.insert(Card::new(Value::Four, Suit::Spade));
 
-        let base_card = Card {
-            value: Value::Five,
-            suit: Suit::Heart,
-        };
-        let mut base_set = super::CardBitSet::new();
+        let base_card = Card::new(Value::Five, Suit::Heart);
+        let mut base_set = CardBitSet::new();
         base_set.insert(base_card);
 
-        // Test that we can OR combinations together
-        for combo in CardIter::new(&h[..], 2) {
+        for combo in CardIter::new(cbs, 2) {
             let combined = base_set | combo;
             assert_eq!(3, combined.count());
             assert!(combined.contains(base_card));
+        }
+    }
+
+    /// Verify exact combination counts match C(n,k) for various n,k
+    #[test]
+    fn test_combination_counts() {
+        let mut cbs = CardBitSet::new();
+        for i in 0..7u8 {
+            cbs.insert(Card::from(i));
+        }
+        assert_eq!(1, CardIter::new(cbs, 0).count());
+        assert_eq!(7, CardIter::new(cbs, 1).count());
+        assert_eq!(21, CardIter::new(cbs, 2).count());
+        assert_eq!(35, CardIter::new(cbs, 3).count());
+        assert_eq!(21, CardIter::new(cbs, 5).count());
+        assert_eq!(1, CardIter::new(cbs, 7).count());
+        assert_eq!(0, CardIter::new(cbs, 8).count());
+    }
+
+    /// Every subset produced should be a proper subset of the input
+    #[test]
+    fn test_all_subsets_are_subsets_of_input() {
+        let mut cbs = CardBitSet::new();
+        for i in 0..6u8 {
+            cbs.insert(Card::from(i * 7));
+        }
+
+        for combo in CardIter::new(cbs, 3) {
+            assert_eq!(3, combo.count());
+            for card in combo {
+                assert!(cbs.contains(card), "Card {card:?} not in input set");
+            }
+        }
+    }
+
+    /// No duplicate subsets
+    #[test]
+    fn test_no_duplicate_subsets() {
+        let mut cbs = CardBitSet::new();
+        for i in 0..5u8 {
+            cbs.insert(Card::from(i));
+        }
+
+        let combos: Vec<CardBitSet> = CardIter::new(cbs, 3).collect();
+        for (i, a) in combos.iter().enumerate() {
+            for b in &combos[i + 1..] {
+                assert_ne!(a, b, "Duplicate subset found");
+            }
         }
     }
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -35,4 +35,10 @@ pub enum RSPokerError {
     InvalidStrategyFrequencies(String),
     #[error("Preflop hand must have exactly 2 cards, got {0}")]
     InvalidPreflopHandSize(usize),
+    #[error("Omaha hole cards must have 2-7 cards, got {0}")]
+    OmahaHoleCardCount(usize),
+    #[error("Omaha board must have 3-5 cards, got {0}")]
+    OmahaBoardCardCount(usize),
+    #[error("Omaha hole cards and board cards must not overlap")]
+    OmahaOverlappingCards,
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -35,7 +35,7 @@ pub use self::flat_deck::FlatDeck;
 /// 5 Card hand ranking code.
 mod rank;
 /// Export the trait and the results.
-pub use self::rank::{CoreRank, Rank, Rankable};
+pub use self::rank::{CoreRank, Rank, RankFive, Rankable};
 
 // u16 backed player set.
 mod player_bit_set;

--- a/src/core/rank.rs
+++ b/src/core/rank.rs
@@ -129,107 +129,21 @@ fn keep_n(rank: u32, to_keep: u32) -> u32 {
 fn find_flush(suit_value_sets: &[u32]) -> Option<usize> {
     suit_value_sets.iter().position(|sv| sv.count_ones() >= 5)
 }
-/// Can this turn into a hand rank? There are default implementations for
-/// `Hand` and `Vec<Card>`.
-pub trait Rankable {
-    /// Rank the current 5 card hand.
-    /// This will not cache the value.
+/// Rank exactly 5 cards. This is a faster path than `Rankable::rank()`
+/// when you know the hand contains exactly 5 cards.
+///
+/// # Examples
+/// ```
+/// use rs_poker::core::{FlatHand, Rank, RankFive};
+///
+/// let hand = FlatHand::new_from_str("Ad8d9dTd5d").unwrap();
+/// let rank = hand.rank_five();
+/// assert!(matches!(rank, Rank::Flush(_)));
+/// ```
+pub trait RankFive {
     fn cards(&self) -> impl Iterator<Item = Card>;
 
-    /// Rank the cards to find the best 5 card hand.
-    /// This will work on 5 cards or more (specifically on 7 card holdem
-    /// hands). If you know that the hand only contains 5 cards then
-    /// `rank_five` will be faster.
-    ///
-    /// # Examples
-    /// ```
-    /// use rs_poker::core::{FlatHand, Rank, Rankable};
-    ///
-    /// let hand = FlatHand::new_from_str("2h2d8d8sKd6sTh").unwrap();
-    /// let rank = hand.rank();
-    /// assert!(Rank::TwoPair(0) <= rank);
-    /// assert!(Rank::TwoPair(u32::max_value()) >= rank);
-    /// ```
-    fn rank(&self) -> Rank {
-        let mut value_to_count: [u8; 13] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let mut count_to_value: [u32; 5] = [0, 0, 0, 0, 0];
-        let mut suit_value_sets: [u32; 4] = [0, 0, 0, 0];
-        let mut value_set: u32 = 0;
-
-        for c in self.cards() {
-            let v = c.value as u8;
-            let s = c.suit as u8;
-            value_set |= 1 << v;
-            value_to_count[v as usize] += 1;
-            suit_value_sets[s as usize] |= 1 << v;
-        }
-
-        // Now rotate the value to count map.
-        for (value, &count) in value_to_count.iter().enumerate() {
-            count_to_value[count as usize] |= 1 << value;
-        }
-
-        // Find out if there's a flush
-        let flush: Option<usize> = find_flush(&suit_value_sets);
-
-        // If this is a flush then it could be a straight flush
-        // or a flush. So check only once.
-        if let Some(flush_idx) = flush {
-            // If we can find a straight in the flush then it's a straight flush
-            if let Some(rank) = rank_straight(suit_value_sets[flush_idx]) {
-                Rank::StraightFlush(rank)
-            } else {
-                // Else it's just a normal flush
-                let rank = keep_n(suit_value_sets[flush_idx], 5);
-                Rank::Flush(rank)
-            }
-        } else if count_to_value[4] != 0 {
-            // Four of a kind.
-            let high = keep_highest(value_set ^ count_to_value[4]);
-            Rank::FourOfAKind((count_to_value[4] << 13) | high)
-        } else if count_to_value[3] != 0 && count_to_value[3].count_ones() == 2 {
-            // There are two sets. So the best we can make is a full house.
-            let set = keep_highest(count_to_value[3]);
-            let pair = count_to_value[3] ^ set;
-            Rank::FullHouse((set << 13) | pair)
-        } else if count_to_value[3] != 0 && count_to_value[2] != 0 {
-            // there is a pair and a set.
-            let set = count_to_value[3];
-            let pair = keep_highest(count_to_value[2]);
-            Rank::FullHouse((set << 13) | pair)
-        } else if let Some(s_rank) = rank_straight(value_set) {
-            // If there's a straight return it now.
-            Rank::Straight(s_rank)
-        } else if count_to_value[3] != 0 {
-            // if there is a set then we need to keep 2 cards that
-            // aren't in the set.
-            let low = keep_n(value_set ^ count_to_value[3], 2);
-            Rank::ThreeOfAKind((count_to_value[3] << 13) | low)
-        } else if count_to_value[2].count_ones() >= 2 {
-            // Two pair
-            //
-            // That can be because we have 3 pairs and a high card.
-            // Or we could have two pair and two high cards.
-            let pairs = keep_n(count_to_value[2], 2);
-            let low = keep_highest(value_set ^ pairs);
-            Rank::TwoPair((pairs << 13) | low)
-        } else if count_to_value[2] == 0 {
-            // This means that there's no pair
-            // no sets, no straights, no flushes, so only a
-            // high card.
-            Rank::HighCard(keep_n(value_set, 5))
-        } else {
-            // Otherwise there's only one pair.
-            let pair = count_to_value[2];
-            // Keep the highest three cards not in the pair.
-            let low = keep_n(value_set ^ count_to_value[2], 3);
-            Rank::OnePair((pair << 13) | low)
-        }
-    }
-
-    /// Rank this hand. It doesn't do any caching so it's left up to the user
-    /// to understand that duplicate work will be done if this is called more
-    /// than once.
+    /// Rank exactly 5 cards.
     fn rank_five(&self) -> Rank {
         // use for bitset
         let mut suit_set: u32 = 0;
@@ -239,7 +153,9 @@ pub trait Rankable {
 
         // count => bitset of values.
         let mut count_to_value: [u32; 5] = [0, 0, 0, 0, 0];
+        let mut card_count = 0u32;
         for c in self.cards() {
+            card_count += 1;
             let v = c.value as u8;
             let s = c.suit as u8;
 
@@ -249,6 +165,10 @@ pub trait Rankable {
             // Keep track of counts for each card.
             value_to_count[v as usize] += 1;
         }
+        debug_assert_eq!(
+            card_count, 5,
+            "rank_five() requires exactly 5 cards, got {card_count}"
+        );
 
         // Now rotate the value to count map.
         for (value, &count) in value_to_count.iter().enumerate() {
@@ -320,40 +240,175 @@ pub trait Rankable {
     }
 }
 
-/// Implementation for `Hand`
-impl Rankable for FlatHand {
+/// Rank a poker hand to find the best possible 5-card hand.
+///
+/// Each implementor defines its own ranking rules:
+/// - 5-card hands: rank directly
+/// - 7-card holdem hands: best 5 of 7
+/// - Omaha hands: best 2 hole + 3 board
+///
+/// # Examples
+/// ```
+/// use rs_poker::core::{FlatHand, Rank, Rankable};
+///
+/// let hand = FlatHand::new_from_str("2h2d8d8sKd6sTh").unwrap();
+/// let rank = hand.rank();
+/// assert!(Rank::TwoPair(0) <= rank);
+/// assert!(Rank::TwoPair(u32::max_value()) >= rank);
+/// ```
+pub trait Rankable {
+    fn rank(&self) -> Rank;
+}
+
+/// Rank a hand of 5 or more cards by finding the best possible 5-card hand.
+/// This is the holdem-style algorithm that works on 7-card hands.
+fn rank_best_of<I: Iterator<Item = Card>>(cards: I) -> Rank {
+    let mut value_to_count: [u8; 13] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut count_to_value: [u32; 5] = [0, 0, 0, 0, 0];
+    let mut suit_value_sets: [u32; 4] = [0, 0, 0, 0];
+    let mut value_set: u32 = 0;
+
+    for c in cards {
+        let v = c.value as u8;
+        let s = c.suit as u8;
+        value_set |= 1 << v;
+        value_to_count[v as usize] += 1;
+        suit_value_sets[s as usize] |= 1 << v;
+    }
+
+    // Now rotate the value to count map.
+    for (value, &count) in value_to_count.iter().enumerate() {
+        count_to_value[count as usize] |= 1 << value;
+    }
+
+    // Find out if there's a flush
+    let flush: Option<usize> = find_flush(&suit_value_sets);
+
+    // If this is a flush then it could be a straight flush
+    // or a flush. So check only once.
+    if let Some(flush_idx) = flush {
+        // If we can find a straight in the flush then it's a straight flush
+        if let Some(rank) = rank_straight(suit_value_sets[flush_idx]) {
+            Rank::StraightFlush(rank)
+        } else {
+            // Else it's just a normal flush
+            let rank = keep_n(suit_value_sets[flush_idx], 5);
+            Rank::Flush(rank)
+        }
+    } else if count_to_value[4] != 0 {
+        // Four of a kind.
+        let high = keep_highest(value_set ^ count_to_value[4]);
+        Rank::FourOfAKind((count_to_value[4] << 13) | high)
+    } else if count_to_value[3] != 0 && count_to_value[3].count_ones() == 2 {
+        // There are two sets. So the best we can make is a full house.
+        let set = keep_highest(count_to_value[3]);
+        let pair = count_to_value[3] ^ set;
+        Rank::FullHouse((set << 13) | pair)
+    } else if count_to_value[3] != 0 && count_to_value[2] != 0 {
+        // there is a pair and a set.
+        let set = count_to_value[3];
+        let pair = keep_highest(count_to_value[2]);
+        Rank::FullHouse((set << 13) | pair)
+    } else if let Some(s_rank) = rank_straight(value_set) {
+        // If there's a straight return it now.
+        Rank::Straight(s_rank)
+    } else if count_to_value[3] != 0 {
+        // if there is a set then we need to keep 2 cards that
+        // aren't in the set.
+        let low = keep_n(value_set ^ count_to_value[3], 2);
+        Rank::ThreeOfAKind((count_to_value[3] << 13) | low)
+    } else if count_to_value[2].count_ones() >= 2 {
+        // Two pair
+        //
+        // That can be because we have 3 pairs and a high card.
+        // Or we could have two pair and two high cards.
+        let pairs = keep_n(count_to_value[2], 2);
+        let low = keep_highest(value_set ^ pairs);
+        Rank::TwoPair((pairs << 13) | low)
+    } else if count_to_value[2] == 0 {
+        // This means that there's no pair
+        // no sets, no straights, no flushes, so only a
+        // high card.
+        Rank::HighCard(keep_n(value_set, 5))
+    } else {
+        // Otherwise there's only one pair.
+        let pair = count_to_value[2];
+        // Keep the highest three cards not in the pair.
+        let low = keep_n(value_set ^ count_to_value[2], 3);
+        Rank::OnePair((pair << 13) | low)
+    }
+}
+
+/// Implementation for `FlatHand`
+impl RankFive for FlatHand {
     fn cards(&self) -> impl Iterator<Item = Card> {
         self.iter().copied()
     }
 }
 
-impl Rankable for Vec<Card> {
+impl RankFive for Vec<Card> {
     fn cards(&self) -> impl Iterator<Item = Card> {
         self.iter().copied()
     }
 }
 
-impl Rankable for [Card] {
+impl RankFive for [Card] {
     fn cards(&self) -> impl Iterator<Item = Card> {
         self.iter().copied()
     }
 }
 
-impl Rankable for &[Card] {
+impl RankFive for &[Card] {
     fn cards(&self) -> impl Iterator<Item = Card> {
         self.iter().copied()
     }
 }
 
-impl Rankable for Hand {
+impl RankFive for Hand {
     fn cards(&self) -> impl Iterator<Item = Card> {
         self.iter()
     }
 }
 
-impl Rankable for CardBitSet {
+impl RankFive for CardBitSet {
     fn cards(&self) -> impl Iterator<Item = Card> {
         self.into_iter()
+    }
+}
+
+impl Rankable for FlatHand {
+    fn rank(&self) -> Rank {
+        rank_best_of(self.iter().copied())
+    }
+}
+
+impl Rankable for Vec<Card> {
+    fn rank(&self) -> Rank {
+        rank_best_of(self.iter().copied())
+    }
+}
+
+impl Rankable for [Card] {
+    fn rank(&self) -> Rank {
+        rank_best_of(self.iter().copied())
+    }
+}
+
+impl Rankable for &[Card] {
+    fn rank(&self) -> Rank {
+        rank_best_of(self.iter().copied())
+    }
+}
+
+impl Rankable for Hand {
+    fn rank(&self) -> Rank {
+        rank_best_of(self.iter())
+    }
+}
+
+impl Rankable for CardBitSet {
+    fn rank(&self) -> Rank {
+        rank_best_of(self.into_iter())
     }
 }
 

--- a/src/holdem/outs_calculator.rs
+++ b/src/holdem/outs_calculator.rs
@@ -292,10 +292,8 @@ impl OutsCalculator {
             })
             .collect();
 
-        let remaining_vec: Vec<Card> = self.remaining_cards.into_iter().collect();
-
         // Iterate through all possible combinations of remaining cards
-        for combo in CardIter::new(&remaining_vec, num_cards_to_deal) {
+        for combo in CardIter::new(self.remaining_cards, num_cards_to_deal) {
             // Build the complete board using bitwise OR
             let full_board = self.board | combo;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! * Holdem Game State with action validation
 //! * Holdem agents
 //! * Holdem game simulation
+//! * Omaha (PLO4/PLO5/PLO6/PLO7) hand evaluation
 //!
 //! Our focus is on correctness and performance.
 //!
@@ -201,6 +202,13 @@ pub mod core;
 /// The holdem specific code. This contains range
 /// parsing, game state, and starting hand code.
 pub mod holdem;
+
+/// Omaha poker hand evaluation.
+///
+/// Supports PLO4, PLO5, PLO6 and partial boards. Ranks hands
+/// using the Omaha rule: exactly 2 hole cards + exactly 3 board cards.
+#[cfg(feature = "omaha")]
+pub mod omaha;
 
 /// Given a tournament calculate the implied
 /// equity in the total tournament.

--- a/src/omaha/mod.rs
+++ b/src/omaha/mod.rs
@@ -1,0 +1,390 @@
+//! Omaha poker hand evaluation.
+//!
+//! In Omaha Hold'em, each player receives hole cards (4 in PLO4, 5 in PLO5, 6
+//! in PLO6, 7 in PLO7) and shares 5 community board cards. A valid 5-card hand must use
+//! **exactly 2** hole cards and **exactly 3** board cards.
+//!
+//! [`OmahaHand`] stores the hole cards and board cards as separate
+//! [`CardBitSet`]s and ranks the best possible 5-card combination.
+//!
+//! # Examples
+//!
+//! ```
+//! use rs_poker::core::{Rank, Rankable};
+//! use rs_poker::omaha::OmahaHand;
+//!
+//! // Hole: AhAsKhKs, Board: QhJhTh9h8h
+//! // Best hand: AhKh (hole) + QhJhTh (board) = royal flush
+//! let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh9h8h").unwrap();
+//! let rank = hand.rank();
+//! assert_eq!(rank, Rank::StraightFlush(9));
+//! ```
+
+use crate::core::{CardBitSet, CardIter, Hand, RSPokerError, Rank, RankFive, Rankable};
+
+/// An Omaha poker hand consisting of private hole cards and shared board cards.
+///
+/// The hand is ranked by finding the best 5-card combination using exactly 2
+/// hole cards and exactly 3 board cards.
+///
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OmahaHand {
+    /// The player's private hole cards (typically 4, but 5 or 6 for variants).
+    hole: CardBitSet,
+    /// The shared community board cards (3 on flop, 4 on turn, 5 on river).
+    board: CardBitSet,
+}
+
+impl OmahaHand {
+    /// Create a new `OmahaHand` from two `CardBitSet`s.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - `hole` has fewer than 2 or more than 7 cards
+    /// - `board` has fewer than 3 or more than 5 cards
+    /// - `hole` and `board` share any cards
+    pub fn new(hole: CardBitSet, board: CardBitSet) -> Result<Self, RSPokerError> {
+        let hole_count = hole.count();
+        if !(2..=7).contains(&hole_count) {
+            return Err(RSPokerError::OmahaHoleCardCount(hole_count));
+        }
+        let board_count = board.count();
+        if !(3..=5).contains(&board_count) {
+            return Err(RSPokerError::OmahaBoardCardCount(board_count));
+        }
+        if !(hole & board).is_empty() {
+            return Err(RSPokerError::OmahaOverlappingCards);
+        }
+        Ok(Self { hole, board })
+    }
+
+    /// Parse an `OmahaHand` from two card strings.
+    ///
+    /// Each string uses the same format as [`Hand::new_from_str`]: pairs of
+    /// value+suit characters like `"AhKsQdJc"`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rs_poker::omaha::OmahaHand;
+    ///
+    /// let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh9h8h").unwrap();
+    /// ```
+    pub fn new_from_str(hole_str: &str, board_str: &str) -> Result<Self, RSPokerError> {
+        let hole: CardBitSet = Hand::new_from_str(hole_str)?.into();
+        let board: CardBitSet = Hand::new_from_str(board_str)?.into();
+        Self::new(hole, board)
+    }
+
+    /// The player's private hole cards.
+    pub fn hole(&self) -> CardBitSet {
+        self.hole
+    }
+
+    /// The shared community board cards.
+    pub fn board(&self) -> CardBitSet {
+        self.board
+    }
+}
+
+impl Rankable for OmahaHand {
+    fn rank(&self) -> Rank {
+        CardIter::new(self.hole, 2)
+            .flat_map(|hole| {
+                CardIter::new(self.board, 3).map(move |board| (hole | board).rank_five())
+            })
+            // OmahaHand::new() guarantees hole >= 2 and board >= 3,
+            // so there is always at least C(2,2) * C(3,3) = 1 combination.
+            .max()
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Card, CoreRank, Hand, Rank, RankFive, Rankable, Suit, Value};
+
+    // ── Construction ─────────────────────────────────────────────
+
+    #[test]
+    fn test_new_valid() {
+        let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh9h8h");
+        assert!(hand.is_ok());
+    }
+
+    #[test]
+    fn test_new_too_few_hole_cards() {
+        // Only 1 hole card
+        let mut hole = CardBitSet::new();
+        hole.insert(Card::new(Value::Ace, Suit::Spade));
+        let mut board = CardBitSet::new();
+        for c in [
+            Card::new(Value::Two, Suit::Heart),
+            Card::new(Value::Three, Suit::Heart),
+            Card::new(Value::Four, Suit::Heart),
+        ] {
+            board.insert(c);
+        }
+        assert!(matches!(
+            OmahaHand::new(hole, board),
+            Err(RSPokerError::OmahaHoleCardCount(1))
+        ));
+    }
+
+    #[test]
+    fn test_new_too_few_board_cards() {
+        let mut hole = CardBitSet::new();
+        hole.insert(Card::new(Value::Ace, Suit::Spade));
+        hole.insert(Card::new(Value::King, Suit::Spade));
+        let mut board = CardBitSet::new();
+        board.insert(Card::new(Value::Two, Suit::Heart));
+        board.insert(Card::new(Value::Three, Suit::Heart));
+        assert!(matches!(
+            OmahaHand::new(hole, board),
+            Err(RSPokerError::OmahaBoardCardCount(2))
+        ));
+    }
+
+    #[test]
+    fn test_new_overlapping_cards() {
+        let shared = Card::new(Value::Ace, Suit::Spade);
+        let mut hole = CardBitSet::new();
+        hole.insert(shared);
+        hole.insert(Card::new(Value::King, Suit::Spade));
+        let mut board = CardBitSet::new();
+        board.insert(shared);
+        board.insert(Card::new(Value::Two, Suit::Heart));
+        board.insert(Card::new(Value::Three, Suit::Heart));
+        assert!(matches!(
+            OmahaHand::new(hole, board),
+            Err(RSPokerError::OmahaOverlappingCards)
+        ));
+    }
+
+    #[test]
+    fn test_new_from_str_duplicate_in_hole() {
+        let result = OmahaHand::new_from_str("AhAhKsQs", "2h3h4h5h6h");
+        assert!(matches!(result, Err(RSPokerError::DuplicateCardInHand(_))));
+    }
+
+    // ── Ranking (issue #33 examples) ─────────────────────────────
+
+    #[test]
+    fn test_issue_33_example() {
+        // From the issue: AhAsKhKs hole, QhJhTh9h8h board.
+        // Best 5-card hand using exactly 2 hole + 3 board:
+        //   AhKh (hole) + QhJhTh (board) = royal flush
+        let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh9h8h").unwrap();
+        let rank = hand.rank();
+        let best_hand: CardBitSet = Hand::new_from_str("AhKhQhJhTh").unwrap().into();
+        assert_eq!(rank, best_hand.rank_five());
+    }
+
+    #[test]
+    fn test_straight_flush() {
+        // Hole: 9s8s7c6c, Board: Ts7s6s5d4d
+        // Best: 9s8s + Ts7s6s = T-high straight flush
+        let hand = OmahaHand::new_from_str("9s8s7c6c", "Ts7s6s5d4d").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::StraightFlush, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_four_of_a_kind() {
+        // Hole: AsAh9c2c, Board: AcAdKs3h4h
+        // Best: AsAh (2 hole aces) + AcAdKs (2 board aces + K) = four aces + K
+        let hand = OmahaHand::new_from_str("AsAh9c2c", "AcAdKs3h4h").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::FourOfAKind, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_full_house() {
+        // Hole: AsAhKsQd, Board: AdKdKc3h4h
+        // Best: AsAh + AdKdKc = AAA KK = full house (aces full of kings)
+        let hand = OmahaHand::new_from_str("AsAhKsQd", "AdKdKc3h4h").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::FullHouse, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_flush() {
+        // Hole: AhKh2s3s, Board: Qh9h5h4d6d
+        // Best: AhKh + Qh9h5h = Ah Kh Qh 9h 5h = ace-high flush
+        let hand = OmahaHand::new_from_str("AhKh2s3s", "Qh9h5h4d6d").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::Flush, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_straight() {
+        // Hole: Ah Ks 2c 3d, Board: Qd Jh Tc 9s 4h
+        // Best: AhKs + QdJhTc = AKQJT = broadway straight
+        let hand = OmahaHand::new_from_str("AhKs2c3d", "QdJhTc9s4h").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::Straight, CoreRank::from(rank));
+        // Broadway is straight index 9
+        assert_eq!(Rank::Straight(9), rank);
+    }
+
+    #[test]
+    fn test_must_use_exactly_two_hole_cards() {
+        // This is the key Omaha rule test.
+        // Hole: AhAdAcAs (four aces), Board: Kh Kd 2c 3c 4c
+        // In holdem, this would be quads. In Omaha, you must use exactly 2
+        // from hole (2 aces) and 3 from board (Kh Kd + one other).
+        // Best: AhAd + KhKd2c = AA KK 2 = two pair
+        // Or: AhAd + KhKd3c = AA KK 3 = two pair
+        // So the best hand is two pair, NOT four of a kind.
+        let hand = OmahaHand::new_from_str("AhAdAcAs", "KhKd2c3c4c").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::TwoPair, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_must_use_exactly_three_board_cards() {
+        // Hole: AhKh2s3s, Board: Qh Jh Th 9h 8d
+        // Board has 4 hearts (Qh Jh Th 9h). With Ah Kh from hole, you'd
+        // have 6 hearts total. But you must use exactly 3 board cards.
+        // Best with 2 hole hearts: AhKh + Qh Jh Th = royal flush
+        // This IS a valid straight flush because we use 2 from hole, 3 from board.
+        let hand = OmahaHand::new_from_str("AhKh2s3s", "QhJhTh9h8d").unwrap();
+        let rank = hand.rank();
+        assert_eq!(Rank::StraightFlush(9), rank);
+    }
+
+    #[test]
+    fn test_board_flush_not_player_flush() {
+        // Board has 5 hearts, but hole has no hearts.
+        // Hole: 2s 3s 4d 5d, Board: Ah Kh Qh Jh 9h
+        // Must use 2 from hole + 3 from board.
+        // No combination gives a flush because hole has no hearts.
+        // Best might be a straight: 2s3s (no), 4d5d (no)...
+        // None of the 2-hole combos with 3 board cards make a flush.
+        let hand = OmahaHand::new_from_str("2s3s4d5d", "AhKhQhJh9h").unwrap();
+        let rank = hand.rank();
+        assert_ne!(CoreRank::Flush, CoreRank::from(rank));
+        assert_ne!(CoreRank::StraightFlush, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_plo5_five_hole_cards() {
+        // PLO5: 5 hole cards
+        let hand = OmahaHand::new_from_str("AhAsKhKs9d", "QhJhTh2c3c").unwrap();
+        assert_eq!(hand.hole().count(), 5);
+        let rank = hand.rank();
+        // AhKh + QhJhTh = royal flush
+        assert_eq!(Rank::StraightFlush(9), rank);
+    }
+
+    #[test]
+    fn test_plo6_six_hole_cards() {
+        // PLO6: 6 hole cards
+        let hand = OmahaHand::new_from_str("AhAsKhKs9d8d", "QhJhTh2c3c").unwrap();
+        assert_eq!(hand.hole().count(), 6);
+        let rank = hand.rank();
+        assert_eq!(Rank::StraightFlush(9), rank);
+    }
+
+    #[test]
+    fn test_flop_three_board_cards() {
+        // Partial board (flop): only 3 board cards
+        let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh").unwrap();
+        let rank = hand.rank();
+        // AhKh + QhJhTh = royal flush
+        assert_eq!(Rank::StraightFlush(9), rank);
+    }
+
+    #[test]
+    fn test_turn_four_board_cards() {
+        // Partial board (turn): 4 board cards
+        let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh2c").unwrap();
+        let rank = hand.rank();
+        assert_eq!(Rank::StraightFlush(9), rank);
+    }
+
+    #[test]
+    fn test_accessors() {
+        let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh9h8h").unwrap();
+        assert_eq!(hand.hole().count(), 4);
+        assert_eq!(hand.board().count(), 5);
+    }
+
+    #[test]
+    fn test_wheel_straight() {
+        // Hole: Ah 2s 9c 8c, Board: 3d 4d 5h Kc Qc
+        // Best: Ah2s + 3d4d5h = A2345 = wheel
+        let hand = OmahaHand::new_from_str("Ah2s9c8c", "3d4d5hKcQc").unwrap();
+        let rank = hand.rank();
+        assert_eq!(Rank::Straight(0), rank);
+    }
+
+    #[test]
+    fn test_high_card_only() {
+        // No pair, no straight, no flush possible with Omaha constraints
+        // Hole: 2s 7d 4c 9h, Board: As Kd Qh 3c Jh
+        // Must use exactly 2 hole + 3 board. Best high card combos:
+        // 9h7d + AsKdQh = A K Q 9 7
+        let hand = OmahaHand::new_from_str("2s7d4c9h", "AsKdQh3cJh").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::HighCard, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_one_pair() {
+        // Hole: AhKs2c3d, Board: Ad 9h 8c 7s 4d
+        // Best: AhKs + Ad9h8c = pair of aces, K 9 8 kickers
+        let hand = OmahaHand::new_from_str("AhKs2c3d", "Ad9h8c7s4d").unwrap();
+        let rank = hand.rank();
+        assert_eq!(CoreRank::OnePair, CoreRank::from(rank));
+    }
+
+    #[test]
+    fn test_rankable_trait_impl() {
+        // Verify OmahaHand can be used through the Rankable trait
+        let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh9h8h").unwrap();
+        let rank = hand.rank();
+        assert_eq!(Rank::StraightFlush(9), rank);
+
+        // Verify it works through a generic function
+        fn rank_any(hand: &impl Rankable) -> Rank {
+            hand.rank()
+        }
+        assert_eq!(Rank::StraightFlush(9), rank_any(&hand));
+    }
+
+    #[test]
+    fn test_new_too_many_hole_cards() {
+        // 8 hole cards should fail (max is 7 for PLO7)
+        let hand = OmahaHand::new_from_str("AhAsKhKs9d8d7c6c", "QhJhTh2s3s");
+        assert!(matches!(hand, Err(RSPokerError::OmahaHoleCardCount(8))));
+    }
+
+    #[test]
+    fn test_new_too_many_board_cards() {
+        // 6 board cards should fail (max is 5)
+        let hand = OmahaHand::new_from_str("AhAsKhKs", "QhJhTh9h8h2c");
+        assert!(matches!(hand, Err(RSPokerError::OmahaBoardCardCount(6))));
+    }
+
+    #[test]
+    fn test_plo7_seven_hole_cards() {
+        // PLO7: 7 hole cards should be valid
+        let hand = OmahaHand::new_from_str("AhAsKhKs9d8d7c", "QdJdTd2s3s");
+        assert!(hand.is_ok());
+        assert_eq!(hand.unwrap().hole().count(), 7);
+    }
+
+    #[test]
+    fn test_rank_comparison_between_hands() {
+        // Hand A: has a flush
+        let hand_a = OmahaHand::new_from_str("AhKh2s3s", "Qh9h5h4d6d").unwrap();
+        // Hand B: has a straight
+        let hand_b = OmahaHand::new_from_str("AhKs2c3d", "QdJhTc9s4h").unwrap();
+        // Flush > Straight
+        assert!(hand_a.rank() > hand_b.rank());
+    }
+}


### PR DESCRIPTION
Add OmahaHand for PLO4/5/6/7 with best-hand selection using the
Omaha rule (exactly 2 hole cards + 3 board cards). Gated behind
a new `omaha` feature flag, enabled by default.

Rewrite CardIter to operate directly on CardBitSet using Gosper's
hack for k-subset enumeration and PDEP for bit-index mapping,
eliminating the Vec<usize> index tracking and all allocation.

Supporting changes:
- Extract pdep() into a shared crate-visible helper
- Add from_u64/to_u64, FromIterator<Card>, From<FlatDeck> to CardBitSet
- Add omaha benchmarks, fuzz target (rank_omaha), and tests
