### PR TITLE
fix(rsp): restore raw mode on setup_terminal failure

### DIFF
--- a/src/bin/rsp/tui/terminal.rs
+++ b/src/bin/rsp/tui/terminal.rs
@@ -9,17 +9,51 @@ use ratatui::{Terminal, prelude::CrosstermBackend};
 
 pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 
+/// RAII guard that disables raw mode on drop.
+///
+/// Used during [`setup_terminal`] to unwind terminal state if a subsequent
+/// initialization step fails. On the happy path the guard is forgotten via
+/// [`std::mem::forget`], transferring cleanup responsibility to the caller
+/// (who must later call [`restore_terminal`]).
+struct RawModeGuard;
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+    }
+}
+
 /// Initialize the terminal for TUI rendering.
 ///
 /// Enables raw mode, enters alternate screen, enables mouse capture,
 /// and installs a panic hook that restores the terminal before aborting.
+/// If any step after [`enable_raw_mode`] fails, raw mode is automatically
+/// disabled before propagating the error so the user's shell doesn't end
+/// up scrambled.
 pub fn setup_terminal() -> io::Result<Tui> {
     install_panic_hook();
     enable_raw_mode()?;
+    // Any early return from here on drops the guard, which restores the
+    // terminal by disabling raw mode.
+    let guard = RawModeGuard;
+
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+
     let backend = CrosstermBackend::new(stdout);
-    let terminal = Terminal::new(backend)?;
+    let terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(e) => {
+            // Roll back what we just enabled before the guard disables
+            // raw mode.
+            let _ = execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen);
+            return Err(e);
+        }
+    };
+
+    // Success: caller now owns the terminal and is responsible for
+    // calling [`restore_terminal`]. Skip the guard's Drop impl.
+    std::mem::forget(guard);
     Ok(terminal)
 }
 


### PR DESCRIPTION
If `EnterAlternateScreen`, `EnableMouseCapture`, or `Terminal::new` fails
after `enable_raw_mode` succeeds, `setup_terminal` used to return
`Err(..)` with raw mode still enabled. The caller has no `Tui` handle to
clean up with, and the panic hook only runs on panic (not on a
propagated `Err`), so the user's shell was left scrambled.

Add a `RawModeGuard` whose `Drop` disables raw mode, construct it
immediately after `enable_raw_mode` succeeds, and `mem::forget` it on
the happy path so the caller's `restore_terminal` retains responsibility.
Also roll back the alternate screen / mouse capture if `Terminal::new`
fails after they were enabled.
