### PR TITLE
fix: use self.rng instead of bare rng in arena generate

### DIFF
--- a/src/bin/rsp/arena/generate.rs
+++ b/src/bin/rsp/arena/generate.rs
@@ -255,7 +255,7 @@ impl<'a> GenerationContext<'a> {
                 if let Some(ref pool) = self.thread_pool {
                     builder = builder.thread_pool(pool.clone());
                 }
-                builder = builder.rng_seed(rng.random::<u64>());
+                builder = builder.rng_seed(self.rng.random::<u64>());
                 Ok(builder.build())
             })
             .collect();


### PR DESCRIPTION
The rng field must be accessed through self since it's a struct field.
