### PR TITLE
fix(core): widen PlayerBitSet::new for 16 players

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,10 @@ name = "omaha"
 harness = false
 required-features = ["omaha"]
 
+[[bench]]
+name = "player_bit_set_init"
+harness = false
+
 [profile.release]
 debug = "line-tables-only"
 lto = true

--- a/benches/player_bit_set_init.rs
+++ b/benches/player_bit_set_init.rs
@@ -1,0 +1,107 @@
+//! Microbenchmark for `PlayerBitSet::new` initialization strategies.
+//!
+//! This benchmark does NOT call the real `PlayerBitSet::new`. It exists to
+//! drive the choice between two ways of producing the initial `u16` bitmask
+//! with the low `players` bits set, without having to commit to either one in
+//! the library first.
+//!
+//! The two candidates:
+//!
+//! * `init_branch` — the current implementation: special-case the full-width
+//!   input (`players == 16`) because `1u16 << 16` overflows, otherwise do
+//!   `(1u16 << players) - 1`.
+//!
+//! * `init_widen`  — do the shift in `u32` where `1 << 16` is representable,
+//!   subtract one, and truncate back to `u16`. No branch, at the cost of a
+//!   32-bit shift/sub pair plus a truncation.
+//!
+//! Both are benchmarked on:
+//!   1. Fixed per-count inputs (0, 2, 6, 9, 16) — shows steady-state cost
+//!      when the branch predictor has a single answer and input is hot.
+//!   2. A mixed batch with an unpredictable distribution of player counts —
+//!      shows what happens when the branch predictor cannot lock onto one
+//!      side and the CPU has to pay for mispredictions.
+
+#[macro_use]
+extern crate criterion;
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion};
+
+/// Branch-on-full-width variant. Matches the current `PlayerBitSet::new`.
+#[inline(always)]
+fn init_branch(players: usize) -> u16 {
+    if players >= 16 {
+        u16::MAX
+    } else {
+        (1u16 << players) - 1
+    }
+}
+
+/// Widen-and-truncate variant. Does the `(1 << x) - 1` math in `u32` so the
+/// `players == 16` case is representable, then truncates to `u16`.
+#[inline(always)]
+fn init_widen(players: usize) -> u16 {
+    ((1u32 << players) - 1) as u16
+}
+
+fn bench_fixed_counts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("player_bit_set_init/fixed");
+
+    // Covers: empty set, heads-up, 6-max, 9-max full ring, 16-player edge.
+    for players in [0usize, 2, 6, 9, 16] {
+        group.bench_with_input(BenchmarkId::new("branch", players), &players, |b, &n| {
+            b.iter(|| init_branch(black_box(n)))
+        });
+        group.bench_with_input(BenchmarkId::new("widen", players), &players, |b, &n| {
+            b.iter(|| init_widen(black_box(n)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_mixed_batch(c: &mut Criterion) {
+    // Realistic-ish mix: common poker table sizes plus a sprinkle of the
+    // 16-player edge case. The goal is to defeat branch prediction on the
+    // `if players >= 16` check so the branch variant cannot hide the cost of
+    // the extra compare.
+    let inputs: Vec<usize> = (0..4096)
+        .map(|i| match i % 11 {
+            0 | 1 => 2,
+            2..=4 => 6,
+            5..=7 => 9,
+            8 => 10,
+            9 => 16,
+            _ => 4,
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("player_bit_set_init/mixed_batch");
+
+    group.bench_function("branch", |b| {
+        b.iter(|| {
+            let mut acc: u16 = 0;
+            for &n in black_box(&inputs) {
+                acc ^= init_branch(n);
+            }
+            acc
+        })
+    });
+
+    group.bench_function("widen", |b| {
+        b.iter(|| {
+            let mut acc: u16 = 0;
+            for &n in black_box(&inputs) {
+                acc ^= init_widen(n);
+            }
+            acc
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_fixed_counts, bench_mixed_batch);
+criterion_main!(benches);

--- a/mise.toml
+++ b/mise.toml
@@ -33,7 +33,7 @@ fi
 description = "Run a benchmark"
 usage = """
 arg "<target>" help="Benchmark to run" {
-    choices "arena" "monte_carlo_game" "holdem_starting_hand" "iter" "parse" "rank" "icm_sim" "deal_deck"
+    choices "arena" "monte_carlo_game" "holdem_starting_hand" "iter" "parse" "rank" "icm_sim" "deal_deck" "player_bit_set_init"
 }
 """
 run = 'cargo bench --bench {{usage.target}}'

--- a/src/core/player_bit_set.rs
+++ b/src/core/player_bit_set.rs
@@ -61,8 +61,20 @@ impl Display for PlayerBitSet {
 
 impl PlayerBitSet {
     /// Creates a new `PlayerBitSet` with `players` number of players.
+    ///
+    /// Supports up to 16 players (the width of the underlying `u16`).
     pub fn new(players: usize) -> Self {
-        let set = (1 << players) - 1;
+        debug_assert!(
+            players <= 16,
+            "PlayerBitSet supports at most 16 players, got {players}"
+        );
+        // `1u16 << 16` overflows, so special-case the full-width case rather
+        // than computing `(1 << players) - 1` directly.
+        let set = if players >= 16 {
+            u16::MAX
+        } else {
+            (1u16 << players) - 1
+        };
         Self { set }
     }
 
@@ -197,6 +209,45 @@ mod tests {
     #[test]
     fn test_new_count() {
         assert_eq!(7, PlayerBitSet::new(7).count());
+    }
+
+    #[test]
+    fn test_new_max_players_count() {
+        // Regression: `(1u16 << 16) - 1` overflows. Building a 16-player
+        // bit set must still report 16 active players.
+        let s = PlayerBitSet::new(16);
+        assert_eq!(16, s.count());
+        for idx in 0..16 {
+            assert!(s.get(idx), "player {idx} should be active");
+        }
+    }
+
+    #[test]
+    fn test_new_max_players_iter() {
+        let s = PlayerBitSet::new(16);
+        let collected: Vec<usize> = s.ones().collect();
+        assert_eq!(collected, (0..16).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_new_all_valid_widths_exact_mask() {
+        // Lock the exact bit pattern `PlayerBitSet::new` produces for every
+        // valid player count, including both edges (0 and 16). This is the
+        // invariant the `benches/player_bit_set_init.rs` candidates were
+        // compared against: the low `players` bits set, nothing else.
+        for players in 0usize..=16 {
+            let s = PlayerBitSet::new(players);
+            assert_eq!(s.count(), players, "count mismatch at players={players}");
+            for idx in 0..players {
+                assert!(s.get(idx), "bit {idx} should be set at players={players}");
+            }
+            for idx in players..16 {
+                assert!(
+                    !s.get(idx),
+                    "bit {idx} should be clear at players={players}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
`(1u16 << 16) - 1` overflows in debug and silently produces 0 in release,
so PlayerBitSet::new(16) reported zero active players. Special-case the
full-width case and add a debug_assert for >16.

Two fixes were considered: the landed branch-on-16 variant, or doing the
`(1 << x) - 1` math in `u32` and truncating to `u16`. A microbenchmark
(`benches/player_bit_set_init.rs`) compares both candidates as local
functions so the pick isn't prejudged. Per-call measurements (0, 2, 6, 9,
16 players) are dominated by bench-harness overhead (~370 ps either way),
but a 4096-call mixed-batch loop with an unpredictable player-count
distribution separates them cleanly:

    branch  ~241 ns / batch   (~59 ps/call)
    widen   ~385 ns / batch   (~94 ps/call)

The branch variant is ~37% faster in the realistic throughput case: the
compiler folds the `if` into a cheap branchless sequence on u16, while
the u32 shift+sub+truncate path emits a heavier sequence that doesn't
vectorize as well. Both are sub-nanosecond and `PlayerBitSet::new` is
only called at game-setup time, so the practical delta is negligible —
but there is no perf reason to take the widen variant's extra complexity
either.

Also adds `test_new_all_valid_widths_exact_mask`, which locks the exact
bit pattern for every valid player count (0..=16)
