### PR TITLE
docs(arena): un-ignore three doctests in cfr and comparison modules

### DIFF
--- a/src/arena/cfr/action_generator/preflop_chart.rs
+++ b/src/arena/cfr/action_generator/preflop_chart.rs
@@ -194,25 +194,34 @@ pub struct PreflopChartActionConfig {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```
+/// use std::sync::Arc;
+///
+/// use rs_poker::arena::GameStateBuilder;
 /// use rs_poker::arena::cfr::{
-///     CFRAgentBuilder, PreflopChartActionGenerator, PreflopChartActionConfig,
-///     CfrDepthConfig, PreflopChartConfig, ConfigurableActionConfig,
+///     ActionGenerator, CFRState, ConfigurableActionConfig, PreflopChartActionConfig,
+///     PreflopChartActionGenerator, PreflopChartConfig, TraversalState,
 /// };
 ///
-/// let preflop_config = PreflopChartConfig::default();
+/// let game_state = GameStateBuilder::new()
+///     .num_players_with_stack(2, 100.0)
+///     .blinds(10.0, 5.0)
+///     .build()
+///     .unwrap();
+///
 /// let action_config = PreflopChartActionConfig {
-///     preflop_config,
+///     preflop_config: PreflopChartConfig::default(),
 ///     postflop_config: ConfigurableActionConfig::default(),
 /// };
 ///
-/// let agent = CFRAgentBuilder::<PreflopChartActionGenerator>::new()
-///     .name("MyAgent")
-///     .player_idx(0)
-///     .game_state(game_state)
-///     .depth_config(CfrDepthConfig::new(vec![10, 5, 1]))
-///     .action_gen_config(action_config)
-///     .build();
+/// let generator = PreflopChartActionGenerator::new(
+///     CFRState::new(game_state.clone()),
+///     TraversalState::new_root(0),
+///     Arc::new(action_config),
+/// );
+///
+/// let actions = generator.gen_possible_actions(&game_state);
+/// assert!(!actions.is_empty());
 /// ```
 pub struct PreflopChartActionGenerator {
     cfr_state: CFRState,

--- a/src/arena/comparison/builder.rs
+++ b/src/arena/comparison/builder.rs
@@ -11,17 +11,23 @@ use super::runner::ArenaComparison;
 ///
 /// # Example
 ///
-/// ```ignore
-/// use rs_poker::arena::comparison::ComparisonBuilder;
+/// ```no_run
+/// use rs_poker::arena::agent::AgentConfig;
+/// use rs_poker::arena::comparison::{ComparisonBuilder, ComparisonError};
 ///
+/// # fn main() -> Result<(), ComparisonError> {
 /// let comparison = ComparisonBuilder::new()
 ///     .num_games(1000)
 ///     .players_per_table(3)
 ///     .big_blind(10.0)
 ///     .small_blind(5.0)
-///     .add_agent_config(agent_config)
+///     .add_agent_config(AgentConfig::Calling { name: None })
+///     .add_agent_config(AgentConfig::Folding { name: None })
+///     .add_agent_config(AgentConfig::AllIn { name: None })
 ///     .seed(42)
 ///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Default)]
 pub struct ComparisonBuilder {

--- a/src/arena/comparison/mod.rs
+++ b/src/arena/comparison/mod.rs
@@ -6,10 +6,12 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use rs_poker::arena::comparison::ComparisonBuilder;
-//! use rs_poker::arena::agent::AgentConfig;
+//! ```no_run
+//! use std::path::PathBuf;
 //!
+//! use rs_poker::arena::comparison::{ComparisonBuilder, ComparisonError};
+//!
+//! # fn main() -> Result<(), ComparisonError> {
 //! // Build a comparison with agents from config files
 //! let comparison = ComparisonBuilder::new()
 //!     .num_games(1000)
@@ -33,7 +35,10 @@
 //! println!("{}", markdown);
 //!
 //! // Save results to files
+//! let output_dir = PathBuf::from("./results");
 //! result.save_to_dir(&output_dir)?;
+//! # Ok(())
+//! # }
 //! ```
 
 mod builder;


### PR DESCRIPTION
Convert the PreflopChartActionGenerator example to a fully runnable
doctest (the prior version also referenced a CFRAgentBuilder API that
no longer exists). Convert the ComparisonBuilder and comparison module
examples to no_run with concrete AgentConfig values and a Result
wrapper so the ? operator compiles.
