### PR TITLE
fix(arena): replace ComparisonError String variants with typed enums

### DIFF
--- a/src/arena/comparison/builder.rs
+++ b/src/arena/comparison/builder.rs
@@ -163,9 +163,7 @@ impl ComparisonBuilder {
 
         // Validate all agent configs up front
         for (_, agent_config) in &self.agents {
-            agent_config
-                .validate()
-                .map_err(ComparisonError::InvalidConfig)?;
+            agent_config.validate()?;
         }
 
         Ok(ArenaComparison::new(config, self.agents))
@@ -261,6 +259,7 @@ fn load_agent_config(path: &Path) -> Result<AgentConfig> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::error::ComparisonConfigError;
     use super::*;
 
     #[test]
@@ -325,7 +324,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ComparisonError::ValidationError(_)
+            ComparisonError::InvalidConfig(ComparisonConfigError::PlayersPerTableTooSmall(1))
         ));
     }
 

--- a/src/arena/comparison/config.rs
+++ b/src/arena/comparison/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::error::{ComparisonError, Result};
+use super::error::{ComparisonConfigError, Result};
 
 /// Configuration for running agent comparisons
 #[derive(Debug, Clone)]
@@ -53,73 +53,58 @@ impl ComparisonConfig {
 
     /// Validate the comparison configuration
     pub fn validate(&self, num_agents: usize) -> Result<()> {
-        // Verify players_per_table >= 2
         if self.players_per_table < 2 {
-            return Err(ComparisonError::ValidationError(
-                "players_per_table must be at least 2".to_string(),
-            ));
+            return Err(
+                ComparisonConfigError::PlayersPerTableTooSmall(self.players_per_table).into(),
+            );
         }
 
-        // Verify players_per_table <= num_agents
         if self.players_per_table > num_agents {
-            return Err(ComparisonError::ValidationError(format!(
-                "players_per_table ({}) cannot exceed number of agents ({})",
-                self.players_per_table, num_agents
-            )));
+            return Err(ComparisonConfigError::PlayersPerTableExceedsAgents {
+                players: self.players_per_table,
+                num_agents,
+            }
+            .into());
         }
 
-        // Verify num_games > 0
         if self.num_games == 0 {
-            return Err(ComparisonError::ValidationError(
-                "num_games must be greater than 0".to_string(),
-            ));
+            return Err(ComparisonConfigError::NumGamesZero.into());
         }
 
-        // Verify blinds are positive
         if self.big_blind <= 0.0 {
-            return Err(ComparisonError::ValidationError(
-                "big_blind must be positive".to_string(),
-            ));
+            return Err(ComparisonConfigError::NonPositiveBigBlind(self.big_blind).into());
         }
 
         if self.small_blind <= 0.0 {
-            return Err(ComparisonError::ValidationError(
-                "small_blind must be positive".to_string(),
-            ));
+            return Err(ComparisonConfigError::NonPositiveSmallBlind(self.small_blind).into());
         }
 
-        // Verify small blind is less than big blind
         if self.small_blind >= self.big_blind {
-            return Err(ComparisonError::ValidationError(
-                "small_blind must be less than big_blind".to_string(),
-            ));
+            return Err(ComparisonConfigError::SmallBlindNotLessThanBigBlind {
+                small: self.small_blind,
+                big: self.big_blind,
+            }
+            .into());
         }
 
-        // Verify stack sizes are positive
         if self.min_stack_bb <= 0.0 {
-            return Err(ComparisonError::ValidationError(
-                "min_stack_bb must be positive".to_string(),
-            ));
+            return Err(ComparisonConfigError::NonPositiveMinStack(self.min_stack_bb).into());
         }
 
         if self.max_stack_bb <= 0.0 {
-            return Err(ComparisonError::ValidationError(
-                "max_stack_bb must be positive".to_string(),
-            ));
+            return Err(ComparisonConfigError::NonPositiveMaxStack(self.max_stack_bb).into());
         }
 
-        // Verify min <= max
         if self.min_stack_bb > self.max_stack_bb {
-            return Err(ComparisonError::ValidationError(
-                "min_stack_bb cannot exceed max_stack_bb".to_string(),
-            ));
+            return Err(ComparisonConfigError::MinStackExceedsMax {
+                min: self.min_stack_bb,
+                max: self.max_stack_bb,
+            }
+            .into());
         }
 
-        // Verify ante is non-negative
         if self.ante < 0.0 {
-            return Err(ComparisonError::ValidationError(
-                "ante must be non-negative".to_string(),
-            ));
+            return Err(ComparisonConfigError::NegativeAnte(self.ante).into());
         }
 
         Ok(())

--- a/src/arena/comparison/error.rs
+++ b/src/arena/comparison/error.rs
@@ -1,6 +1,44 @@
 use thiserror::Error;
 
 use crate::arena::agent::AgentConfigError;
+use crate::arena::errors::HoldemSimulationError;
+use crate::arena::historian::HistorianError;
+
+/// Errors produced while validating a [`ComparisonConfig`].
+///
+/// [`ComparisonConfig`]: super::config::ComparisonConfig
+#[derive(Debug, Error, PartialEq)]
+pub enum ComparisonConfigError {
+    #[error("players_per_table must be at least 2, got {0}")]
+    PlayersPerTableTooSmall(usize),
+
+    #[error("players_per_table ({players}) cannot exceed number of agents ({num_agents})")]
+    PlayersPerTableExceedsAgents { players: usize, num_agents: usize },
+
+    #[error("num_games must be greater than 0")]
+    NumGamesZero,
+
+    #[error("big_blind must be positive, got {0}")]
+    NonPositiveBigBlind(f32),
+
+    #[error("small_blind must be positive, got {0}")]
+    NonPositiveSmallBlind(f32),
+
+    #[error("small_blind ({small}) must be less than big_blind ({big})")]
+    SmallBlindNotLessThanBigBlind { small: f32, big: f32 },
+
+    #[error("min_stack_bb must be positive, got {0}")]
+    NonPositiveMinStack(f32),
+
+    #[error("max_stack_bb must be positive, got {0}")]
+    NonPositiveMaxStack(f32),
+
+    #[error("min_stack_bb ({min}) cannot exceed max_stack_bb ({max})")]
+    MinStackExceedsMax { min: f32, max: f32 },
+
+    #[error("ante must be non-negative, got {0}")]
+    NegativeAnte(f32),
+}
 
 /// Errors that can occur during agent comparison
 #[derive(Debug, Error)]
@@ -16,16 +54,28 @@ pub enum ComparisonError {
     },
 
     #[error("Failed to validate agent config: {0}")]
-    InvalidConfig(#[from] AgentConfigError),
+    InvalidAgentConfig(#[from] AgentConfigError),
 
-    #[error("Configuration validation error: {0}")]
-    ValidationError(String),
+    #[error("Invalid comparison configuration: {0}")]
+    InvalidConfig(#[from] ComparisonConfigError),
 
     #[error("No agent config files found in directory: {0}")]
     NoAgentsFound(String),
 
     #[error("Simulation error: {0}")]
-    SimulationError(String),
+    Simulation(#[from] HoldemSimulationError),
+
+    #[error("Historian error: {0}")]
+    Historian(#[from] HistorianError),
+
+    /// The random game-state generator ran out of game states before the
+    /// comparison completed.
+    #[error("Random game-state generator exhausted before comparison finished")]
+    GameStateGeneratorExhausted,
+
+    /// Reading stats from the historian's shared storage failed.
+    #[error("Failed to read stats from historian storage: {reason}")]
+    StatsUnavailable { reason: String },
 
     #[error("Failed to serialize JSON: {0}")]
     JsonSerialize(#[from] serde_json::Error),

--- a/src/arena/comparison/mod.rs
+++ b/src/arena/comparison/mod.rs
@@ -45,7 +45,7 @@ mod stats;
 
 pub use builder::ComparisonBuilder;
 pub use config::ComparisonConfig;
-pub use error::{ComparisonError, Result};
+pub use error::{ComparisonConfigError, ComparisonError, Result};
 pub use result::ComparisonResult;
 pub use runner::{ArenaComparison, PermutationResult};
 pub use stats::{AgentStats, AgentStatsBuilder, PositionStats};

--- a/src/arena/comparison/runner.rs
+++ b/src/arena/comparison/runner.rs
@@ -7,7 +7,6 @@ use tracing::event;
 
 use crate::arena::agent::{AgentConfig, ConfigAgentBuilder};
 use crate::arena::cfr::{CFRState, TraversalSet};
-use crate::arena::errors::HoldemSimulationError;
 use crate::arena::game_state::{GameState, RandomGameStateGenerator};
 use crate::arena::historian::OpenHandHistoryHistorian;
 use crate::arena::historian::{StatsStorage, StatsTrackingHistorian};
@@ -168,9 +167,9 @@ impl ArenaComparison {
             }
 
             // Generate a game state
-            let game_state = game_state_gen.next().ok_or_else(|| {
-                ComparisonError::SimulationError("Failed to generate game state".to_string())
-            })?;
+            let game_state = game_state_gen
+                .next()
+                .ok_or(ComparisonError::GameStateGeneratorExhausted)?;
 
             // Run all permutations with this game state
             let mut perm_ctx = PermutationContext {
@@ -297,9 +296,7 @@ impl ArenaComparison {
             if let Some((cfr_states, traversal_set)) = cfr_context {
                 sim_builder = sim_builder.cfr_context(cfr_states, traversal_set, true);
             }
-            let mut sim = sim_builder.build().map_err(|e: HoldemSimulationError| {
-                ComparisonError::SimulationError(e.to_string())
-            })?;
+            let mut sim = sim_builder.build()?;
 
             let perm_start = Instant::now();
             sim.run(rng);
@@ -318,9 +315,12 @@ impl ArenaComparison {
             drop(sim);
 
             // Extract statistics from the historian via the shared storage
-            let stats = stats_storage.try_read().map_err(|e| {
-                ComparisonError::SimulationError(format!("Failed to read stats: {}", e))
-            })?;
+            let stats =
+                stats_storage
+                    .try_read()
+                    .map_err(|e| ComparisonError::StatsUnavailable {
+                        reason: e.to_string(),
+                    })?;
 
             // Notify the callback with per-permutation data
             let perm_names: Vec<String> = permutation


### PR DESCRIPTION
`ComparisonError::ValidationError(String)` absorbed every
`ComparisonConfig::validate` failure as an untyped string, and
`ComparisonError::SimulationError(String)` threw away the typed
`HoldemSimulationError` it was wrapping (as well as covering unrelated
failure modes like "no stats available" and "game-state generator
exhausted").

Introduce a dedicated `ComparisonConfigError` thiserror enum covering
every config validation case, replace `ValidationError` with
`InvalidConfig(#[from] ComparisonConfigError)`, replace
`SimulationError` with a typed `Simulation(#[from] HoldemSimulationError)`
variant, and split the other string cases into typed variants
(`GameStateGeneratorExhausted`, `StatsUnavailable`, `Historian`,
`InvalidAgentConfig`). Update the config validator, the runner, and the
builder test accordingly.
