### PR TITLE
fix(rsp): cancel arena compare background thread when TUI exits

### DIFF
--- a/src/arena/comparison/runner.rs
+++ b/src/arena/comparison/runner.rs
@@ -92,10 +92,29 @@ impl ArenaComparison {
         self.run_with_callback(|_| {})
     }
 
-    /// Run the comparison, calling `on_game` after each permutation completes.
+    /// Run the comparison, calling `on_game` after each permutation
+    /// completes. The callback is always called to completion.
     pub fn run_with_callback<F>(&self, mut on_game: F) -> Result<ComparisonResult>
     where
         F: FnMut(PermutationResult),
+    {
+        self.run_with_cancellable_callback(|perm| {
+            on_game(perm);
+            std::ops::ControlFlow::Continue(())
+        })
+    }
+
+    /// Run the comparison, calling `on_game` after each permutation
+    /// completes. The callback returns a `ControlFlow` value; returning
+    /// `Break(())` cancels the comparison after the current permutation,
+    /// leaving any remaining permutations unrun.
+    ///
+    /// Use this variant when a downstream consumer (e.g., a TUI that the
+    /// user quit) wants the comparison to stop promptly rather than
+    /// continuing to allocate CFR trees that will never be observed.
+    pub fn run_with_cancellable_callback<F>(&self, mut on_game: F) -> Result<ComparisonResult>
+    where
+        F: FnMut(PermutationResult) -> std::ops::ControlFlow<()>,
     {
         event!(
             tracing::Level::INFO,
@@ -182,7 +201,13 @@ impl ArenaComparison {
                 ohh_output_path: ohh_output_path.as_ref(),
                 on_game: &mut on_game,
             };
-            self.run_single_game_state(game_state, &mut perm_ctx)?;
+            if self
+                .run_single_game_state(game_state, &mut perm_ctx)?
+                .is_break()
+            {
+                event!(tracing::Level::INFO, game_idx, "Comparison cancelled");
+                break;
+            }
         }
 
         // Build the final aggregated statistics
@@ -197,14 +222,15 @@ impl ArenaComparison {
         ))
     }
 
-    /// Run all permutations for a single game state
+    /// Run all permutations for a single game state. Returns
+    /// `ControlFlow::Break(())` if the callback asked to cancel.
     fn run_single_game_state<F>(
         &self,
         game_state: GameState,
         perm_ctx: &mut PermutationContext<'_, F>,
-    ) -> Result<()>
+    ) -> Result<std::ops::ControlFlow<()>>
     where
-        F: FnMut(PermutationResult),
+        F: FnMut(PermutationResult) -> std::ops::ControlFlow<()>,
     {
         let agent_configs = perm_ctx.agent_configs;
         let agent_names = perm_ctx.agent_names;
@@ -330,7 +356,7 @@ impl ArenaComparison {
                 .iter()
                 .map(|&agent_idx| agent_names[agent_idx].clone())
                 .collect();
-            on_game(PermutationResult {
+            let control = on_game(PermutationResult {
                 agent_names: perm_names,
                 stats: stats.clone(),
                 duration: perm_duration,
@@ -338,9 +364,13 @@ impl ArenaComparison {
 
             // Merge the stats into the builder using agent indices
             builder.merge_permutation_stats(&permutation, &stats);
+
+            if control.is_break() {
+                return Ok(std::ops::ControlFlow::Break(()));
+            }
         }
 
-        Ok(())
+        Ok(std::ops::ControlFlow::Continue(()))
     }
 
     /// Print a summary of the configuration to stdout
@@ -459,6 +489,46 @@ mod tests {
 
         // Check total games
         assert_eq!(result.total_games(), 20);
+    }
+
+    /// Regression test for M5: a callback returning
+    /// `ControlFlow::Break` must stop the comparison after the current
+    /// permutation, leaving the remaining permutations unrun.
+    #[test]
+    fn test_run_with_cancellable_callback_stops_early() {
+        use std::ops::ControlFlow;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let comparison = ComparisonBuilder::new()
+            .num_games(100)
+            .players_per_table(2)
+            .seed(7)
+            .add_agent_config(AgentConfig::Folding {
+                name: Some("A".to_string()),
+            })
+            .add_agent_config(AgentConfig::Calling {
+                name: Some("B".to_string()),
+            })
+            .build()
+            .unwrap();
+
+        let seen = AtomicUsize::new(0);
+        let _ = comparison
+            .run_with_cancellable_callback(|_perm| {
+                let count = seen.fetch_add(1, Ordering::Relaxed) + 1;
+                if count >= 3 {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })
+            .unwrap();
+
+        let count = seen.load(Ordering::Relaxed);
+        assert!(
+            count <= 4,
+            "cancellation should stop after ~3 permutations, got {count}"
+        );
     }
 
     #[test]

--- a/src/bin/rsp/arena/compare.rs
+++ b/src/bin/rsp/arena/compare.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use clap::Args;
@@ -121,16 +122,21 @@ fn perm_to_game_result(perm: PermutationResult, big_blind: f32) -> GameResult {
 }
 
 /// Run the comparison in a background thread, sending results over a channel.
+///
+/// `cancel` is a shared cancellation flag. The callback checks it after
+/// each permutation and returns `Break` to stop the comparison early,
+/// so the worker stops allocating CFR trees as soon as the TUI quits.
 fn run_comparison_background(
     comparison: ArenaComparison,
     tx: std::sync::mpsc::SyncSender<SimMessage<GameResult>>,
     hand_store: HandStore,
     ohh_path: Option<PathBuf>,
     big_blind: f32,
+    cancel: Arc<AtomicBool>,
 ) {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut prev_file_size: u64 = 0;
-        comparison.run_with_callback(|perm| {
+        comparison.run_with_cancellable_callback(|perm| {
             // Track byte offsets for on-demand hand loading
             if let Some(ref path) = ohh_path {
                 let current_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
@@ -141,8 +147,18 @@ fn run_comparison_background(
             }
 
             let game_result = perm_to_game_result(perm, big_blind);
-            // If send fails, the TUI has quit — exit cleanly
-            let _ = tx.send(SimMessage::GameResult(game_result));
+            // If send fails the TUI has quit — mark cancelled so we stop
+            // as soon as the current permutation ends rather than
+            // allocating the next CFR tree.
+            if tx.send(SimMessage::GameResult(game_result)).is_err() {
+                cancel.store(true, Ordering::Release);
+            }
+
+            if cancel.load(Ordering::Acquire) {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
         })
     }));
 
@@ -179,15 +195,27 @@ fn run_comparison_with_tui(
 
     let (tx, rx) = std::sync::mpsc::sync_channel::<SimMessage<GameResult>>(1024);
 
+    // Shared cancellation flag: set when the TUI exits so the background
+    // comparison stops allocating new CFR trees.
+    let cancel = Arc::new(AtomicBool::new(false));
+
     // Must use a large stack to match the main binary's linker-configured stack
     // (47 MB via -Wl,-zstack-size), since CFR traversal with 3+ players recurses
     // deeply and overflows the default 8 MB thread stack.
     let bg_hand_store = hand_store.clone();
+    let bg_cancel = Arc::clone(&cancel);
     const STACK_SIZE: usize = 47 * 1024 * 1024;
-    std::thread::Builder::new()
+    let handle = std::thread::Builder::new()
         .stack_size(STACK_SIZE)
         .spawn(move || {
-            run_comparison_background(comparison, tx, bg_hand_store, ohh_path, big_blind);
+            run_comparison_background(
+                comparison,
+                tx,
+                bg_hand_store,
+                ohh_path,
+                big_blind,
+                bg_cancel,
+            );
         })
         .expect("failed to spawn comparison thread");
 
@@ -195,8 +223,15 @@ fn run_comparison_with_tui(
     let mut tui_app = App::new(Some(total_games));
     tui_app.hand_store = hand_store;
 
-    app::run_app(&mut tui_app, &handler)?;
+    let tui_result = app::run_app(&mut tui_app, &handler);
 
+    // Whatever happened in the TUI, signal the worker to stop and wait
+    // for it to exit before returning. This keeps any caller-owned temp
+    // directory alive until the OHH historian is done writing to it.
+    cancel.store(true, Ordering::Release);
+    let _ = handle.join();
+
+    tui_result?;
     Ok(())
 }
 


### PR DESCRIPTION
`run_comparison_with_tui` spawned the comparison thread, dropped the
`JoinHandle`, and swallowed `tx.send` errors inside the callback — so
after the user quit the TUI the comparison kept running, allocating a
full CFR tree per remaining permutation, and the temp output directory
could be dropped out from under the OHH historian.

Add `ArenaComparison::run_with_cancellable_callback` that takes a
closure returning `ControlFlow<()>` and short-circuits both the
permutation loop and the outer game loop on `Break`. Keep the existing
`run_with_callback` as a `Continue`-always convenience wrapper.

Share an `Arc<AtomicBool>` between the TUI-side runner and the worker
callback; the callback flips it on send failure and returns `Break`
so the worker stops as soon as the current permutation ends. Keep the
worker's `JoinHandle`, set the flag once the TUI event loop returns,
and `join()` the handle before returning — that keeps any caller-owned
temp directory alive until the OHH historian is done writing.

Add a regression test that `run_with_cancellable_callback` stops after
~3 permutations instead of running all 100 configured games.
