### PR TITLE
fix(arena): replace HistorianError::LockPoisoned(String) with typed variant

### DIFF
--- a/src/arena/historian/mod.rs
+++ b/src/arena/historian/mod.rs
@@ -1,6 +1,27 @@
 use super::{GameState, action::Action};
 use thiserror::Error;
 
+/// Identifies which historian-owned lock was poisoned.
+///
+/// Used by [`HistorianError::LockPoisoned`] to carry typed context about
+/// where the poisoning occurred, instead of a free-form string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistorianLock {
+    /// Read lock on the shared `StatsStorage`.
+    StatsStorageRead,
+    /// Write lock on the shared `StatsStorage`.
+    StatsStorageWrite,
+}
+
+impl std::fmt::Display for HistorianLock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StatsStorageRead => write!(f, "StatsStorage read"),
+            Self::StatsStorageWrite => write!(f, "StatsStorage write"),
+        }
+    }
+}
+
 /// HistorianError is the error type for historian implementations.
 #[derive(Error, Debug)]
 pub enum HistorianError {
@@ -12,8 +33,10 @@ pub enum HistorianError {
     BorrowMutError(#[from] std::cell::BorrowMutError),
     #[error("Borrow Error: {0}")]
     BorrowError(#[from] std::cell::BorrowError),
-    #[error("Lock Poisoned: {0}")]
-    LockPoisoned(String),
+    /// A shared lock on historian state was poisoned by a panicking thread.
+    /// The `lock` field identifies which lock to aid debugging.
+    #[error("{lock} lock poisoned by a panicking thread")]
+    LockPoisoned { lock: HistorianLock },
     #[cfg(any(test, feature = "serde"))]
     #[error("JSON Error: {0}")]
     JSONError(#[from] serde_json::Error),

--- a/src/arena/historian/stats_tracking.rs
+++ b/src/arena/historian/stats_tracking.rs
@@ -554,9 +554,11 @@ impl SharedStatsStorage {
     ///
     /// Returns an error if the lock is poisoned.
     pub fn try_read(&self) -> Result<RwLockReadGuard<'_, StatsStorage>, super::HistorianError> {
-        self.inner.read().map_err(|e| {
-            super::HistorianError::LockPoisoned(format!("StatsStorage read lock poisoned: {}", e))
-        })
+        self.inner
+            .read()
+            .map_err(|_| super::HistorianError::LockPoisoned {
+                lock: super::HistorianLock::StatsStorageRead,
+            })
     }
 
     /// Clone the current stats (snapshot).
@@ -981,9 +983,13 @@ impl StatsTrackingHistorian {
         self.current_round = round;
 
         // Track round completions - acquire write lock once
-        let mut storage = self.storage.inner().write().map_err(|e| {
-            super::HistorianError::LockPoisoned(format!("Write lock poisoned: {}", e))
-        })?;
+        let mut storage =
+            self.storage
+                .inner()
+                .write()
+                .map_err(|_| super::HistorianError::LockPoisoned {
+                    lock: super::HistorianLock::StatsStorageWrite,
+                })?;
 
         let num_players = storage.num_players();
 
@@ -1022,9 +1028,13 @@ impl StatsTrackingHistorian {
     /// Flush accumulated stats to shared storage.
     /// Called once at game completion to minimize lock acquisitions.
     fn flush_accumulated_stats(&mut self) -> Result<(), super::HistorianError> {
-        let mut storage = self.storage.inner().write().map_err(|e| {
-            super::HistorianError::LockPoisoned(format!("Write lock poisoned: {}", e))
-        })?;
+        let mut storage =
+            self.storage
+                .inner()
+                .write()
+                .map_err(|_| super::HistorianError::LockPoisoned {
+                    lock: super::HistorianLock::StatsStorageWrite,
+                })?;
 
         for (player_idx, player_stats) in self.accumulator.player_stats.iter().enumerate() {
             storage.actions_count[player_idx] += player_stats.actions_count;
@@ -1090,9 +1100,13 @@ impl StatsTrackingHistorian {
         self.flush_accumulated_stats()?;
 
         // Then record game completion stats
-        let mut storage = self.storage.inner().write().map_err(|e| {
-            super::HistorianError::LockPoisoned(format!("Write lock poisoned: {}", e))
-        })?;
+        let mut storage =
+            self.storage
+                .inner()
+                .write()
+                .map_err(|_| super::HistorianError::LockPoisoned {
+                    lock: super::HistorianLock::StatsStorageWrite,
+                })?;
 
         // Determine if this went to showdown (round is Complete and more than one player active)
         let went_to_showdown =


### PR DESCRIPTION
The new `LockPoisoned(String)` variant stuffed a free-form description
into an error type, violating CLAUDE.md's "no bare String errors" rule.

Introduce a `HistorianLock` enum identifying which lock was poisoned
(currently `StatsStorageRead` / `StatsStorageWrite`) and change the
variant to `LockPoisoned { lock: HistorianLock }`. Update the four
call sites in `stats_tracking.rs` to use the typed variant instead of
stringifying `PoisonError`.
