### PR TITLE
feat: add deterministic seeded RNG support for agents

### DIFF
--- a/src/arena/agent/config.rs
+++ b/src/arena/agent/config.rs
@@ -152,12 +152,14 @@ use crate::arena::agent::{
     AllInAgent, CallingAgent, FoldingAgent, RandomAgent, RandomPotControlAgent,
 };
 use crate::arena::cfr::{
-    BasicCFRActionGenerator, CFRAgentBuilder, CFRState, ConfigurableActionConfig,
+    ActionGenerator, BasicCFRActionGenerator, CFRAgentBuilder, CFRState, ConfigurableActionConfig,
     ConfigurableActionGenerator, DepthBasedIteratorGen, DepthBasedIteratorGenConfig,
-    PreflopChartActionConfig, PreflopChartActionGenerator, PreflopChartConfig,
-    SimpleActionGenerator, TraversalSet,
+    GameStateIteratorGen, PreflopChartActionConfig, PreflopChartActionGenerator,
+    PreflopChartConfig, SimpleActionGenerator, TraversalSet,
 };
 use crate::arena::{Agent, GameState};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 use std::{io::ErrorKind, path::Path, sync::Arc};
 use thiserror::Error;
@@ -438,6 +440,7 @@ pub struct ConfigAgentBuilder {
     cfr_states: Option<Vec<CFRState>>,
     traversal_set: Option<TraversalSet>,
     thread_pool: Option<Arc<rayon::ThreadPool>>,
+    rng_seed: Option<u64>,
 }
 
 impl ConfigAgentBuilder {
@@ -451,6 +454,7 @@ impl ConfigAgentBuilder {
             cfr_states: None,
             traversal_set: None,
             thread_pool: None,
+            rng_seed: None,
         })
     }
 
@@ -497,6 +501,16 @@ impl ConfigAgentBuilder {
     /// iterations and actions using the provided rayon thread pool.
     pub fn thread_pool(mut self, pool: Arc<rayon::ThreadPool>) -> Self {
         self.thread_pool = Some(pool);
+        self
+    }
+
+    /// Set an RNG seed for the agent.
+    ///
+    /// When set, agents that use randomness (Random, RandomPotControl, CFR)
+    /// will use a deterministic RNG seeded from this value instead of
+    /// system entropy.
+    pub fn rng_seed(mut self, seed: u64) -> Self {
+        self.rng_seed = Some(seed);
         self
     }
 
@@ -557,21 +571,39 @@ impl ConfigAgentBuilder {
                 name,
                 percent_fold,
                 percent_call,
-            } => Box::new(RandomAgent::new(
-                resolve_agent_name(name, "RandomAgent", player_idx),
-                percent_fold.clone(),
-                percent_call.clone(),
-            )),
+            } => {
+                let agent_name = resolve_agent_name(name, "RandomAgent", player_idx);
+                if let Some(seed) = self.rng_seed {
+                    Box::new(RandomAgent::new_with_seed(
+                        agent_name,
+                        percent_fold.clone(),
+                        percent_call.clone(),
+                        seed,
+                    ))
+                } else {
+                    Box::new(RandomAgent::new(
+                        agent_name,
+                        percent_fold.clone(),
+                        percent_call.clone(),
+                    ))
+                }
+            }
             AgentConfig::RandomPotControl { name, percent_call } => {
-                Box::new(RandomPotControlAgent::new(
-                    resolve_agent_name(name, "RandomPotControlAgent", player_idx),
-                    percent_call.clone(),
-                ))
+                let agent_name = resolve_agent_name(name, "RandomPotControlAgent", player_idx);
+                if let Some(seed) = self.rng_seed {
+                    Box::new(RandomPotControlAgent::new_with_seed(
+                        agent_name,
+                        percent_call.clone(),
+                        seed,
+                    ))
+                } else {
+                    Box::new(RandomPotControlAgent::new(agent_name, percent_call.clone()))
+                }
             }
             AgentConfig::CfrBasic { name, depth_hands } => {
                 let (cfr_states, traversal_set) = self.resolve_cfr_context();
                 let iter_config = DepthBasedIteratorGenConfig::new(depth_hands.clone());
-                let mut builder =
+                let builder =
                     CFRAgentBuilder::<BasicCFRActionGenerator, DepthBasedIteratorGen>::new()
                         .name(resolve_agent_name(name, "CFRAgent", player_idx))
                         .player_idx(player_idx)
@@ -579,15 +611,12 @@ impl ConfigAgentBuilder {
                         .traversal_set(traversal_set)
                         .gamestate_iterator_gen_config(iter_config)
                         .action_gen_config(());
-                if let Some(pool) = &self.thread_pool {
-                    builder = builder.thread_pool(pool.clone());
-                }
-                Box::new(builder.build())
+                Box::new(self.apply_cfr_options(builder).build())
             }
             AgentConfig::CfrSimple { name, depth_hands } => {
                 let (cfr_states, traversal_set) = self.resolve_cfr_context();
                 let iter_config = DepthBasedIteratorGenConfig::new(depth_hands.clone());
-                let mut builder =
+                let builder =
                     CFRAgentBuilder::<SimpleActionGenerator, DepthBasedIteratorGen>::new()
                         .name(resolve_agent_name(name, "CFRSimpleAgent", player_idx))
                         .player_idx(player_idx)
@@ -595,10 +624,7 @@ impl ConfigAgentBuilder {
                         .traversal_set(traversal_set)
                         .gamestate_iterator_gen_config(iter_config)
                         .action_gen_config(());
-                if let Some(pool) = &self.thread_pool {
-                    builder = builder.thread_pool(pool.clone());
-                }
-                Box::new(builder.build())
+                Box::new(self.apply_cfr_options(builder).build())
             }
             AgentConfig::CfrConfigurable {
                 name,
@@ -607,7 +633,7 @@ impl ConfigAgentBuilder {
             } => {
                 let (cfr_states, traversal_set) = self.resolve_cfr_context();
                 let iter_config = DepthBasedIteratorGenConfig::new(depth_hands.clone());
-                let mut builder =
+                let builder =
                     CFRAgentBuilder::<ConfigurableActionGenerator, DepthBasedIteratorGen>::new()
                         .name(resolve_agent_name(name, "CFRConfigurableAgent", player_idx))
                         .player_idx(player_idx)
@@ -615,10 +641,7 @@ impl ConfigAgentBuilder {
                         .traversal_set(traversal_set)
                         .gamestate_iterator_gen_config(iter_config)
                         .action_gen_config(action_config.as_ref().clone());
-                if let Some(pool) = &self.thread_pool {
-                    builder = builder.thread_pool(pool.clone());
-                }
-                Box::new(builder.build())
+                Box::new(self.apply_cfr_options(builder).build())
             }
             AgentConfig::CfrPreflopChart {
                 name,
@@ -638,7 +661,7 @@ impl ConfigAgentBuilder {
                         .map(|c| c.as_ref().clone())
                         .unwrap_or_default(),
                 };
-                let mut builder =
+                let builder =
                     CFRAgentBuilder::<PreflopChartActionGenerator, DepthBasedIteratorGen>::new()
                         .name(resolve_agent_name(name, "CFRPreflopChartAgent", player_idx))
                         .player_idx(player_idx)
@@ -646,12 +669,23 @@ impl ConfigAgentBuilder {
                         .traversal_set(traversal_set)
                         .gamestate_iterator_gen_config(iter_config)
                         .action_gen_config(action_config);
-                if let Some(pool) = &self.thread_pool {
-                    builder = builder.thread_pool(pool.clone());
-                }
-                Box::new(builder.build())
+                Box::new(self.apply_cfr_options(builder).build())
             }
         }
+    }
+
+    /// Apply thread pool and RNG seed options to a CFR agent builder.
+    fn apply_cfr_options<T: ActionGenerator, I: GameStateIteratorGen>(
+        &self,
+        mut builder: CFRAgentBuilder<T, I>,
+    ) -> CFRAgentBuilder<T, I> {
+        if let Some(pool) = &self.thread_pool {
+            builder = builder.thread_pool(pool.clone());
+        }
+        if let Some(seed) = self.rng_seed {
+            builder = builder.rng(StdRng::seed_from_u64(seed));
+        }
+        builder
     }
 
     /// Get the shared CFR states and TraversalSet for CFR agents.

--- a/src/arena/agent/random.rs
+++ b/src/arena/agent/random.rs
@@ -1,4 +1,5 @@
-use rand::{RngExt, rng};
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng, rng};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tracing::{instrument, trace};
@@ -19,14 +20,44 @@ pub struct RandomAgent {
     name: String,
     percent_fold: Vec<f64>,
     percent_call: Vec<f64>,
+    rng: SmallRng,
 }
 
 impl RandomAgent {
     pub fn new(name: impl Into<String>, percent_fold: Vec<f64>, percent_call: Vec<f64>) -> Self {
+        Self::with_rng(
+            name,
+            percent_fold,
+            percent_call,
+            SmallRng::from_rng(&mut rng()),
+        )
+    }
+
+    pub fn new_with_seed(
+        name: impl Into<String>,
+        percent_fold: Vec<f64>,
+        percent_call: Vec<f64>,
+        seed: u64,
+    ) -> Self {
+        Self::with_rng(
+            name,
+            percent_fold,
+            percent_call,
+            SmallRng::seed_from_u64(seed),
+        )
+    }
+
+    fn with_rng(
+        name: impl Into<String>,
+        percent_fold: Vec<f64>,
+        percent_call: Vec<f64>,
+        rng: SmallRng,
+    ) -> Self {
         Self {
             name: name.into(),
             percent_call,
             percent_fold,
+            rng,
         }
     }
 }
@@ -35,7 +66,7 @@ impl Default for RandomAgent {
     fn default() -> Self {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let idx = COUNTER.fetch_add(1, Ordering::Relaxed);
-        RandomAgent::new(
+        Self::new(
             format!("RandomAgent-default-{idx}"),
             vec![0.25, 0.30, 0.50],
             vec![0.5, 0.6, 0.45],
@@ -51,8 +82,6 @@ impl Agent for RandomAgent {
         let player_stack = game_state.stacks[round_data.to_act_idx];
         let curr_bet = round_data.bet;
         let raise_count = round_data.total_raise_count;
-
-        let mut rng = rng();
 
         // The min we can bet when not calling is the current bet plus the min raise
         // However it's possible that would put the player all in.
@@ -83,17 +112,17 @@ impl Agent for RandomAgent {
         let percent_call = self.percent_call.get(call_idx).map_or_else(|| 1.0, |v| *v);
 
         // Now do the action decision
-        let action = if can_fold && rng.random_bool(percent_fold) {
+        let action = if can_fold && self.rng.random_bool(percent_fold) {
             // We can fold and the rng was in favor so fold.
             AgentAction::Fold
-        } else if rng.random_bool(percent_call) {
+        } else if self.rng.random_bool(percent_call) {
             // We're calling, which is the same as betting the same as the current.
             // Luckily for us the simulation will take care of us if this puts us all in.
             AgentAction::Call
         } else if max > min {
             // If there's some range and the rng didn't choose another option. So bet some
             // amount.
-            AgentAction::Bet(rng.random_range(min..max))
+            AgentAction::Bet(self.rng.random_range(min..max))
         } else {
             AgentAction::Bet(max)
         };
@@ -162,9 +191,26 @@ impl Default for RandomAgentGenerator {
 pub struct RandomPotControlAgent {
     name: String,
     percent_call: Vec<f64>,
+    rng: SmallRng,
 }
 
 impl RandomPotControlAgent {
+    pub fn new(name: impl Into<String>, percent_call: Vec<f64>) -> Self {
+        Self::with_rng(name, percent_call, SmallRng::from_rng(&mut rng()))
+    }
+
+    pub fn new_with_seed(name: impl Into<String>, percent_call: Vec<f64>, seed: u64) -> Self {
+        Self::with_rng(name, percent_call, SmallRng::seed_from_u64(seed))
+    }
+
+    fn with_rng(name: impl Into<String>, percent_call: Vec<f64>, rng: SmallRng) -> Self {
+        Self {
+            name: name.into(),
+            percent_call,
+            rng,
+        }
+    }
+
     fn expected_pot(&self, game_state: &GameState) -> f32 {
         if game_state.round == Round::Preflop {
             (3.0 * game_state.big_blind).max(game_state.total_pot)
@@ -195,7 +241,7 @@ impl RandomPotControlAgent {
     }
 
     fn monte_carlo_based_action(
-        &self,
+        &mut self,
         game_state: &GameState,
         mut monte: MonteCarloGame,
     ) -> AgentAction {
@@ -233,8 +279,7 @@ impl RandomPotControlAgent {
         }
     }
 
-    fn random_action(&self, game_state: &GameState, max_value: f32) -> AgentAction {
-        let mut rng = rng();
+    fn random_action(&mut self, game_state: &GameState, max_value: f32) -> AgentAction {
         // Use the number of bets to determine the call percentage
         let round_data = &game_state.round_data;
         let raise_count = round_data.total_raise_count;
@@ -247,7 +292,7 @@ impl RandomPotControlAgent {
         let player_bet_this_round = game_state.current_round_current_player_bet();
         let max_total_bet = player_bet_this_round + player_stack;
 
-        if rng.random_bool(percent_call) {
+        if self.rng.random_bool(percent_call) {
             AgentAction::Bet(round_data.bet)
         } else {
             // Even though this is a random action try not to under min raise
@@ -270,17 +315,12 @@ impl RandomPotControlAgent {
                 let high = max_value
                     .max(min_raise_total + min_raise)
                     .min(max_total_bet);
-                let bet_value = rng.random_range(min_raise_total..high.max(min_raise_total + 1.0));
+                let bet_value = self
+                    .rng
+                    .random_range(min_raise_total..high.max(min_raise_total + 1.0));
 
                 AgentAction::Bet(bet_value)
             }
-        }
-    }
-
-    pub fn new(name: impl Into<String>, percent_call: Vec<f64>) -> Self {
-        Self {
-            name: name.into(),
-            percent_call,
         }
     }
 }

--- a/src/arena/comparison/runner.rs
+++ b/src/arena/comparison/runner.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use itertools::Itertools;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 use tracing::event;
 
 use crate::arena::agent::{AgentConfig, ConfigAgentBuilder};
@@ -228,6 +228,8 @@ impl ArenaComparison {
                     if let Some(ref pool) = self.config.thread_pool {
                         builder = builder.thread_pool(pool.clone());
                     }
+                    // Derive a deterministic per-agent seed from the runner's RNG
+                    builder = builder.rng_seed(rng.random::<u64>());
                     builder.build()
                 })
                 .collect();

--- a/src/arena/competition/holdem_competition.rs
+++ b/src/arena/competition/holdem_competition.rs
@@ -3,14 +3,17 @@ use std::{
     fmt::Debug,
 };
 
+use rand::Rng;
+
 use crate::arena::{HoldemSimulation, errors::HoldemSimulationError, game_state::Round};
 
 /// A  struct to help seeing which agent is likely to do well
 ///
 /// Each competition is a series of `HoldemSimulations`
 /// from the `HoldemSimulationGenerator` passed in.
-pub struct HoldemCompetition<T: Iterator<Item = HoldemSimulation>> {
+pub struct HoldemCompetition<T: Iterator<Item = HoldemSimulation>, R: Rng> {
     simulation_iterator: T,
+    rng: R,
     /// The number of rounds that have been run.
     pub num_rounds: usize,
 
@@ -35,15 +38,16 @@ pub struct HoldemCompetition<T: Iterator<Item = HoldemSimulation>> {
 
 const MAX_PLAYERS: usize = 12;
 
-impl<T: Iterator<Item = HoldemSimulation>> HoldemCompetition<T> {
+impl<T: Iterator<Item = HoldemSimulation>, R: Rng> HoldemCompetition<T, R> {
     /// Creates a new HoldemHandCompetition instance with the provided
     /// HoldemSimulation.
     ///
     /// Initializes the number of rounds to 0 and the stack change vectors to 0
     /// for each agent.
-    pub fn new(simulation_iterator: T) -> HoldemCompetition<T> {
+    pub fn new(simulation_iterator: T, rng: R) -> HoldemCompetition<T, R> {
         HoldemCompetition {
             simulation_iterator,
+            rng,
             max_sim_history: 100,
             // Set everything to zero
             num_rounds: 0,
@@ -63,13 +67,12 @@ impl<T: Iterator<Item = HoldemSimulation>> HoldemCompetition<T> {
         num_rounds: usize,
     ) -> Result<Vec<HoldemSimulation>, HoldemSimulationError> {
         let mut sims = VecDeque::with_capacity(self.max_sim_history);
-        let mut rand = rand::rng();
 
         for _round in 0..num_rounds {
             // Createa a new holdem simulation
             let mut running_sim = self.simulation_iterator.next().unwrap();
             // Run the sim
-            running_sim.run(&mut rand);
+            running_sim.run(&mut self.rng);
             // Update the stack change stats
             self.update_metrics(&running_sim);
             // Update the counter
@@ -130,7 +133,7 @@ impl<T: Iterator<Item = HoldemSimulation>> HoldemCompetition<T> {
     }
 }
 
-impl<T: Iterator<Item = HoldemSimulation>> Debug for HoldemCompetition<T> {
+impl<T: Iterator<Item = HoldemSimulation>, R: Rng> Debug for HoldemCompetition<T, R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HoldemCompetition")
             .field("num_rounds", &self.num_rounds)
@@ -173,7 +176,7 @@ mod tests {
             vec![], // no historians
             CloneGameStateGenerator::new(game_state),
         );
-        let mut competition = HoldemCompetition::new(sim_gen);
+        let mut competition = HoldemCompetition::new(sim_gen, rand::rng());
 
         let _first_results = competition.run(100).unwrap();
     }

--- a/src/arena/competition/tournament.rs
+++ b/src/arena/competition/tournament.rs
@@ -1,3 +1,4 @@
+use rand::Rng;
 use tracing::{event, trace_span};
 
 use crate::arena::{
@@ -28,12 +29,12 @@ pub struct TournamentResults {
     max_stacks: Vec<f32>,
     rounds: usize,
 }
-pub struct SingleTableTournament {
+pub struct SingleTableTournament<R: Rng> {
     agent_generators: Vec<Box<dyn AgentGenerator>>,
     historian_generators: Vec<Box<dyn HistorianGenerator>>,
     starting_game_state: GameState,
     panic_on_historian_error: bool,
-    // TODO should this include payouts?
+    rng: R,
 }
 impl TournamentResults {
     pub fn new(starting_stacks: &[f32]) -> Self {
@@ -106,7 +107,7 @@ impl SingleTableTournamentBuilder {
     }
 
     /// Builds the `SingleTableTournament` from the builder.
-    pub fn build(self) -> Result<SingleTableTournament, HoldemSimulationError> {
+    pub fn build<R: Rng>(self, rng: R) -> Result<SingleTableTournament<R>, HoldemSimulationError> {
         // Make sure that the needed properties are set
         let agent_builders = self
             .agent_generators
@@ -122,11 +123,12 @@ impl SingleTableTournamentBuilder {
             historian_generators: historian_builders,
             starting_game_state,
             panic_on_historian_error: self.panic_on_historian_error,
+            rng,
         })
     }
 }
 
-impl SingleTableTournament {
+impl<R: Rng> SingleTableTournament<R> {
     /// Run the single table tournament to completion.
     ///
     /// Returns a vector of the places that each agent finished in.
@@ -135,11 +137,9 @@ impl SingleTableTournament {
     /// Meaning `[2 , 1, 3, 4]` indicates that the first agent
     /// finished in second place, the second agent won, the third agent got
     /// third and the fourth agent finished in last.
-    pub fn run(self) -> Result<TournamentResults, HoldemSimulationError> {
+    pub fn run(mut self) -> Result<TournamentResults, HoldemSimulationError> {
         let span = trace_span!("SingleTableTournament::run");
         let _enter = span.enter();
-
-        let mut rand = rand::rng();
         // The place that we are about to assign to the next agent to bust out.
         let mut place = self.agent_generators.len();
         // Holds the results of the tournament.
@@ -167,7 +167,7 @@ impl SingleTableTournament {
                 .build()?;
 
             // Run the simulation
-            sim.run(&mut rand);
+            sim.run(&mut self.rng);
 
             // Update the results
             results.update_max(&sim.game_state.stacks);
@@ -270,7 +270,7 @@ mod tests {
         let tournament = SingleTableTournamentBuilder::default()
             .agent_generators(gens)
             .starting_game_state(game_state)
-            .build()
+            .build(rand::rng())
             .unwrap();
 
         let results = tournament.run().unwrap();
@@ -307,7 +307,7 @@ mod tests {
         let tournament = SingleTableTournamentBuilder::default()
             .agent_generators(agent_gens)
             .starting_game_state(game_state)
-            .build()
+            .build(rand::rng())
             .unwrap();
 
         let results = tournament.run().unwrap();

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -61,7 +61,7 @@
 //! let game_state_gen = RandomGameStateGenerator::new(3, 100.0, 500.0, 10.0, 5.0, 0.0);
 //! let sim_gen = StandardSimulationIterator::new(agent_gens, vec![], game_state_gen);
 //!
-//! let mut competition = HoldemCompetition::new(sim_gen);
+//! let mut competition = HoldemCompetition::new(sim_gen, rand::rng());
 //!
 //! let _first_results = competition.run(100).unwrap();
 //! let recent_results = competition.run(100).unwrap();
@@ -100,7 +100,7 @@
 //! let tournament = SingleTableTournamentBuilder::default()
 //!     .agent_generators(agent_gens)
 //!     .starting_game_state(game_state)
-//!     .build()
+//!     .build(rand::rng())
 //!     .unwrap();
 //!
 //! let results = tournament.run().unwrap();

--- a/src/bin/rsp/arena/generate.rs
+++ b/src/bin/rsp/arena/generate.rs
@@ -244,6 +244,7 @@ fn run_generation(args: &GenerateArgs, configs: &[AgentConfig]) -> Result<(), Ge
                 if let Some(ref pool) = thread_pool {
                     builder = builder.thread_pool(pool.clone());
                 }
+                builder = builder.rng_seed(rng.random::<u64>());
                 Ok(builder.build())
             })
             .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 //!     vec![], // no historians
 //!     CloneGameStateGenerator::new(game_state),
 //! );
-//! let mut competition = HoldemCompetition::new(sim_gen);
+//! let mut competition = HoldemCompetition::new(sim_gen, rand::rng());
 //! let _first_results = competition.run(100).unwrap();
 //! ```
 #![deny(clippy::all)]


### PR DESCRIPTION
Store RNG in HoldemCompetition and SingleTableTournament structs so
callers provide the RNG at construction time and run() stays clean.
Seed agents from the runner's RNG in the generate binary.
