### PR TITLE
fix: allow active players to respond to all-in bets in run_betting_round

### DIFF
--- a/src/arena/agent/replay.rs
+++ b/src/arena/agent/replay.rs
@@ -582,6 +582,93 @@ mod tests {
         );
     }
 
+    /// When the BB forces a player all-in (BB > their stack), the SB must
+    /// still get to fold or call, and the all-in BB must NOT get to act.
+    #[test]
+    fn test_forced_all_in_bb_sb_acts_bb_does_not() {
+        use crate::arena::action::Action;
+        use crate::arena::game_state::Round;
+        use crate::arena::historian::{self, VecHistorian};
+
+        // Player 0 (dealer/SB): stack=1000, will fold
+        // Player 1 (BB): stack=8, BB=10 → forced all-in posting BB
+        //
+        // BB posts 8 (all their chips). SB must still decide.
+        // BB should never get to act voluntarily.
+        let agent_zero = boxed_vec_agent_with_default(vec![AgentAction::Fold], AgentAction::Fold);
+
+        // If BB were ever asked to act, this would produce a Call.
+        // We'll assert it never happens.
+        let agent_one = boxed_vec_agent_with_default(vec![AgentAction::Call], AgentAction::Call);
+
+        let game_state = GameStateBuilder::new()
+            .stacks(vec![1000.0, 8.0])
+            .blinds(10.0, 5.0)
+            .build()
+            .unwrap();
+        let agents: Vec<Box<dyn Agent>> = vec![agent_zero, agent_one];
+        let mut rng = StdRng::seed_from_u64(99);
+
+        let vec_hist = Box::new(VecHistorian::new());
+        let vec_storage = vec_hist.get_storage();
+        let historians: Vec<Box<dyn historian::Historian>> = vec![vec_hist];
+
+        let mut sim: HoldemSimulation = HoldemSimulationBuilder::default()
+            .game_state(game_state)
+            .agents(agents)
+            .historians(historians)
+            .build()
+            .unwrap();
+
+        sim.run(&mut rng);
+
+        assert_valid_round_data(&sim.game_state.round_data);
+        assert_valid_game_state(&sim.game_state);
+
+        let records = vec_storage.borrow();
+        let preflop_played: Vec<_> = records
+            .iter()
+            .filter_map(|r| match &r.action {
+                Action::PlayedAction(a) if a.round == Round::Preflop => Some(a),
+                Action::FailedAction(f) if f.result.round == Round::Preflop => Some(&f.result),
+                _ => None,
+            })
+            .collect();
+
+        // SB (Player 0) should have exactly one preflop action: Fold
+        let sb_actions: Vec<_> = preflop_played.iter().filter(|a| a.idx == 0).collect();
+        assert_eq!(
+            sb_actions.len(),
+            1,
+            "SB should act exactly once on preflop, got {} actions: {:?}",
+            sb_actions.len(),
+            sb_actions
+                .iter()
+                .map(|a| format!("{:?}", a.action))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            matches!(sb_actions[0].action, AgentAction::Fold),
+            "SB should fold, got {:?}",
+            sb_actions[0].action
+        );
+
+        // BB (Player 1) should have ZERO voluntary preflop actions.
+        // They were forced all-in by the blind — no decision to make.
+        let bb_actions: Vec<_> = preflop_played.iter().filter(|a| a.idx == 1).collect();
+        assert_eq!(
+            bb_actions.len(),
+            0,
+            "BB (forced all-in by blind) should not act on preflop, \
+             but got {} actions: {:?}",
+            bb_actions.len(),
+            bb_actions
+                .iter()
+                .map(|a| format!("{:?}", a.action))
+                .collect::<Vec<_>>()
+        );
+    }
+
     /// Test that all-in players should not have any actions on subsequent streets.
     /// When both players go all-in preflop, the simulation should not ask them
     /// to act on flop/turn/river, and no Check actions should be recorded.
@@ -659,5 +746,239 @@ mod tests {
             assert_valid_open_hand_history(hand);
             assert_open_hand_history_matches_game_state(hand, &sim.game_state);
         }
+    }
+
+    /// When a player goes all-in on the river, the remaining active player
+    /// must still get to act (fold or call). This is a regression test for a
+    /// bug where `run_betting_round` skipped the round because only one
+    /// player was in `player_active`, even though the active player had an
+    /// unmatched bet to respond to.
+    #[test]
+    fn test_player_acts_after_opponent_river_all_in() {
+        use crate::arena::action::Action;
+        use crate::arena::game_state::Round;
+        use crate::arena::historian::{self, VecHistorian};
+
+        // Player 0 (dealer/SB): stack=100, goes all-in on river
+        // Player 1 (BB): stack=100, calls throughout, then folds to river all-in
+        //
+        // Preflop: both call (match blinds)
+        // Flop/Turn: both check
+        // River: Player 0 goes all-in, Player 1 must fold/call
+
+        // Player 0 (dealer/SB in heads-up):
+        // - Posts SB (forced)
+        // - Preflop: Calls BB
+        // - Flop: Checks (Bet(0) = check)
+        // - Turn: Checks
+        // - River: Goes all-in
+        let agent_zero = boxed_vec_agent_with_default(
+            vec![
+                AgentAction::Call,     // preflop: call BB
+                AgentAction::Bet(0.0), // flop: check
+                AgentAction::Bet(0.0), // turn: check
+                AgentAction::AllIn,    // river: all-in
+            ],
+            AgentAction::Fold,
+        );
+
+        // Player 1 (BB in heads-up):
+        // - Posts BB (forced)
+        // - Preflop: Checks
+        // - Flop: Checks
+        // - Turn: Checks
+        // - River: Folds to the all-in
+        let agent_one = boxed_vec_agent_with_default(
+            vec![
+                AgentAction::Call,     // preflop: check
+                AgentAction::Bet(0.0), // flop: check
+                AgentAction::Bet(0.0), // turn: check
+                AgentAction::Fold,     // river: fold to all-in
+            ],
+            AgentAction::Fold,
+        );
+
+        let game_state = GameStateBuilder::new()
+            .stacks(vec![100.0, 100.0])
+            .blinds(10.0, 5.0)
+            .build()
+            .unwrap();
+        let agents: Vec<Box<dyn Agent>> = vec![agent_zero, agent_one];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let vec_hist = Box::new(VecHistorian::new());
+        let vec_storage = vec_hist.get_storage();
+        let historians: Vec<Box<dyn historian::Historian>> = vec![vec_hist];
+
+        let mut sim: HoldemSimulation = HoldemSimulationBuilder::default()
+            .game_state(game_state)
+            .agents(agents)
+            .historians(historians)
+            .build()
+            .unwrap();
+
+        sim.run(&mut rng);
+
+        assert_valid_round_data(&sim.game_state.round_data);
+        assert_valid_game_state(&sim.game_state);
+
+        // Verify that Player 1 acted on the river (responded to the all-in).
+        let records = vec_storage.borrow();
+        let river_actions: Vec<_> = records
+            .iter()
+            .filter_map(|r| match &r.action {
+                Action::PlayedAction(a) if a.round == Round::River => Some(a),
+                _ => None,
+            })
+            .collect();
+
+        // There should be exactly 2 river actions: P0's all-in and P1's fold
+        assert_eq!(
+            river_actions.len(),
+            2,
+            "Expected 2 river actions (all-in + fold), got {}. \
+             Actions: {:?}",
+            river_actions.len(),
+            river_actions
+                .iter()
+                .map(|a| format!("P{}: {:?}", a.idx, a.action))
+                .collect::<Vec<_>>()
+        );
+
+        // First action should be P0's all-in
+        assert_eq!(river_actions[0].idx, 0);
+        assert!(
+            matches!(river_actions[0].action, AgentAction::AllIn),
+            "P0's river action should be AllIn, got {:?}",
+            river_actions[0].action
+        );
+
+        // Second action should be P1's fold
+        assert_eq!(river_actions[1].idx, 1);
+        assert!(
+            matches!(river_actions[1].action, AgentAction::Fold),
+            "P1's river action should be Fold, got {:?}",
+            river_actions[1].action
+        );
+
+        // P0 should win the pot (P1 folded)
+        assert!(
+            sim.game_state.player_reward(0) > 0.0,
+            "P0 should profit from P1's fold, got reward {}",
+            sim.game_state.player_reward(0)
+        );
+    }
+
+    /// Same scenario as above but with 3 players where one folded earlier.
+    /// This is the exact topology that triggered the original bug: after
+    /// one player folds and another goes all-in, `player_active` has only
+    /// the remaining player, but they still need to respond to the all-in.
+    #[test]
+    fn test_three_player_river_all_in_remaining_player_acts() {
+        use crate::arena::action::Action;
+        use crate::arena::game_state::Round;
+        use crate::arena::historian::{self, VecHistorian};
+
+        // 3-player game:
+        // Player 0 (dealer): folds preflop
+        // Player 1 (SB): calls throughout, goes all-in on river
+        // Player 2 (BB): calls throughout, must respond to river all-in
+
+        // Player 0: folds immediately
+        let agent_zero = boxed_vec_agent_with_default(vec![AgentAction::Fold], AgentAction::Fold);
+
+        // Player 1 (SB):
+        // - Posts SB (forced)
+        // - Preflop: Calls BB
+        // - Flop: Checks
+        // - Turn: Checks
+        // - River: Goes all-in
+        let agent_one = boxed_vec_agent_with_default(
+            vec![
+                AgentAction::Call,     // preflop
+                AgentAction::Bet(0.0), // flop: check
+                AgentAction::Bet(0.0), // turn: check
+                AgentAction::AllIn,    // river: all-in
+            ],
+            AgentAction::Fold,
+        );
+
+        // Player 2 (BB):
+        // - Posts BB (forced)
+        // - Preflop: Checks
+        // - Flop: Checks
+        // - Turn: Checks
+        // - River: Folds to all-in
+        let agent_two = boxed_vec_agent_with_default(
+            vec![
+                AgentAction::Call,     // preflop: check
+                AgentAction::Bet(0.0), // flop: check
+                AgentAction::Bet(0.0), // turn: check
+                AgentAction::Fold,     // river: fold to all-in
+            ],
+            AgentAction::Fold,
+        );
+
+        let game_state = GameStateBuilder::new()
+            .stacks(vec![100.0, 100.0, 100.0])
+            .blinds(10.0, 5.0)
+            .build()
+            .unwrap();
+        let agents: Vec<Box<dyn Agent>> = vec![agent_zero, agent_one, agent_two];
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let vec_hist = Box::new(VecHistorian::new());
+        let vec_storage = vec_hist.get_storage();
+        let historians: Vec<Box<dyn historian::Historian>> = vec![vec_hist];
+
+        let mut sim: HoldemSimulation = HoldemSimulationBuilder::default()
+            .game_state(game_state)
+            .agents(agents)
+            .historians(historians)
+            .build()
+            .unwrap();
+
+        sim.run(&mut rng);
+
+        assert_valid_round_data(&sim.game_state.round_data);
+        assert_valid_game_state(&sim.game_state);
+
+        // Verify Player 2 acted on the river
+        let records = vec_storage.borrow();
+        let river_actions: Vec<_> = records
+            .iter()
+            .filter_map(|r| match &r.action {
+                Action::PlayedAction(a) if a.round == Round::River => Some(a),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            river_actions.len(),
+            2,
+            "Expected 2 river actions (all-in + fold), got {}. \
+             Actions: {:?}",
+            river_actions.len(),
+            river_actions
+                .iter()
+                .map(|a| format!("P{}: {:?}", a.idx, a.action))
+                .collect::<Vec<_>>()
+        );
+
+        // P1's all-in and P2's fold
+        assert!(
+            matches!(river_actions[0].action, AgentAction::AllIn),
+            "First river action should be AllIn, got {:?}",
+            river_actions[0].action
+        );
+        assert_eq!(
+            river_actions[1].idx, 2,
+            "P2 should be the one folding on the river"
+        );
+        assert!(
+            matches!(river_actions[1].action, AgentAction::Fold),
+            "P2's river action should be Fold, got {:?}",
+            river_actions[1].action
+        );
     }
 }

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -1174,4 +1174,205 @@ mod tests {
         assert_eq!(traversal_set.get(0).node_idx(), initial_node);
         assert_eq!(traversal_set.get(0).chosen_child_idx(), initial_child);
     }
+
+    /// Reproduction test for the river call bug.
+    ///
+    /// Scenario: Player 1 holds K-high (7s Ks) facing an all-in on the river
+    /// against Player 2 who has a pair of 9s (9h Qs). Board: 4s 4d 9d Ah Jd.
+    /// Player 1 should ALWAYS fold, never call.
+    ///
+    /// This test verifies that:
+    /// 1. The PCFR+ regret matcher correctly learns to fold with the reward structure
+    /// 2. The full CFR agent picks fold when given this game state
+    #[test]
+    fn test_river_should_fold_king_high_vs_pair() {
+        use crate::arena::cfr::action_generator::{
+            ConfigurableActionConfig, ConfigurableActionGenerator,
+        };
+        use crate::arena::game_state::Round;
+        use crate::core::{Card, Hand, PlayerBitSet, Suit, Value};
+        use rand::SeedableRng;
+
+        // Simplified version: 2-player, river, Player 1 facing all-in
+        // Player 0 has pair of 9s (winning hand)
+        // Player 1 has K-high (losing hand)
+        //
+        // Setup: preflop/flop/turn betting already happened.
+        // Player 0 went all-in on river for 500.
+        // Player 1 (with 300 remaining) must decide: fold or call.
+        //
+        // Board: 4s 4d 9d Ah Jd
+        // Player 0 hand: 9h Qs (pair of 9s)
+        // Player 1 hand: 7s Ks (K high)
+
+        let board_cards = vec![
+            Card::new(Value::Four, Suit::Spade),
+            Card::new(Value::Four, Suit::Diamond),
+            Card::new(Value::Nine, Suit::Diamond),
+            Card::new(Value::Ace, Suit::Heart),
+            Card::new(Value::Jack, Suit::Diamond),
+        ];
+
+        // Player hands (including board cards for ranking)
+        let p0_hole = vec![
+            Card::new(Value::Nine, Suit::Heart),
+            Card::new(Value::Queen, Suit::Spade),
+        ];
+        let p1_hole = vec![
+            Card::new(Value::Seven, Suit::Spade),
+            Card::new(Value::King, Suit::Spade),
+        ];
+
+        let mut p0_hand = Hand::new_with_cards(p0_hole.clone());
+        p0_hand.extend(board_cards.iter().copied());
+        let mut p1_hand = Hand::new_with_cards(p1_hole.clone());
+        p1_hand.extend(board_cards.iter().copied());
+
+        // Create game state at river decision point:
+        // - Player 0 has gone all-in for 500 this round
+        // - Player 1 has 300 left in stack, hasn't bet on river yet
+        // - Previous rounds: both put in 200 each
+        let stacks = vec![0.0, 300.0]; // P0 is all-in, P1 has 300 left
+        let starting_stacks = vec![700.0, 700.0]; // Both started with 700
+        let player_bet = vec![700.0, 400.0]; // Total bets over all rounds
+
+        // Round data: P0 bet 500 this round, P1 hasn't bet yet
+        let round_player_bet = vec![500.0, 0.0];
+        let mut active = PlayerBitSet::new(2);
+        // Only P1 is active (P0 is all-in)
+        active.disable(0);
+
+        let round_data = crate::arena::game_state::RoundData::new_with_bets(
+            10.0, // min_raise
+            active,
+            1, // P1 to act
+            round_player_bet,
+        );
+
+        let mut game_state = GameStateBuilder::new()
+            .round(Round::River)
+            .round_data(round_data)
+            .stacks(stacks)
+            .player_bet(player_bet)
+            .big_blind(10.0)
+            .small_blind(5.0)
+            .hands(vec![p0_hand, p1_hand])
+            .board(board_cards)
+            .build()
+            .unwrap();
+        // Override starting_stacks (builder sets them = stacks)
+        game_state.starting_stacks = starting_stacks;
+
+        // Verify game state is correct
+        assert_eq!(game_state.round, Round::River);
+        assert_eq!(game_state.to_act_idx(), 1); // Player 1's turn
+        assert_eq!(game_state.current_round_bet(), 500.0); // P0's all-in
+        assert_eq!(game_state.current_player_stack(), 300.0); // P1's stack
+
+        // Create CFR agent for Player 1
+        let cfr_states = make_cfr_states(&game_state);
+        let traversal_set = TraversalSet::new(game_state.num_players);
+
+        // Use the configurable action generator (same as preflop chart post-flop)
+        let action_config = ConfigurableActionConfig::default();
+
+        let mut agent =
+            CFRAgentBuilder::<ConfigurableActionGenerator, DepthBasedIteratorGen, StdRng>::new()
+                .name("TestCFRAgent")
+                .player_idx(1)
+                .cfr_states(cfr_states.clone())
+                .traversal_set(traversal_set.clone())
+                .gamestate_iterator_gen_config(DepthBasedIteratorGenConfig::new(vec![24, 3, 1]))
+                .action_gen_config(action_config)
+                .limited_exploration_depth(3)
+                .rng(StdRng::seed_from_u64(42))
+                .build();
+
+        // Check what actions the generator produces
+        let possible_actions = agent.action_generator.gen_possible_actions(&game_state);
+        println!("Possible actions: {:?}", possible_actions);
+        for action in &possible_actions {
+            let idx = agent.action_index_mapper.action_to_idx(action, &game_state);
+            println!("  {:?} -> index {}", action, idx);
+        }
+
+        // Run act() - this explores and picks an action
+        let chosen_action = agent.act(0, &game_state);
+        println!("Chosen action: {:?}", chosen_action);
+
+        // The agent should fold with K-high facing an all-in
+        assert!(
+            matches!(chosen_action, AgentAction::Fold),
+            "Agent should fold K-high facing all-in, but chose {:?}. \
+             With a fresh regret matcher, 24 iterations of exploration \
+             should overwhelmingly prefer fold over call.",
+            chosen_action
+        );
+
+        // Also verify the regret matcher weights
+        let target_node_idx = agent.target_node_idx().unwrap();
+        agent
+            .cfr_state
+            .with_node_data(target_node_idx, |node_data| {
+                let matcher = get_regret_matcher_from_node(node_data).unwrap();
+                let weights = matcher.best_weight();
+                let fold_weight = weights[0]; // ACTION_IDX_FOLD
+                let call_weight = weights[1]; // ACTION_IDX_CALL
+
+                println!(
+                    "Weights after exploration: fold={:.6}, call={:.6}",
+                    fold_weight, call_weight
+                );
+
+                assert!(
+                    fold_weight > 0.99,
+                    "Fold weight should be >0.99, got {:.6}. Call weight: {:.6}",
+                    fold_weight,
+                    call_weight
+                );
+            });
+    }
+
+    /// Test that PCFR+ correctly handles the reward structure where call
+    /// reward equals the invalid action penalty.
+    #[test]
+    fn test_pcfr_fold_vs_call_with_penalty_equal_to_call() {
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+
+        // Simulate the exact reward structure from the river call bug:
+        // - Fold reward: -604 (lost what was already bet)
+        // - Call reward: -1463 (lost entire stack)
+        // - Invalid penalty: -1463 (same as call, since losing whole stack)
+        let fold_reward = -604.0_f32;
+        let call_reward = -1463.0_f32;
+        let invalid_penalty = -1463.0_f32;
+
+        for _ in 0..24 {
+            let mut rewards = vec![invalid_penalty; NUM_ACTION_INDICES];
+            rewards[0] = fold_reward; // Fold
+            rewards[1] = call_reward; // Call
+            matcher.update_regret(&rewards);
+        }
+
+        let weights = matcher.best_weight();
+        let fold_weight = weights[0];
+        let call_weight = weights[1];
+
+        println!(
+            "PCFR+ after 24 iterations: fold={:.6}, call={:.6}",
+            fold_weight, call_weight
+        );
+
+        // Fold should dominate
+        assert!(
+            fold_weight > 0.99,
+            "Fold should have >99% weight, got {:.4}%",
+            fold_weight * 100.0
+        );
+        assert!(
+            call_weight < 0.01,
+            "Call should have <1% weight, got {:.4}%",
+            call_weight * 100.0
+        );
+    }
 }

--- a/src/arena/simulation.rs
+++ b/src/arena/simulation.rs
@@ -400,17 +400,19 @@ impl HoldemSimulation {
     /// everyone has acted or until the round has been completed because no one
     /// can act anymore.
     ///
-    /// On post-flop streets (flop, turn, river), if fewer than 2 players are
-    /// active (the rest are all-in or folded), no betting is possible and the
-    /// round is skipped. On preflop, players may still need to respond to
-    /// forced bets (e.g., SB deciding whether to call after BB is forced
-    /// all-in).
+    /// When fewer than 2 players are active (the rest are all-in or folded),
+    /// we skip the round since the lone active player has no one to bet against.
+    /// However, if there's an unmatched bet (e.g., an all-in or a blind that
+    /// hasn't been called), active players must still fold or call.
     fn run_betting_round(&mut self) {
         let current_round = self.game_state.round;
-        // Post-flop: skip if < 2 active players (rest are all-in/folded), no one to bet against.
-        // Preflop is excluded: a player forced all-in by the BB still leaves the SB needing to act.
-        if current_round != Round::Preflop && self.game_state.player_active.count() < 2 {
-            return;
+        if self.game_state.player_active.count() < 2 {
+            let has_unmatched_bet = self.game_state.player_active.ones().any(|idx| {
+                self.game_state.round_data.player_bet[idx] < self.game_state.round_data.bet
+            });
+            if !has_unmatched_bet {
+                return;
+            }
         }
         while self.needs_action() && self.game_state.round == current_round {
             self.run_single_agent();


### PR DESCRIPTION
run_betting_round skipped the entire round when player_active.count() < 2,
but this incorrectly skipped cases where an active player still needed to
fold or call an opponent's all-in. The fix checks for unmatched bets before
skipping — if any active player's round bet is below the current bet, the
round proceeds.

This also removes the preflop special-case since the unmatched bet check
handles forced blind all-ins uniformly across all streets.
