### PR TITLE
fix(rsp): filter OHH directory readers by .ohh extension

### DIFF
--- a/src/bin/rsp/ohh/reader.rs
+++ b/src/bin/rsp/ohh/reader.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::Path;
 
 use rs_poker::open_hand_history::{HandHistory, OpenHandHistoryWrapper};
@@ -13,12 +14,18 @@ pub enum ReaderError {
     },
 }
 
-/// Read all OHH files from a directory (sorted by filename).
+/// Read all `.ohh` files from a directory (sorted by filename).
+///
+/// Files that do not have an `.ohh` extension are skipped. Without this
+/// filter, a directory that happens to contain other artifacts (e.g.
+/// `results.json`, `hands.jsonl`, or markdown reports produced by
+/// `rsp arena compare`) would cause the reader to try parsing them as
+/// JSONL OHH and fail on the first non-OHH line.
 pub fn read_ohh_dir(dir: &Path) -> Result<Vec<HandHistory>, ReaderError> {
     let mut entries: Vec<std::path::PathBuf> = std::fs::read_dir(dir)?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
-        .filter(|p| p.is_file())
+        .filter(|p| p.is_file() && has_ohh_extension(p))
         .collect();
     entries.sort();
 
@@ -28,6 +35,14 @@ pub fn read_ohh_dir(dir: &Path) -> Result<Vec<HandHistory>, ReaderError> {
         all_hands.extend(hands);
     }
     Ok(all_hands)
+}
+
+/// Returns `true` if the given path's extension is `ohh`
+/// (case-insensitive).
+pub fn has_ohh_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ohh"))
 }
 
 /// Read an OHH file (JSONL format: one JSON object per line).
@@ -54,8 +69,9 @@ pub fn read_ohh_file(path: &Path) -> Result<Vec<HandHistory>, ReaderError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::io::Write;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, tempdir};
 
     #[test]
     fn test_empty_file() {
@@ -71,5 +87,32 @@ mod tests {
         writeln!(f, "not json").unwrap();
         let result = read_ohh_file(f.path());
         assert!(result.is_err());
+    }
+
+    /// Regression test for B6: `read_ohh_dir` must ignore non-`.ohh`
+    /// files. Previously it walked every regular file and tried to parse
+    /// them, so running it on an `arena compare` output directory (which
+    /// also contains `results.json`, `hands.jsonl`, `results.md`, etc.)
+    /// would fail on the first non-OHH line.
+    #[test]
+    fn test_read_ohh_dir_skips_non_ohh_files() {
+        let dir = tempdir().unwrap();
+        // An empty .ohh file (valid: 0 hands)
+        fs::write(dir.path().join("a.ohh"), "").unwrap();
+        // Unrelated files that would fail to parse as JSONL OHH.
+        fs::write(dir.path().join("results.json"), "{ invalid ohh }").unwrap();
+        fs::write(dir.path().join("report.md"), "# Report\n").unwrap();
+        fs::write(dir.path().join("hands.jsonl"), "not a hand").unwrap();
+
+        let hands = read_ohh_dir(dir.path()).unwrap();
+        assert!(hands.is_empty());
+    }
+
+    #[test]
+    fn test_has_ohh_extension() {
+        assert!(has_ohh_extension(Path::new("hand.ohh")));
+        assert!(has_ohh_extension(Path::new("/tmp/hand.OHH")));
+        assert!(!has_ohh_extension(Path::new("hand.json")));
+        assert!(!has_ohh_extension(Path::new("results")));
     }
 }

--- a/src/bin/rsp/tui/hand_store.rs
+++ b/src/bin/rsp/tui/hand_store.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -13,6 +14,13 @@ pub enum HandStoreError {
     Io(#[from] std::io::Error),
     #[error("JSON parse error: {0}")]
     Json(#[from] serde_json::Error),
+}
+
+/// Returns `true` if the given path's extension is `ohh` (case-insensitive).
+fn has_ohh_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ohh"))
 }
 
 struct FileEntry {
@@ -67,11 +75,15 @@ impl HandStore {
     }
 
     /// For static viewers (`ohh view`): scans all `.ohh` files in a directory.
+    ///
+    /// Files without an `.ohh` extension are skipped, so directories that
+    /// also contain `results.json`, markdown reports, or other artifacts
+    /// (as produced by `rsp arena compare`) don't pollute the index.
     pub fn from_existing_dir(dir: &Path) -> Result<Self, HandStoreError> {
         let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)?
             .filter_map(|e| e.ok())
             .map(|e| e.path())
-            .filter(|p| p.is_file())
+            .filter(|p| p.is_file() && has_ohh_extension(p))
             .collect();
         entries.sort();
 
@@ -352,5 +364,24 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = HandStore::from_existing_dir(dir.path()).unwrap();
         assert_eq!(store.len(), 0);
+    }
+
+    /// Regression test for B6: `from_existing_dir` must skip non-`.ohh`
+    /// files. A directory also containing `results.json` (as written by
+    /// `rsp arena compare`) used to populate the `HandStore` with phantom
+    /// offsets into a file that isn't an OHH JSONL.
+    #[test]
+    fn test_from_existing_dir_skips_non_ohh_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_hand_to_path(&dir.path().join("a.ohh"), &[("1",), ("2",)]);
+        // Unrelated artifacts that used to confuse the reader.
+        std::fs::write(dir.path().join("results.json"), "{ \"unrelated\": true }").unwrap();
+        std::fs::write(dir.path().join("report.md"), "# Report\n").unwrap();
+        std::fs::write(dir.path().join("hands.jsonl"), "{}\n").unwrap();
+
+        let store = HandStore::from_existing_dir(dir.path()).unwrap();
+        assert_eq!(store.len(), 2);
+        let h1 = store.fetch(1).unwrap().expect("game 1");
+        assert_eq!(h1.game_number, "1");
     }
 }


### PR DESCRIPTION
Both `rsp ohh view <dir>` (via `read_ohh_dir`) and the TUI's
`HandStore::from_existing_dir` walked every regular file in the target
directory without an extension filter. Running these on an
`arena compare` output directory — which also contains `results.json`,
`results.md`, `hands.jsonl`, etc. — caused the reader to try to parse
those files as JSONL OHH and fail (or, in the hand store case, index
phantom byte offsets into a non-OHH file).

Add a shared `has_ohh_extension` predicate (case-insensitive) and apply
it at both call sites. Add regression tests that populate a mixed
directory and verify only `.ohh` files are picked up.
