### PR TITLE
feat: enhance TUI with structured game log, BB-relative profits, and new filters

### DIFF
--- a/src/bin/rsp/arena/compare.rs
+++ b/src/bin/rsp/arena/compare.rs
@@ -100,7 +100,7 @@ fn build_comparison(args: &CompareArgs) -> Result<ArenaComparison, CompareError>
 }
 
 /// Convert a PermutationResult into a GameResult for the TUI.
-fn perm_to_game_result(perm: PermutationResult) -> GameResult {
+fn perm_to_game_result(perm: PermutationResult, big_blind: f32) -> GameResult {
     let num_players = perm.agent_names.len();
     let ending_round = ending_round_from_stats(&perm.stats, num_players);
     let profits: Vec<f32> = (0..num_players)
@@ -116,6 +116,7 @@ fn perm_to_game_result(perm: PermutationResult) -> GameResult {
         profits,
         ending_round,
         seat_stats,
+        big_blind,
     }
 }
 
@@ -125,6 +126,7 @@ fn run_comparison_background(
     tx: std::sync::mpsc::SyncSender<SimMessage<GameResult>>,
     hand_store: HandStore,
     ohh_path: Option<PathBuf>,
+    big_blind: f32,
 ) {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut prev_file_size: u64 = 0;
@@ -138,7 +140,7 @@ fn run_comparison_background(
                 prev_file_size = current_size;
             }
 
-            let game_result = perm_to_game_result(perm);
+            let game_result = perm_to_game_result(perm, big_blind);
             // If send fails, the TUI has quit — exit cleanly
             let _ = tx.send(SimMessage::GameResult(game_result));
         })
@@ -158,7 +160,10 @@ fn run_comparison_background(
 }
 
 /// Run comparison with the TUI dashboard.
-fn run_comparison_with_tui(comparison: ArenaComparison) -> Result<(), CompareError> {
+fn run_comparison_with_tui(
+    comparison: ArenaComparison,
+    big_blind: f32,
+) -> Result<(), CompareError> {
     let total_games = comparison.total_games();
 
     // Extract OHH path before moving comparison into background thread
@@ -182,7 +187,7 @@ fn run_comparison_with_tui(comparison: ArenaComparison) -> Result<(), CompareErr
     std::thread::Builder::new()
         .stack_size(STACK_SIZE)
         .spawn(move || {
-            run_comparison_background(comparison, tx, bg_hand_store, ohh_path);
+            run_comparison_background(comparison, tx, bg_hand_store, ohh_path, big_blind);
         })
         .expect("failed to spawn comparison thread");
 
@@ -211,7 +216,7 @@ pub fn run(mut args: CompareArgs, tui_flags: &TuiFlags) -> Result<(), CompareErr
 
     if tui_flags.should_use_tui() {
         comparison.print_configuration_summary();
-        run_comparison_with_tui(comparison)
+        run_comparison_with_tui(comparison, args.big_blind)
     } else {
         // Print configuration summary
         comparison.print_configuration_summary();

--- a/src/bin/rsp/arena/generate.rs
+++ b/src/bin/rsp/arena/generate.rs
@@ -461,6 +461,7 @@ fn run_generation_inner(
             profits,
             ending_round,
             seat_stats,
+            big_blind: args.big_blind,
         };
 
         // If send fails, the TUI has quit - exit cleanly

--- a/src/bin/rsp/ohh/stats.rs
+++ b/src/bin/rsp/ohh/stats.rs
@@ -91,6 +91,7 @@ pub fn build_state_from_hands(hands: &[HandHistory]) -> TuiState {
             profits,
             ending_round,
             seat_stats,
+            big_blind: hand.big_blind_amount,
         });
     }
 

--- a/src/bin/rsp/tui/app.rs
+++ b/src/bin/rsp/tui/app.rs
@@ -302,6 +302,10 @@ impl App {
                 self.state.active_panel = self.state.active_panel.next();
                 self.focus_effect = Some(effects::border_chase());
             }
+            KeyCode::BackTab => {
+                self.state.active_panel = self.state.active_panel.prev();
+                self.focus_effect = Some(effects::border_chase());
+            }
             KeyCode::Char('s') => {
                 self.state.sort_col = self.state.sort_col.next();
                 self.state.invalidate_display_cache();
@@ -358,12 +362,24 @@ impl App {
                     self.state.filter.toggle_winner(name);
                     self.reset_log_selection();
                 }
+                FilterItem::Loser(name) => {
+                    self.state.filter.toggle_loser(name);
+                    self.reset_log_selection();
+                }
                 FilterItem::Participant(name) => {
                     self.state.filter.toggle_participant(name);
                     self.reset_log_selection();
                 }
                 FilterItem::Street(round) => {
                     self.state.filter.toggle_street(*round);
+                    self.reset_log_selection();
+                }
+                FilterItem::WinSize(bucket) => {
+                    self.state.filter.toggle_win_size(*bucket);
+                    self.reset_log_selection();
+                }
+                FilterItem::LossSize(bucket) => {
+                    self.state.filter.toggle_loss_size(*bucket);
                     self.reset_log_selection();
                 }
                 FilterItem::PlayerCount(count) => {
@@ -473,12 +489,13 @@ impl App {
     pub fn handle_sim_message(&mut self, msg: SimMessage<GameResult>) {
         match msg {
             SimMessage::GameResult(result) => {
-                let entry = GameLogEntry {
-                    game_number: self.state.games_completed + 1,
-                    agent_names: result.agent_names.clone(),
-                    profits: result.profits.clone(),
-                    ending_round: result.ending_round,
-                };
+                let entry = GameLogEntry::new(
+                    self.state.games_completed + 1,
+                    result.agent_names.clone(),
+                    result.profits.clone(),
+                    result.ending_round,
+                    result.big_blind,
+                );
                 self.state.update(result);
                 self.filtered_log.on_new_game(&entry, &self.state.filter);
             }
@@ -659,6 +676,18 @@ mod tests {
     }
 
     #[test]
+    fn test_shift_tab_switches_panel_reverse() {
+        let mut app = App::new(Some(10));
+        assert_eq!(app.state.active_panel, Panel::Table);
+        app.handle_key(key(KeyCode::BackTab));
+        assert_eq!(app.state.active_panel, Panel::Filter);
+        app.handle_key(key(KeyCode::BackTab));
+        assert_eq!(app.state.active_panel, Panel::GameLog);
+        app.handle_key(key(KeyCode::BackTab));
+        assert_eq!(app.state.active_panel, Panel::Table);
+    }
+
+    #[test]
     fn test_s_cycles_sort_column() {
         let mut app = App::new(Some(10));
         use crate::tui::widgets::stats_table::SortColumn;
@@ -686,6 +715,7 @@ mod tests {
             profits: vec![10.0],
             ending_round: RoundLabel::Preflop,
             seat_stats: vec![SeatStats::default()],
+            big_blind: 10.0,
         };
         app.handle_sim_message(SimMessage::GameResult(result));
         assert_eq!(app.state.games_completed, 1);
@@ -712,6 +742,7 @@ mod tests {
             profits: profits.to_vec(),
             ending_round: round,
             seat_stats,
+            big_blind: 10.0,
         }));
     }
 
@@ -764,7 +795,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_panel_enter_toggles_item() {
+    fn test_filter_panel_enter_toggles_winner() {
         let mut app = App::new(Some(10));
         add_game(
             &mut app,
@@ -798,6 +829,79 @@ mod tests {
         app.state.filter.selected = 1; // Winner("Alice")
         app.handle_key(key(KeyCode::Char(' ')));
         assert!(app.state.filter.winners.contains("Alice"));
+    }
+
+    #[test]
+    fn test_filter_panel_enter_toggles_loser() {
+        let mut app = App::new(Some(10));
+        add_game(
+            &mut app,
+            &["Alice", "Bob"],
+            &[10.0, -10.0],
+            RoundLabel::River,
+        );
+
+        app.state.active_panel = Panel::Filter;
+        // Header "Winner" + 2 winners + Header "Loser" = index 3 is header
+        // index 4 is Loser("Alice")
+        app.state.filter.selected = 4;
+        app.handle_key(key(KeyCode::Enter));
+        assert!(app.state.filter.losers.contains("Alice"));
+
+        app.handle_key(key(KeyCode::Enter));
+        assert!(!app.state.filter.losers.contains("Alice"));
+    }
+
+    #[test]
+    fn test_filter_panel_enter_toggles_win_size() {
+        let mut app = App::new(Some(10));
+        add_game(
+            &mut app,
+            &["Alice", "Bob"],
+            &[10.0, -10.0],
+            RoundLabel::River,
+        );
+
+        app.state.active_panel = Panel::Filter;
+        // Winner(2) + Loser(2) + Participant(2) + headers(3) = 9
+        // + Header "Street" = 10, + 5 streets = 15
+        // + Header "Win Size" = 16, first WinSize = 17
+        // With 2 agents: indices are:
+        // 0: Header Winner, 1-2: winners, 3: Header Loser, 4-5: losers,
+        // 6: Header Participant, 7-8: participants,
+        // 9: Header Street, 10-14: streets,
+        // 15: Header Win Size, 16: WinSize(Small)
+        app.state.filter.selected = 16;
+        app.handle_key(key(KeyCode::Enter));
+        assert!(
+            app.state
+                .filter
+                .win_sizes
+                .contains(&crate::tui::state::ProfitBucket::Small)
+        );
+    }
+
+    #[test]
+    fn test_filter_panel_enter_toggles_loss_size() {
+        let mut app = App::new(Some(10));
+        add_game(
+            &mut app,
+            &["Alice", "Bob"],
+            &[10.0, -10.0],
+            RoundLabel::River,
+        );
+
+        app.state.active_panel = Panel::Filter;
+        // After Win Size section: 16-19 are WinSize buckets
+        // 20: Header Loss Size, 21: LossSize(Small)
+        app.state.filter.selected = 21;
+        app.handle_key(key(KeyCode::Enter));
+        assert!(
+            app.state
+                .filter
+                .loss_sizes
+                .contains(&crate::tui::state::ProfitBucket::Small)
+        );
     }
 
     #[test]

--- a/src/bin/rsp/tui/filtered_log.rs
+++ b/src/bin/rsp/tui/filtered_log.rs
@@ -126,12 +126,13 @@ impl FilteredGameLog {
             };
             match hand_store.fetch_entry(game_number) {
                 Ok(Some(entry)) => self.window_cache.push(entry),
-                _ => self.window_cache.push(GameLogEntry {
+                _ => self.window_cache.push(GameLogEntry::new(
                     game_number,
-                    agent_names: vec![],
-                    profits: vec![],
-                    ending_round: crate::tui::state::RoundLabel::Preflop,
-                }),
+                    vec![],
+                    vec![],
+                    crate::tui::state::RoundLabel::Preflop,
+                    0.0,
+                )),
             }
         }
     }
@@ -213,12 +214,7 @@ mod tests {
     fn test_on_new_game_no_filter() {
         let mut log = FilteredGameLog::new();
         let filter = FilterState::default();
-        let entry = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["A".into()],
-            profits: vec![1.0],
-            ending_round: RoundLabel::Preflop,
-        };
+        let entry = GameLogEntry::new(1, vec!["A".into()], vec![1.0], RoundLabel::Preflop, 10.0);
         log.on_new_game(&entry, &filter);
         assert_eq!(log.total(), 1);
     }
@@ -231,12 +227,7 @@ mod tests {
         let mut filter = FilterState::default();
         filter.toggle_street(RoundLabel::River);
 
-        let entry = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["A".into()],
-            profits: vec![1.0],
-            ending_round: RoundLabel::River,
-        };
+        let entry = GameLogEntry::new(1, vec!["A".into()], vec![1.0], RoundLabel::River, 10.0);
         log.on_new_game(&entry, &filter);
         assert_eq!(log.total(), 1);
         assert_eq!(log.game_number_at(0), Some(1));
@@ -250,12 +241,7 @@ mod tests {
         let mut filter = FilterState::default();
         filter.toggle_street(RoundLabel::River);
 
-        let entry = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["A".into()],
-            profits: vec![1.0],
-            ending_round: RoundLabel::Flop,
-        };
+        let entry = GameLogEntry::new(1, vec!["A".into()], vec![1.0], RoundLabel::Flop, 10.0);
         log.on_new_game(&entry, &filter);
         assert_eq!(log.total(), 0);
     }
@@ -300,12 +286,13 @@ mod tests {
     #[test]
     fn test_invalidate_clears_cache() {
         let mut log = FilteredGameLog::new();
-        log.window_cache.push(GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["A".into()],
-            profits: vec![1.0],
-            ending_round: RoundLabel::Preflop,
-        });
+        log.window_cache.push(GameLogEntry::new(
+            1,
+            vec!["A".into()],
+            vec![1.0],
+            RoundLabel::Preflop,
+            10.0,
+        ));
         assert_eq!(log.window_cache.len(), 1);
         log.invalidate();
         assert!(log.window_cache.is_empty());

--- a/src/bin/rsp/tui/screens/overview.rs
+++ b/src/bin/rsp/tui/screens/overview.rs
@@ -5,6 +5,7 @@ use ratatui::{
 
 use crate::tui::{
     state::{AgentDisplayData, GameLogEntry, Panel, TuiState},
+    theme,
     widgets::{
         filter_panel::render_filter_panel, game_log::render_game_log,
         profit_chart::render_profit_chart, progress_bar::render_progress,
@@ -101,6 +102,12 @@ pub fn render_overview(
         Layout::horizontal([Constraint::Percentage(70), Constraint::Percentage(30)])
             .split(main_chunks[1]);
 
+    let agent_colors: std::collections::HashMap<&str, ratatui::style::Color> = agents
+        .iter()
+        .enumerate()
+        .map(|(i, a)| (a.name.as_str(), theme::agent_color(i)))
+        .collect();
+
     render_game_log(
         frame,
         bottom_chunks[0],
@@ -108,6 +115,7 @@ pub fn render_overview(
         0,
         log_selected,
         log_focused,
+        &agent_colors,
     );
 
     let player_counts: Vec<usize> = state.distinct_player_counts.iter().copied().collect();

--- a/src/bin/rsp/tui/state.rs
+++ b/src/bin/rsp/tui/state.rs
@@ -254,6 +254,7 @@ pub struct GameResult {
     pub profits: Vec<f32>,
     pub ending_round: RoundLabel,
     pub seat_stats: Vec<SeatStats>,
+    pub big_blind: f32,
 }
 
 /// Simplified round label for display.
@@ -297,6 +298,8 @@ impl fmt::Display for RoundLabel {
 pub struct AgentDisplayData {
     pub name: String,
     pub total_profit: f32,
+    /// Cumulative profit in big blinds, accumulated per-game using each game's BB.
+    pub profit_bb: f32,
     pub games_played: usize,
     pub wins: usize,
     pub vpip_percent: f32,
@@ -335,12 +338,27 @@ impl StreetDistribution {
     }
 }
 
+fn toggle_in<T: Eq + std::hash::Hash>(set: &mut HashSet<T>, item: T) {
+    if !set.remove(&item) {
+        set.insert(item);
+    }
+}
+
+fn toggle_in_str(set: &mut HashSet<String>, name: &str) {
+    if !set.remove(name) {
+        set.insert(name.to_string());
+    }
+}
+
 /// Filter state for narrowing the game log and stats table.
 #[derive(Debug, Clone, Default)]
 pub struct FilterState {
     pub winners: HashSet<String>,
+    pub losers: HashSet<String>,
     pub participants: HashSet<String>,
     pub streets: HashSet<RoundLabel>,
+    pub win_sizes: HashSet<ProfitBucket>,
+    pub loss_sizes: HashSet<ProfitBucket>,
     pub player_counts: HashSet<usize>,
     /// Index of the selected item in the filter panel list.
     pub selected: usize,
@@ -349,55 +367,63 @@ pub struct FilterState {
 impl FilterState {
     pub fn is_active(&self) -> bool {
         !self.winners.is_empty()
+            || !self.losers.is_empty()
             || !self.participants.is_empty()
             || !self.streets.is_empty()
+            || !self.win_sizes.is_empty()
+            || !self.loss_sizes.is_empty()
             || !self.player_counts.is_empty()
     }
 
     pub fn clear(&mut self) {
         self.winners.clear();
+        self.losers.clear();
         self.participants.clear();
         self.streets.clear();
+        self.win_sizes.clear();
+        self.loss_sizes.clear();
         self.player_counts.clear();
     }
 
     pub fn toggle_winner(&mut self, name: &str) {
-        if !self.winners.remove(name) {
-            self.winners.insert(name.to_string());
-        }
+        toggle_in_str(&mut self.winners, name);
+    }
+
+    pub fn toggle_loser(&mut self, name: &str) {
+        toggle_in_str(&mut self.losers, name);
     }
 
     pub fn toggle_participant(&mut self, name: &str) {
-        if !self.participants.remove(name) {
-            self.participants.insert(name.to_string());
-        }
+        toggle_in_str(&mut self.participants, name);
     }
 
     pub fn toggle_street(&mut self, street: RoundLabel) {
-        if !self.streets.remove(&street) {
-            self.streets.insert(street);
-        }
+        toggle_in(&mut self.streets, street);
+    }
+
+    pub fn toggle_win_size(&mut self, bucket: ProfitBucket) {
+        toggle_in(&mut self.win_sizes, bucket);
+    }
+
+    pub fn toggle_loss_size(&mut self, bucket: ProfitBucket) {
+        toggle_in(&mut self.loss_sizes, bucket);
     }
 
     pub fn toggle_player_count(&mut self, count: usize) {
-        if !self.player_counts.remove(&count) {
-            self.player_counts.insert(count);
-        }
+        toggle_in(&mut self.player_counts, count);
     }
 
     /// Returns true if the given game log entry passes all active filters.
     /// Filters combine with AND across types: winner AND participant AND street.
     pub fn matches_entry(&self, entry: &GameLogEntry) -> bool {
-        // Winner filter: at least one winner in the entry matches
-        if !self.winners.is_empty() {
-            let has_winner = entry
-                .agent_names
-                .iter()
-                .zip(entry.profits.iter())
-                .any(|(name, profit)| *profit > 0.0 && self.winners.contains(name));
-            if !has_winner {
-                return false;
-            }
+        // Winner filter: entry's biggest winner matches
+        if !self.winners.is_empty() && !self.winners.contains(&entry.winner_name) {
+            return false;
+        }
+
+        // Loser filter: entry's biggest loser matches
+        if !self.losers.is_empty() && !self.losers.contains(&entry.loser_name) {
+            return false;
         }
 
         // Participant filter: at least one participant in the entry matches
@@ -416,6 +442,22 @@ impl FilterState {
             return false;
         }
 
+        // Win size filter: bucket of winner's profit in BB
+        if !self.win_sizes.is_empty() && entry.big_blind > 0.0 {
+            let bucket = ProfitBucket::from_bb(entry.winner_profit / entry.big_blind);
+            if !self.win_sizes.contains(&bucket) {
+                return false;
+            }
+        }
+
+        // Loss size filter: bucket of loser's loss in BB
+        if !self.loss_sizes.is_empty() && entry.big_blind > 0.0 {
+            let bucket = ProfitBucket::from_bb(entry.loser_loss.abs() / entry.big_blind);
+            if !self.loss_sizes.contains(&bucket) {
+                return false;
+            }
+        }
+
         // Player count filter: entry's player count matches one of the selected counts
         if !self.player_counts.is_empty() && !self.player_counts.contains(&entry.agent_names.len())
         {
@@ -426,16 +468,110 @@ impl FilterState {
     }
 }
 
+/// Bucket for categorizing profit/loss sizes in big blinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProfitBucket {
+    /// 0-5 big blinds.
+    Small,
+    /// 5-20 big blinds.
+    Medium,
+    /// 20-100 big blinds.
+    Large,
+    /// 100+ big blinds.
+    Huge,
+}
+
+impl ProfitBucket {
+    /// Classify an amount (in big blinds) into a bucket.
+    pub fn from_bb(amount_bb: f32) -> Self {
+        if amount_bb < 5.0 {
+            Self::Small
+        } else if amount_bb < 20.0 {
+            Self::Medium
+        } else if amount_bb < 100.0 {
+            Self::Large
+        } else {
+            Self::Huge
+        }
+    }
+
+    /// Human-readable label for this bucket.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Small => "0-5bb",
+            Self::Medium => "5-20bb",
+            Self::Large => "20-100bb",
+            Self::Huge => "100+bb",
+        }
+    }
+}
+
+impl fmt::Display for ProfitBucket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.label())
+    }
+}
+
+/// All profit buckets in order.
+pub const ALL_PROFIT_BUCKETS: [ProfitBucket; 4] = [
+    ProfitBucket::Small,
+    ProfitBucket::Medium,
+    ProfitBucket::Large,
+    ProfitBucket::Huge,
+];
+
 /// A single entry in the game log.
 #[derive(Debug, Clone)]
 pub struct GameLogEntry {
     pub game_number: usize,
     pub agent_names: Vec<String>,
-    pub profits: Vec<f32>,
     pub ending_round: RoundLabel,
+    pub winner_name: String,
+    pub winner_profit: f32,
+    pub loser_name: String,
+    pub loser_loss: f32,
+    pub pot_size: f32,
+    pub big_blind: f32,
 }
 
 impl GameLogEntry {
+    /// Create a new game log entry, computing derived fields from the raw data.
+    pub fn new(
+        game_number: usize,
+        agent_names: Vec<String>,
+        profits: Vec<f32>,
+        ending_round: RoundLabel,
+        big_blind: f32,
+    ) -> Self {
+        let (winner_name, winner_profit) = agent_names
+            .iter()
+            .zip(profits.iter())
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(n, &p)| (n.clone(), p))
+            .unwrap_or_default();
+
+        let (loser_name, loser_loss) = agent_names
+            .iter()
+            .zip(profits.iter())
+            .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(n, &p)| (n.clone(), p))
+            .unwrap_or_default();
+
+        let pot_size: f32 = profits.iter().filter(|&&p| p > 0.0).sum();
+
+        Self {
+            game_number,
+            agent_names,
+            ending_round,
+            winner_name,
+            winner_profit,
+            loser_name,
+            loser_loss,
+            pot_size,
+            big_blind,
+        }
+    }
+
     /// Create a `GameLogEntry` from an OHH `HandHistory`.
     pub fn from_hand(game_number: usize, hand: &HandHistory) -> Self {
         let agent_names: Vec<String> = hand.players.iter().map(|p| p.name.clone()).collect();
@@ -447,12 +583,13 @@ impl GameLogEntry {
             .map(|r| RoundLabel::from_street_name(&r.street))
             .unwrap_or(RoundLabel::Preflop);
 
-        Self {
+        Self::new(
             game_number,
             agent_names,
             profits,
             ending_round,
-        }
+            hand.big_blind_amount,
+        )
     }
 }
 
@@ -469,6 +606,8 @@ pub struct TuiState {
 
     /// Per-agent accumulated stats (keyed by agent name).
     agent_stats: HashMap<String, StatsStorage>,
+    /// Per-agent cumulative profit in big blinds (accumulated per-game).
+    agent_profit_bb: HashMap<String, f32>,
     /// Per-agent running profit history (cumulative).
     agent_profit_history: HashMap<String, Vec<f32>>,
     /// Street distribution tracker.
@@ -505,6 +644,14 @@ impl Panel {
             Self::Filter => Self::Table,
         }
     }
+
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Table => Self::Filter,
+            Self::GameLog => Self::Table,
+            Self::Filter => Self::GameLog,
+        }
+    }
 }
 
 impl TuiState {
@@ -517,6 +664,7 @@ impl TuiState {
             live: true,
             error: None,
             agent_stats: HashMap::new(),
+            agent_profit_bb: HashMap::new(),
             agent_profit_history: HashMap::new(),
             street_dist: StreetDistribution::default(),
             distinct_player_counts: BTreeSet::new(),
@@ -557,6 +705,12 @@ impl TuiState {
             *agent_profits.entry(name.as_str()).or_default() += result.profits[seat_idx];
         }
         for (name, profit) in agent_profits {
+            // Accumulate BB-relative profit for this game
+            if result.big_blind > 0.0 {
+                *self.agent_profit_bb.entry(name.to_string()).or_default() +=
+                    profit / result.big_blind;
+            }
+
             let history = self
                 .agent_profit_history
                 .entry(name.to_string())
@@ -581,10 +735,12 @@ impl TuiState {
             .iter()
             .map(|(name, stats)| {
                 let idx = 0;
+                let profit_bb = self.agent_profit_bb.get(name).copied().unwrap_or(0.0);
 
                 AgentDisplayData {
                     name: name.clone(),
                     total_profit: stats.total_profit[idx],
+                    profit_bb,
                     games_played: stats.hands_played[idx],
                     wins: stats.games_won[idx],
                     vpip_percent: stats.vpip_percent(idx),
@@ -602,8 +758,8 @@ impl TuiState {
         agents.sort_by(|a, b| match self.sort_col {
             SortColumn::Name => a.name.cmp(&b.name),
             SortColumn::Profit => b
-                .total_profit
-                .partial_cmp(&a.total_profit)
+                .profit_bb
+                .partial_cmp(&a.profit_bb)
                 .unwrap_or(std::cmp::Ordering::Equal),
             SortColumn::Games => b.games_played.cmp(&a.games_played),
             SortColumn::WinPct => {
@@ -736,6 +892,7 @@ mod tests {
             profits: profits.to_vec(),
             ending_round: round,
             seat_stats,
+            big_blind: 10.0,
         }
     }
 
@@ -954,15 +1111,71 @@ mod tests {
         assert!(!filter.is_active());
     }
 
+    fn make_entry(
+        game_number: usize,
+        names: &[&str],
+        profits: &[f32],
+        round: RoundLabel,
+    ) -> GameLogEntry {
+        GameLogEntry::new(
+            game_number,
+            names.iter().map(|s| s.to_string()).collect(),
+            profits.to_vec(),
+            round,
+            10.0,
+        )
+    }
+
+    #[test]
+    fn test_game_log_entry_new_derived_fields() {
+        let entry = make_entry(1, &["Alice", "Bob"], &[15.0, -15.0], RoundLabel::River);
+        assert_eq!(entry.winner_name, "Alice");
+        assert!((entry.winner_profit - 15.0).abs() < 0.01);
+        assert_eq!(entry.loser_name, "Bob");
+        assert!((entry.loser_loss - (-15.0)).abs() < 0.01);
+        assert!((entry.pot_size - 15.0).abs() < 0.01);
+        assert!((entry.big_blind - 10.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_game_log_entry_three_players() {
+        let entry = make_entry(
+            1,
+            &["A", "B", "C"],
+            &[20.0, -5.0, -15.0],
+            RoundLabel::Showdown,
+        );
+        assert_eq!(entry.winner_name, "A");
+        assert!((entry.winner_profit - 20.0).abs() < 0.01);
+        assert_eq!(entry.loser_name, "C");
+        assert!((entry.loser_loss - (-15.0)).abs() < 0.01);
+        assert!((entry.pot_size - 20.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_profit_bucket_from_bb() {
+        assert_eq!(ProfitBucket::from_bb(0.0), ProfitBucket::Small);
+        assert_eq!(ProfitBucket::from_bb(4.9), ProfitBucket::Small);
+        assert_eq!(ProfitBucket::from_bb(5.0), ProfitBucket::Medium);
+        assert_eq!(ProfitBucket::from_bb(19.9), ProfitBucket::Medium);
+        assert_eq!(ProfitBucket::from_bb(20.0), ProfitBucket::Large);
+        assert_eq!(ProfitBucket::from_bb(99.9), ProfitBucket::Large);
+        assert_eq!(ProfitBucket::from_bb(100.0), ProfitBucket::Huge);
+        assert_eq!(ProfitBucket::from_bb(500.0), ProfitBucket::Huge);
+    }
+
+    #[test]
+    fn test_profit_bucket_label() {
+        assert_eq!(ProfitBucket::Small.label(), "0-5bb");
+        assert_eq!(ProfitBucket::Medium.label(), "5-20bb");
+        assert_eq!(ProfitBucket::Large.label(), "20-100bb");
+        assert_eq!(ProfitBucket::Huge.label(), "100+bb");
+    }
+
     #[test]
     fn test_filter_matches_entry_no_filters() {
         let filter = FilterState::default();
-        let entry = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["Alice".into(), "Bob".into()],
-            profits: vec![10.0, -10.0],
-            ending_round: RoundLabel::River,
-        };
+        let entry = make_entry(1, &["Alice", "Bob"], &[10.0, -10.0], RoundLabel::River);
         assert!(filter.matches_entry(&entry));
     }
 
@@ -970,12 +1183,7 @@ mod tests {
     fn test_filter_matches_winner() {
         let mut filter = FilterState::default();
         filter.toggle_winner("Alice");
-        let entry = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["Alice".into(), "Bob".into()],
-            profits: vec![10.0, -10.0],
-            ending_round: RoundLabel::River,
-        };
+        let entry = make_entry(1, &["Alice", "Bob"], &[10.0, -10.0], RoundLabel::River);
         assert!(filter.matches_entry(&entry));
 
         // Bob is not a winner in this entry
@@ -985,15 +1193,22 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_matches_loser() {
+        let mut filter = FilterState::default();
+        filter.toggle_loser("Bob");
+        let entry = make_entry(1, &["Alice", "Bob"], &[10.0, -10.0], RoundLabel::River);
+        assert!(filter.matches_entry(&entry));
+
+        let mut filter2 = FilterState::default();
+        filter2.toggle_loser("Alice");
+        assert!(!filter2.matches_entry(&entry));
+    }
+
+    #[test]
     fn test_filter_matches_participant() {
         let mut filter = FilterState::default();
         filter.toggle_participant("Bob");
-        let entry = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["Alice".into(), "Bob".into()],
-            profits: vec![10.0, -10.0],
-            ending_round: RoundLabel::River,
-        };
+        let entry = make_entry(1, &["Alice", "Bob"], &[10.0, -10.0], RoundLabel::River);
         assert!(filter.matches_entry(&entry));
 
         let mut filter2 = FilterState::default();
@@ -1005,20 +1220,34 @@ mod tests {
     fn test_filter_matches_street() {
         let mut filter = FilterState::default();
         filter.toggle_street(RoundLabel::River);
-        let river_entry = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["A".into()],
-            profits: vec![1.0],
-            ending_round: RoundLabel::River,
-        };
-        let flop_entry = GameLogEntry {
-            game_number: 2,
-            agent_names: vec!["A".into()],
-            profits: vec![1.0],
-            ending_round: RoundLabel::Flop,
-        };
+        let river_entry = make_entry(1, &["A"], &[1.0], RoundLabel::River);
+        let flop_entry = make_entry(2, &["A"], &[1.0], RoundLabel::Flop);
         assert!(filter.matches_entry(&river_entry));
         assert!(!filter.matches_entry(&flop_entry));
+    }
+
+    #[test]
+    fn test_filter_matches_win_size() {
+        let mut filter = FilterState::default();
+        filter.toggle_win_size(ProfitBucket::Medium);
+        // 10.0 profit / 10.0 bb = 1.0bb => Small, should not match
+        let entry = make_entry(1, &["A", "B"], &[10.0, -10.0], RoundLabel::River);
+        assert!(!filter.matches_entry(&entry));
+        // 100.0 profit / 10.0 bb = 10.0bb => Medium, should match
+        let entry2 = make_entry(2, &["A", "B"], &[100.0, -100.0], RoundLabel::River);
+        assert!(filter.matches_entry(&entry2));
+    }
+
+    #[test]
+    fn test_filter_matches_loss_size() {
+        let mut filter = FilterState::default();
+        filter.toggle_loss_size(ProfitBucket::Large);
+        // loss = 10.0 / 10.0bb = 1.0bb => Small, should not match
+        let entry = make_entry(1, &["A", "B"], &[10.0, -10.0], RoundLabel::River);
+        assert!(!filter.matches_entry(&entry));
+        // loss = 500.0 / 10.0bb = 50.0bb => Large, should match
+        let entry2 = make_entry(2, &["A", "B"], &[500.0, -500.0], RoundLabel::River);
+        assert!(filter.matches_entry(&entry2));
     }
 
     #[test]
@@ -1028,30 +1257,15 @@ mod tests {
         filter.toggle_winner("Alice");
         filter.toggle_street(RoundLabel::River);
 
-        let matching = GameLogEntry {
-            game_number: 1,
-            agent_names: vec!["Alice".into(), "Bob".into()],
-            profits: vec![10.0, -10.0],
-            ending_round: RoundLabel::River,
-        };
+        let matching = make_entry(1, &["Alice", "Bob"], &[10.0, -10.0], RoundLabel::River);
         assert!(filter.matches_entry(&matching));
 
         // Alice wins but wrong street
-        let wrong_street = GameLogEntry {
-            game_number: 2,
-            agent_names: vec!["Alice".into(), "Bob".into()],
-            profits: vec![10.0, -10.0],
-            ending_round: RoundLabel::Flop,
-        };
+        let wrong_street = make_entry(2, &["Alice", "Bob"], &[10.0, -10.0], RoundLabel::Flop);
         assert!(!filter.matches_entry(&wrong_street));
 
         // Right street but Alice lost
-        let alice_lost = GameLogEntry {
-            game_number: 3,
-            agent_names: vec!["Alice".into(), "Bob".into()],
-            profits: vec![-10.0, 10.0],
-            ending_round: RoundLabel::River,
-        };
+        let alice_lost = make_entry(3, &["Alice", "Bob"], &[-10.0, 10.0], RoundLabel::River);
         assert!(!filter.matches_entry(&alice_lost));
     }
 

--- a/src/bin/rsp/tui/widgets/filter_panel.rs
+++ b/src/bin/rsp/tui/widgets/filter_panel.rs
@@ -1,16 +1,16 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{List, ListItem, ListState},
 };
 
 use crate::tui::{
-    state::{FilterState, RoundLabel},
+    state::{ALL_PROFIT_BUCKETS, FilterState, ProfitBucket, RoundLabel},
     theme::{
-        CHECK_OFF, CHECK_ON, GREEN, ICON_FILTER, MAUVE, OVERLAY1, PEACH, RED, SKY, SURFACE1, TEXT,
-        header_style, panel_block,
+        CHECK_OFF, CHECK_ON, FLAMINGO, GREEN, ICON_FILTER, MAUVE, OVERLAY1, PEACH, RED, SKY,
+        SURFACE1, TEXT, header_style, panel_block,
     },
 };
 
@@ -21,14 +21,33 @@ pub enum FilterItem {
     Header(String),
     /// A winner agent filter.
     Winner(String),
+    /// A loser (biggest loser) filter.
+    Loser(String),
     /// A participant agent filter.
     Participant(String),
     /// A street filter.
     Street(RoundLabel),
+    /// A win size bucket filter.
+    WinSize(ProfitBucket),
+    /// A loss size bucket filter.
+    LossSize(ProfitBucket),
     /// A player count filter.
     PlayerCount(usize),
     /// Clear all filters action.
     ClearAll,
+}
+
+/// Build a checkbox list item with consistent styling.
+fn checkbox_item(label: &str, checked: bool, active_color: Color) -> ListItem<'static> {
+    let (symbol, color) = if checked {
+        (CHECK_ON, active_color)
+    } else {
+        (CHECK_OFF, OVERLAY1)
+    };
+    ListItem::new(Line::from(vec![
+        Span::styled(format!(" {} ", symbol), Style::default().fg(color)),
+        Span::raw(label.to_string()),
+    ]))
 }
 
 /// Build the flat list of filter items from current agent names and player counts.
@@ -38,6 +57,11 @@ pub fn build_filter_items(agent_names: &[String], player_counts: &[usize]) -> Ve
     items.push(FilterItem::Header("Winner".into()));
     for name in agent_names {
         items.push(FilterItem::Winner(name.clone()));
+    }
+
+    items.push(FilterItem::Header("Loser".into()));
+    for name in agent_names {
+        items.push(FilterItem::Loser(name.clone()));
     }
 
     items.push(FilterItem::Header("Participant".into()));
@@ -51,6 +75,16 @@ pub fn build_filter_items(agent_names: &[String], player_counts: &[usize]) -> Ve
     items.push(FilterItem::Street(RoundLabel::Turn));
     items.push(FilterItem::Street(RoundLabel::River));
     items.push(FilterItem::Street(RoundLabel::Showdown));
+
+    items.push(FilterItem::Header("Win Size".into()));
+    for &bucket in &ALL_PROFIT_BUCKETS {
+        items.push(FilterItem::WinSize(bucket));
+    }
+
+    items.push(FilterItem::Header("Loss Size".into()));
+    for &bucket in &ALL_PROFIT_BUCKETS {
+        items.push(FilterItem::LossSize(bucket));
+    }
 
     if !player_counts.is_empty() {
         items.push(FilterItem::Header("Players".into()));
@@ -82,54 +116,25 @@ pub fn render_filter_panel(
                 format!("─── {} ───", label),
                 header_style(),
             ))),
-            FilterItem::Winner(name) => {
-                let checked = filter.winners.contains(name);
-                let (symbol, color) = if checked {
-                    (CHECK_ON, GREEN)
-                } else {
-                    (CHECK_OFF, OVERLAY1)
-                };
-                ListItem::new(Line::from(vec![
-                    Span::styled(format!(" {} ", symbol), Style::default().fg(color)),
-                    Span::raw(name.as_str()),
-                ]))
-            }
+            FilterItem::Winner(name) => checkbox_item(name, filter.winners.contains(name), GREEN),
+            FilterItem::Loser(name) => checkbox_item(name, filter.losers.contains(name), RED),
             FilterItem::Participant(name) => {
-                let checked = filter.participants.contains(name);
-                let (symbol, color) = if checked {
-                    (CHECK_ON, SKY)
-                } else {
-                    (CHECK_OFF, OVERLAY1)
-                };
-                ListItem::new(Line::from(vec![
-                    Span::styled(format!(" {} ", symbol), Style::default().fg(color)),
-                    Span::raw(name.as_str()),
-                ]))
+                checkbox_item(name, filter.participants.contains(name), SKY)
             }
             FilterItem::Street(round) => {
-                let checked = filter.streets.contains(round);
-                let (symbol, color) = if checked {
-                    (CHECK_ON, MAUVE)
-                } else {
-                    (CHECK_OFF, OVERLAY1)
-                };
-                ListItem::new(Line::from(vec![
-                    Span::styled(format!(" {} ", symbol), Style::default().fg(color)),
-                    Span::raw(format!("{}", round)),
-                ]))
+                checkbox_item(&format!("{}", round), filter.streets.contains(round), MAUVE)
             }
-            FilterItem::PlayerCount(count) => {
-                let checked = filter.player_counts.contains(count);
-                let (symbol, color) = if checked {
-                    (CHECK_ON, PEACH)
-                } else {
-                    (CHECK_OFF, OVERLAY1)
-                };
-                ListItem::new(Line::from(vec![
-                    Span::styled(format!(" {} ", symbol), Style::default().fg(color)),
-                    Span::raw(format!("{}-player", count)),
-                ]))
+            FilterItem::WinSize(bucket) => {
+                checkbox_item(bucket.label(), filter.win_sizes.contains(bucket), GREEN)
             }
+            FilterItem::LossSize(bucket) => {
+                checkbox_item(bucket.label(), filter.loss_sizes.contains(bucket), FLAMINGO)
+            }
+            FilterItem::PlayerCount(count) => checkbox_item(
+                &format!("{}-player", count),
+                filter.player_counts.contains(count),
+                PEACH,
+            ),
             FilterItem::ClearAll => ListItem::new(Line::from(Span::styled(
                 "  ✕ Clear All",
                 Style::default().fg(RED).add_modifier(Modifier::BOLD),
@@ -158,29 +163,53 @@ mod tests {
         let names = vec!["Alice".into(), "Bob".into()];
         let items = build_filter_items(&names, &[2, 6]);
 
-        // Header "Winner" + 2 winners + Header "Participant" + 2 participants
-        // + Header "Street" + 5 streets + Header "Players" + 2 counts + ClearAll = 16
-        assert_eq!(items.len(), 16);
+        // Header "Winner" + 2 winners
+        // + Header "Loser" + 2 losers
+        // + Header "Participant" + 2 participants
+        // + Header "Street" + 5 streets
+        // + Header "Win Size" + 4 buckets
+        // + Header "Loss Size" + 4 buckets
+        // + Header "Players" + 2 counts
+        // + ClearAll
+        // = 7 headers + 2+2+2+5+4+4+2 items + 1 ClearAll = 29
+        assert_eq!(items.len(), 29);
 
         assert!(matches!(&items[0], FilterItem::Header(s) if s == "Winner"));
         assert!(matches!(&items[1], FilterItem::Winner(s) if s == "Alice"));
         assert!(matches!(&items[2], FilterItem::Winner(s) if s == "Bob"));
-        assert!(matches!(&items[3], FilterItem::Header(s) if s == "Participant"));
-        assert!(matches!(&items[4], FilterItem::Participant(s) if s == "Alice"));
-        assert!(matches!(&items[5], FilterItem::Participant(s) if s == "Bob"));
-        assert!(matches!(&items[6], FilterItem::Header(s) if s == "Street"));
-        assert!(matches!(&items[7], FilterItem::Street(RoundLabel::Preflop)));
-        assert!(matches!(&items[12], FilterItem::Header(s) if s == "Players"));
-        assert!(matches!(&items[13], FilterItem::PlayerCount(2)));
-        assert!(matches!(&items[14], FilterItem::PlayerCount(6)));
-        assert!(matches!(&items[15], FilterItem::ClearAll));
+        assert!(matches!(&items[3], FilterItem::Header(s) if s == "Loser"));
+        assert!(matches!(&items[4], FilterItem::Loser(s) if s == "Alice"));
+        assert!(matches!(&items[5], FilterItem::Loser(s) if s == "Bob"));
+        assert!(matches!(&items[6], FilterItem::Header(s) if s == "Participant"));
+        assert!(matches!(&items[7], FilterItem::Participant(s) if s == "Alice"));
+        assert!(matches!(&items[8], FilterItem::Participant(s) if s == "Bob"));
+        assert!(matches!(&items[9], FilterItem::Header(s) if s == "Street"));
+        assert!(matches!(
+            &items[10],
+            FilterItem::Street(RoundLabel::Preflop)
+        ));
+        assert!(matches!(&items[15], FilterItem::Header(s) if s == "Win Size"));
+        assert!(matches!(
+            &items[16],
+            FilterItem::WinSize(ProfitBucket::Small)
+        ));
+        assert!(matches!(&items[20], FilterItem::Header(s) if s == "Loss Size"));
+        assert!(matches!(
+            &items[21],
+            FilterItem::LossSize(ProfitBucket::Small)
+        ));
+        assert!(matches!(&items[25], FilterItem::Header(s) if s == "Players"));
+        assert!(matches!(&items[26], FilterItem::PlayerCount(2)));
+        assert!(matches!(&items[27], FilterItem::PlayerCount(6)));
+        assert!(matches!(&items[28], FilterItem::ClearAll));
     }
 
     #[test]
     fn test_build_filter_items_empty_agents() {
         let items = build_filter_items(&[], &[]);
-        // 3 headers + 5 streets + ClearAll = 9
-        assert_eq!(items.len(), 9);
+        // 6 headers (Winner, Loser, Participant, Street, Win Size, Loss Size)
+        // + 0+0+0+5+4+4 items + ClearAll = 20
+        assert_eq!(items.len(), 20);
     }
 
     #[test]

--- a/src/bin/rsp/tui/widgets/game_log.rs
+++ b/src/bin/rsp/tui/widgets/game_log.rs
@@ -1,36 +1,36 @@
+use std::collections::HashMap;
+
 use ratatui::{
     Frame,
-    layout::Rect,
-    style::Style,
-    text::{Line, Span},
-    widgets::{List, ListItem, ListState},
+    layout::{Constraint, Rect},
+    style::{Color, Style},
+    widgets::{Cell, Row, Table, TableState},
 };
 
 use crate::tui::{
     state::GameLogEntry,
-    theme::{ICON_GAMES, OVERLAY0, SURFACE1, TEXT, panel_block, profit_style},
+    theme::{ICON_GAMES, OVERLAY0, SURFACE1, TEXT, header_style, panel_block, profit_style},
 };
 
-fn entry_to_list_item(entry: &GameLogEntry) -> ListItem<'static> {
-    let mut spans = vec![Span::styled(
-        format!("#{:<5} ", entry.game_number),
-        Style::default().fg(OVERLAY0),
-    )];
-
-    for (name, profit) in entry.agent_names.iter().zip(entry.profits.iter()) {
-        spans.push(Span::raw(format!("{} ", name)));
-        spans.push(Span::styled(
-            format!("{:+.0} ", profit),
-            profit_style(*profit),
-        ));
-    }
-
-    spans.push(Span::styled(
-        format!("({})", entry.ending_round),
-        Style::default().fg(OVERLAY0),
-    ));
-
-    ListItem::new(Line::from(spans))
+fn entry_to_row(entry: &GameLogEntry, agent_colors: &HashMap<&str, Color>) -> Row<'static> {
+    let winner_color = agent_colors
+        .get(entry.winner_name.as_str())
+        .copied()
+        .unwrap_or(TEXT);
+    let loser_color = agent_colors
+        .get(entry.loser_name.as_str())
+        .copied()
+        .unwrap_or(TEXT);
+    let cells = vec![
+        Cell::from(format!("{}", entry.game_number)).style(Style::default().fg(OVERLAY0)),
+        Cell::from(entry.winner_name.clone()).style(Style::default().fg(winner_color)),
+        Cell::from(format!("{:+.0}", entry.winner_profit)).style(profit_style(entry.winner_profit)),
+        Cell::from(entry.loser_name.clone()).style(Style::default().fg(loser_color)),
+        Cell::from(format!("{:+.0}", entry.loser_loss)).style(profit_style(entry.loser_loss)),
+        Cell::from(format!("{:.0}", entry.pot_size)).style(Style::default().fg(TEXT)),
+        Cell::from(format!("{}", entry.ending_round)).style(Style::default().fg(OVERLAY0)),
+    ];
+    Row::new(cells)
 }
 
 pub fn render_game_log(
@@ -40,18 +40,40 @@ pub fn render_game_log(
     scroll: usize,
     selected: Option<usize>,
     focused: bool,
+    agent_colors: &HashMap<&str, Color>,
 ) {
-    // Virtualize: only build ListItems for the visible window.
-    // The block border + title consume 2 rows.
-    let visible_rows = area.height.saturating_sub(2) as usize;
+    // Virtualize: only build Rows for the visible window.
+    // The block border + title + header consume rows.
+    let visible_rows = area.height.saturating_sub(5) as usize;
     let window_end = (scroll + visible_rows + 1).min(log.len());
     let window_start = scroll.min(window_end);
     let window = &log[window_start..window_end];
 
-    let items: Vec<ListItem> = window
+    let header_cells = vec![
+        Cell::from("#").style(header_style()),
+        Cell::from("Winner").style(header_style()),
+        Cell::from("Win").style(header_style()),
+        Cell::from("Loser").style(header_style()),
+        Cell::from("Loss").style(header_style()),
+        Cell::from("Pot").style(header_style()),
+        Cell::from("Street").style(header_style()),
+    ];
+    let header = Row::new(header_cells).height(1).bottom_margin(1);
+
+    let rows: Vec<Row> = window
         .iter()
-        .map(|entry| entry_to_list_item(entry))
+        .map(|entry| entry_to_row(entry, agent_colors))
         .collect();
+
+    let widths = [
+        Constraint::Length(7),
+        Constraint::Min(10),
+        Constraint::Length(8),
+        Constraint::Min(10),
+        Constraint::Length(8),
+        Constraint::Length(8),
+        Constraint::Length(9),
+    ];
 
     // Adjust selected to be relative to the window start
     let relative_selected = selected.and_then(|s| s.checked_sub(window_start));
@@ -59,44 +81,57 @@ pub fn render_game_log(
     let title = format!("{} Recent Games", ICON_GAMES);
     let block = panel_block(&title, focused);
 
-    let list = List::new(items)
+    let table = Table::new(rows, widths)
+        .header(header)
         .block(block)
-        .highlight_style(Style::default().bg(SURFACE1).fg(TEXT));
+        .row_highlight_style(Style::default().bg(SURFACE1).fg(TEXT));
 
-    let mut state = ListState::default();
+    let mut state = TableState::default();
     state.select(relative_selected);
 
-    frame.render_stateful_widget(list, area, &mut state);
+    frame.render_stateful_widget(table, area, &mut state);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tui::state::RoundLabel;
+    use crate::tui::theme;
     use insta::assert_snapshot;
     use ratatui::{Terminal, backend::TestBackend};
+
+    fn test_agent_colors<'a>(names: &'a [&'a str]) -> HashMap<&'a str, Color> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(i, &n)| (n, theme::agent_color(i)))
+            .collect()
+    }
 
     #[test]
     fn test_render_game_log() {
         let backend = TestBackend::new(80, 12);
         let mut terminal = Terminal::new(backend).unwrap();
         let entries = [
-            GameLogEntry {
-                game_number: 1,
-                agent_names: vec!["Alice".into(), "Bob".into()],
-                profits: vec![15.0, -15.0],
-                ending_round: RoundLabel::River,
-            },
-            GameLogEntry {
-                game_number: 2,
-                agent_names: vec!["Alice".into(), "Bob".into()],
-                profits: vec![-5.0, 5.0],
-                ending_round: RoundLabel::Flop,
-            },
+            GameLogEntry::new(
+                1,
+                vec!["Alice".into(), "Bob".into()],
+                vec![15.0, -15.0],
+                RoundLabel::River,
+                10.0,
+            ),
+            GameLogEntry::new(
+                2,
+                vec!["Alice".into(), "Bob".into()],
+                vec![-5.0, 5.0],
+                RoundLabel::Flop,
+                10.0,
+            ),
         ];
+        let colors = test_agent_colors(&["Alice", "Bob"]);
         terminal
             .draw(|frame| {
-                render_game_log(frame, frame.area(), &entries, 0, None, true);
+                render_game_log(frame, frame.area(), &entries, 0, None, true, &colors);
             })
             .unwrap();
         assert_snapshot!(terminal.backend());
@@ -106,9 +141,10 @@ mod tests {
     fn test_render_game_log_empty() {
         let backend = TestBackend::new(80, 8);
         let mut terminal = Terminal::new(backend).unwrap();
+        let colors = HashMap::new();
         terminal
             .draw(|frame| {
-                render_game_log(frame, frame.area(), &[], 0, None, false);
+                render_game_log(frame, frame.area(), &[], 0, None, false, &colors);
             })
             .unwrap();
         assert_snapshot!(terminal.backend());
@@ -117,23 +153,27 @@ mod tests {
     #[test]
     fn test_virtualized_only_builds_visible_items() {
         // Create 10000 entries but render in a 12-row area (10 visible rows).
-        // This should NOT build 10000 ListItems.
+        // This should NOT build 10000 Rows.
         let entries: Vec<GameLogEntry> = (1..=10_000)
-            .map(|i| GameLogEntry {
-                game_number: i,
-                agent_names: vec!["A".into()],
-                profits: vec![1.0],
-                ending_round: RoundLabel::Preflop,
-            })
+            .map(|i| GameLogEntry::new(i, vec!["A".into()], vec![1.0], RoundLabel::Preflop, 10.0))
             .collect();
 
         let backend = TestBackend::new(80, 12);
         let mut terminal = Terminal::new(backend).unwrap();
+        let colors = test_agent_colors(&["A"]);
 
         // Scroll to middle (game 5000)
         terminal
             .draw(|frame| {
-                render_game_log(frame, frame.area(), &entries, 5000, Some(5000), true);
+                render_game_log(
+                    frame,
+                    frame.area(),
+                    &entries,
+                    5000,
+                    Some(5000),
+                    true,
+                    &colors,
+                );
             })
             .unwrap();
 
@@ -148,7 +188,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         assert!(
-            content.contains("#5001"),
+            content.contains("5001"),
             "Should show game #5001 at scroll=5000"
         );
         assert!(

--- a/src/bin/rsp/tui/widgets/progress_bar.rs
+++ b/src/bin/rsp/tui/widgets/progress_bar.rs
@@ -81,7 +81,7 @@ fn render_live_progress(frame: &mut Frame, area: Rect, state: &TuiState) {
         .unwrap_or_else(|| "--:--".to_string());
 
     let mut spans = vec![
-        Span::styled(format!(" {:.0} g/s", gps), Style::default().fg(SKY)),
+        Span::styled(format!(" {:.1} g/s", gps), Style::default().fg(SKY)),
         Span::styled(
             format!(" │ {} │ ETA {} │ ", elapsed_str, eta_str),
             Style::default().fg(SUBTEXT0),

--- a/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log.snap
+++ b/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log.snap
@@ -3,10 +3,10 @@ source: src/bin/rsp/tui/widgets/game_log.rs
 expression: terminal.backend()
 ---
 "╭ ♥ Recent Games ──────────────────────────────────────────────────────────────╮"
-"│ #1     Alice +15 Bob -15 (river)                                             │"
-"│ #2     Alice -5 Bob +5 (flop)                                                │"
+"│ #       Winner          Win      Loser           Loss     Pot      Street    │"
 "│                                                                              │"
-"│                                                                              │"
+"│ 1       Alice           +15      Bob             -15      15       river     │"
+"│ 2       Bob             +5       Alice           -5       5        flop      │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log_empty.snap
+++ b/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log_empty.snap
@@ -3,7 +3,7 @@ source: src/bin/rsp/tui/widgets/game_log.rs
 expression: terminal.backend()
 ---
 "╭ ♥ Recent Games ──────────────────────────────────────────────────────────────╮"
-"│                                                                              │"
+"│ #       Winner          Win      Loser           Loss     Pot      Street    │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__stats_table__tests__render_stats_table.snap
+++ b/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__stats_table__tests__render_stats_table.snap
@@ -3,10 +3,10 @@ source: src/bin/rsp/tui/widgets/stats_table.rs
 expression: terminal.backend()
 ---
 "╭ ♠ Agent Rankings ────────────────────────────────────────────────────────────────────────────────────────────────────╮"
-"│ Agent                         Profit ▲   Games   Win%   ROI%    VPIP%   PFR%   3Bet%  AF     CBet%   WTSD%   W$SD%   │"
+"│ Agent                         Profit(bb) Games   Win%   ROI%    VPIP%   PFR%   3Bet%  AF     CBet%   WTSD%   W$SD%   │"
 "│                                                                                                                      │"
-"│ Alice                         +150.0     100     55.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
-"│ Bob                           -50.0      100     45.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
+"│ Alice                         +15.0      100     55.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
+"│ Bob                           -5.0       100     45.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"

--- a/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__stats_table__tests__render_stats_table_empty.snap
+++ b/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__stats_table__tests__render_stats_table_empty.snap
@@ -3,7 +3,7 @@ source: src/bin/rsp/tui/widgets/stats_table.rs
 expression: terminal.backend()
 ---
 "╭ ♠ Agent Rankings ────────────────────────────────────────────────────────────────────────────────────────────────────╮"
-"│ Agent                         Profit ▲   Games   Win%   ROI%    VPIP%   PFR%   3Bet%  AF     CBet%   WTSD%   W$SD%   │"
+"│ Agent                         Profit(bb) Games   Win%   ROI%    VPIP%   PFR%   3Bet%  AF     CBet%   WTSD%   W$SD%   │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"

--- a/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__stats_table__tests__render_stats_table_with_selection.snap
+++ b/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__stats_table__tests__render_stats_table_with_selection.snap
@@ -3,10 +3,10 @@ source: src/bin/rsp/tui/widgets/stats_table.rs
 expression: terminal.backend()
 ---
 "╭ ♠ Agent Rankings ────────────────────────────────────────────────────────────────────────────────────────────────────╮"
-"│ Agent                         Profit ▲   Games   Win%   ROI%    VPIP%   PFR%   3Bet%  AF     CBet%   WTSD%   W$SD%   │"
+"│ Agent                         Profit(bb) Games   Win%   ROI%    VPIP%   PFR%   3Bet%  AF     CBet%   WTSD%   W$SD%   │"
 "│                                                                                                                      │"
-"│ Alice                         +150.0     100     55.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
-"│ Bob                           -50.0      100     45.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
+"│ Alice                         +15.0      100     55.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
+"│ Bob                           -5.0       100     45.0   5.0     25.0    18.0   8.0    2.50   60.0    30.0    55.0    │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"

--- a/src/bin/rsp/tui/widgets/stats_table.rs
+++ b/src/bin/rsp/tui/widgets/stats_table.rs
@@ -51,7 +51,7 @@ impl SortColumn {
     fn header(&self) -> &'static str {
         match self {
             Self::Name => "Agent",
-            Self::Profit => "Profit",
+            Self::Profit => "Profit(bb)",
             Self::Games => "Games",
             Self::WinPct => "Win%",
             Self::Roi => "ROI%",
@@ -114,8 +114,7 @@ pub fn render_stats_table(
 
             let cells = vec![
                 Cell::from(agent.name.clone()).style(Style::default().fg(theme::agent_color(idx))),
-                Cell::from(format!("{:+.1}", agent.total_profit))
-                    .style(profit_style(agent.total_profit)),
+                Cell::from(format!("{:+.1}", agent.profit_bb)).style(profit_style(agent.profit_bb)),
                 Cell::from(format!("{}", agent.games_played)).style(Style::default().fg(TEXT)),
                 Cell::from(format!("{:.1}", win_pct)).style(Style::default().fg(TEXT)),
                 Cell::from(format!("{:.1}", agent.roi_percent)).style(Style::default().fg(TEXT)),
@@ -179,6 +178,7 @@ mod tests {
         AgentDisplayData {
             name: name.to_string(),
             total_profit: profit,
+            profit_bb: profit / 10.0,
             games_played: games,
             wins,
             vpip_percent: 25.0,


### PR DESCRIPTION
Redesign the game log from a flat list into a columnar table showing winner,
loser, pot size, and street with agent-colored names. Display profits in big
blinds throughout the stats table. Add loser, win-size, and loss-size bucket
filters to the filter panel. Support Shift+Tab for reverse panel navigation.
