### PR TITLE
perf(cfr): single shared tree, compact action space, regret-based pruning, and board enumeration

### DIFF
--- a/benches/cfr.rs
+++ b/benches/cfr.rs
@@ -65,7 +65,7 @@ fn run_cfr_configurable_arena(num_hands: usize) -> GameState {
         .build()
         .unwrap();
 
-    let cfr_states: Vec<CFRState> = (0..2).map(|_| CFRState::new(game_state.clone())).collect();
+    let cfr_state = CFRState::new(game_state.clone());
     let traversal_set = TraversalSet::new(2);
     let builder = ConfigAgentBuilder::from_json(&json).expect("Failed to parse CFR config");
 
@@ -75,7 +75,7 @@ fn run_cfr_configurable_arena(num_hands: usize) -> GameState {
                 .clone()
                 .player_idx(idx)
                 .game_state(game_state.clone())
-                .cfr_context(cfr_states.clone(), traversal_set.clone())
+                .cfr_context(cfr_state.clone(), traversal_set.clone())
                 .build()
         })
         .collect();
@@ -83,7 +83,7 @@ fn run_cfr_configurable_arena(num_hands: usize) -> GameState {
     let mut sim = HoldemSimulationBuilder::default()
         .game_state(game_state)
         .agents(agents)
-        .cfr_context(cfr_states, traversal_set, true)
+        .cfr_context(cfr_state, traversal_set, true)
         .build()
         .unwrap();
 
@@ -100,7 +100,7 @@ fn run_cfr_configurable_arena_default() -> GameState {
         .build()
         .unwrap();
 
-    let cfr_states: Vec<CFRState> = (0..2).map(|_| CFRState::new(game_state.clone())).collect();
+    let cfr_state = CFRState::new(game_state.clone());
     let traversal_set = TraversalSet::new(2);
     let builder =
         ConfigAgentBuilder::from_json(CFR_CONFIGURABLE_JSON).expect("Failed to parse CFR config");
@@ -111,7 +111,7 @@ fn run_cfr_configurable_arena_default() -> GameState {
                 .clone()
                 .player_idx(idx)
                 .game_state(game_state.clone())
-                .cfr_context(cfr_states.clone(), traversal_set.clone())
+                .cfr_context(cfr_state.clone(), traversal_set.clone())
                 .build()
         })
         .collect();
@@ -119,7 +119,7 @@ fn run_cfr_configurable_arena_default() -> GameState {
     let mut sim = HoldemSimulationBuilder::default()
         .game_state(game_state)
         .agents(agents)
-        .cfr_context(cfr_states, traversal_set, true)
+        .cfr_context(cfr_state, traversal_set, true)
         .build()
         .unwrap();
 

--- a/fuzz/fuzz_targets/cfr_mixed_agents.rs
+++ b/fuzz/fuzz_targets/cfr_mixed_agents.rs
@@ -62,10 +62,8 @@ fuzz_target!(|input: MixedAgentInput| {
         .build()
         .unwrap();
 
-    // Create shared CFR context
-    let cfr_states: Vec<CFRState> = (0..game_state.num_players)
-        .map(|_| CFRState::new(game_state.clone()))
-        .collect();
+    // Create shared CFR context (single tree for all players)
+    let cfr_state = CFRState::new(game_state.clone());
     let traversal_set = TraversalSet::new(game_state.num_players);
 
     let agents: Vec<Box<dyn Agent>> = vec![
@@ -74,7 +72,7 @@ fuzz_target!(|input: MixedAgentInput| {
             input.cfr_indices[0],
             input.cfr_variants[0],
             &input.player0_actions,
-            &cfr_states,
+            &cfr_state,
             &traversal_set,
             &depth_hands,
         ),
@@ -83,7 +81,7 @@ fuzz_target!(|input: MixedAgentInput| {
             input.cfr_indices[1],
             input.cfr_variants[1],
             &input.player1_actions,
-            &cfr_states,
+            &cfr_state,
             &traversal_set,
             &depth_hands,
         ),
@@ -93,7 +91,7 @@ fuzz_target!(|input: MixedAgentInput| {
     let mut sim = HoldemSimulationBuilder::default()
         .game_state(game_state)
         .agents(agents)
-        .cfr_context(cfr_states, traversal_set, true)
+        .cfr_context(cfr_state, traversal_set, true)
         .build()
         .unwrap();
 
@@ -111,7 +109,7 @@ fn create_agent(
     is_cfr: bool,
     cfr_variant: CfrVariant,
     actions: &[AgentAction],
-    cfr_states: &[CFRState],
+    cfr_state: &CFRState,
     traversal_set: &TraversalSet,
     depth_hands: &[usize],
 ) -> Box<dyn Agent> {
@@ -122,7 +120,7 @@ fn create_agent(
                 CFRAgentBuilder::<SimpleActionGenerator>::new()
                     .name(format!("CFRAgent-{player_idx}"))
                     .player_idx(player_idx)
-                    .cfr_states(cfr_states.to_vec())
+                    .cfr_state(cfr_state.clone())
                     .traversal_set(traversal_set.clone())
                     .depth_config(depth_config)
                     .action_gen_config(())
@@ -147,7 +145,7 @@ fn create_agent(
                     CFRAgentBuilder::<ConfigurableActionGenerator>::new()
                         .name(format!("CFRConfigurableAgent-{player_idx}"))
                         .player_idx(player_idx)
-                        .cfr_states(cfr_states.to_vec())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(depth_config)
                         .action_gen_config(config)

--- a/fuzz/fuzz_targets/config_agent.rs
+++ b/fuzz/fuzz_targets/config_agent.rs
@@ -175,11 +175,9 @@ fuzz_target!(|input: ConfigAgentInput| {
     // Check if any agent is CFR-based; if so create shared context
     let has_cfr = input.player_configs.iter().any(|c| c.is_cfr());
     let cfr_context = if has_cfr {
-        let cfr_states: Vec<CFRState> = (0..game_state.num_players)
-            .map(|_| CFRState::new(game_state.clone()))
-            .collect();
+        let cfr_state = CFRState::new(game_state.clone());
         let traversal_set = TraversalSet::new(game_state.num_players);
-        Some((cfr_states, traversal_set))
+        Some((cfr_state, traversal_set))
     } else {
         None
     };
@@ -194,8 +192,8 @@ fuzz_target!(|input: ConfigAgentInput| {
             let mut builder = ConfigAgentBuilder::new(config.clone())?
                 .player_idx(idx)
                 .game_state(game_state.clone());
-            if let Some((ref cfr_states, ref ts)) = cfr_context {
-                builder = builder.cfr_context(cfr_states.clone(), ts.clone());
+            if let Some((ref cfr_state, ref ts)) = cfr_context {
+                builder = builder.cfr_context(cfr_state.clone(), ts.clone());
             }
             Ok(builder.build())
         })
@@ -219,8 +217,8 @@ fuzz_target!(|input: ConfigAgentInput| {
         .game_state(game_state)
         .agents(agents)
         .historians(historians);
-    if let Some((cfr_states, traversal_set)) = cfr_context {
-        sim_builder = sim_builder.cfr_context(cfr_states, traversal_set, true);
+    if let Some((cfr_state, traversal_set)) = cfr_context {
+        sim_builder = sim_builder.cfr_context(cfr_state, traversal_set, true);
     }
     let mut sim: HoldemSimulation = sim_builder.build().unwrap();
     sim.run(&mut rng);

--- a/src/arena/agent/config.rs
+++ b/src/arena/agent/config.rs
@@ -442,7 +442,7 @@ pub struct ConfigAgentBuilder {
     config: AgentConfig,
     player_idx: Option<usize>,
     game_state: Option<GameState>,
-    cfr_states: Option<Vec<CFRState>>,
+    cfr_state: Option<CFRState>,
     traversal_set: Option<TraversalSet>,
     thread_pool: Option<Arc<rayon::ThreadPool>>,
     rng_seed: Option<u64>,
@@ -456,7 +456,7 @@ impl ConfigAgentBuilder {
             config,
             player_idx: None,
             game_state: None,
-            cfr_states: None,
+            cfr_state: None,
             traversal_set: None,
             thread_pool: None,
             rng_seed: None,
@@ -471,18 +471,15 @@ impl ConfigAgentBuilder {
 
     /// Set the game state for the agent.
     ///
-    /// For CFR agents, this eagerly initializes CFR states and a
+    /// For CFR agents, this eagerly initializes a shared CFR state and a
     /// `TraversalSet` (unless explicit context was already provided via
     /// `cfr_context()`). This means cloned builders automatically share
     /// the same CFR state (CFRState is cheap to clone via Arc).
     pub fn game_state(mut self, game_state: GameState) -> Self {
         // Eagerly create CFR context so that cloned builders share the
-        // same Arc-backed states. Explicit cfr_context() takes priority.
-        if self.config.is_cfr() && self.cfr_states.is_none() {
-            let cfr_states: Vec<CFRState> = (0..game_state.num_players)
-                .map(|_| CFRState::new(game_state.clone()))
-                .collect();
-            self.cfr_states = Some(cfr_states);
+        // same Arc-backed state. Explicit cfr_context() takes priority.
+        if self.config.is_cfr() && self.cfr_state.is_none() {
+            self.cfr_state = Some(CFRState::new(game_state.clone()));
             self.traversal_set = Some(TraversalSet::new(game_state.num_players));
         }
         self.game_state = Some(game_state);
@@ -494,8 +491,8 @@ impl ConfigAgentBuilder {
     /// When set, all CFR agents built will share the same CFR states
     /// and `TraversalSet`, enabling shared learning across agents.
     /// When not set, each CFR agent creates its own.
-    pub fn cfr_context(mut self, cfr_states: Vec<CFRState>, traversal_set: TraversalSet) -> Self {
-        self.cfr_states = Some(cfr_states);
+    pub fn cfr_context(mut self, cfr_state: CFRState, traversal_set: TraversalSet) -> Self {
+        self.cfr_state = Some(cfr_state);
         self.traversal_set = Some(traversal_set);
         self
     }
@@ -606,24 +603,24 @@ impl ConfigAgentBuilder {
                 }
             }
             AgentConfig::CfrBasic { name, depth_hands } => {
-                let (cfr_states, traversal_set) = self.resolve_cfr_context();
+                let (cfr_state, traversal_set) = self.resolve_cfr_context();
                 let depth_config = CfrDepthConfig::new(depth_hands.clone());
                 let builder = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                     .name(resolve_agent_name(name, "CFRAgent", player_idx))
                     .player_idx(player_idx)
-                    .cfr_states(cfr_states)
+                    .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .depth_config(depth_config)
                     .action_gen_config(());
                 Box::new(self.apply_cfr_options(builder).build())
             }
             AgentConfig::CfrSimple { name, depth_hands } => {
-                let (cfr_states, traversal_set) = self.resolve_cfr_context();
+                let (cfr_state, traversal_set) = self.resolve_cfr_context();
                 let depth_config = CfrDepthConfig::new(depth_hands.clone());
                 let builder = CFRAgentBuilder::<SimpleActionGenerator>::new()
                     .name(resolve_agent_name(name, "CFRSimpleAgent", player_idx))
                     .player_idx(player_idx)
-                    .cfr_states(cfr_states)
+                    .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .depth_config(depth_config)
                     .action_gen_config(());
@@ -634,12 +631,12 @@ impl ConfigAgentBuilder {
                 depth_hands,
                 action_config,
             } => {
-                let (cfr_states, traversal_set) = self.resolve_cfr_context();
+                let (cfr_state, traversal_set) = self.resolve_cfr_context();
                 let depth_config = CfrDepthConfig::new(depth_hands.clone());
                 let builder = CFRAgentBuilder::<ConfigurableActionGenerator>::new()
                     .name(resolve_agent_name(name, "CFRConfigurableAgent", player_idx))
                     .player_idx(player_idx)
-                    .cfr_states(cfr_states)
+                    .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .depth_config(depth_config)
                     .action_gen_config(action_config.as_ref().clone());
@@ -654,7 +651,7 @@ impl ConfigAgentBuilder {
                 let resolved_preflop_config = preflop_config
                     .resolve()
                     .expect("Invalid preflop config - should have been validated");
-                let (cfr_states, traversal_set) = self.resolve_cfr_context();
+                let (cfr_state, traversal_set) = self.resolve_cfr_context();
                 let depth_config = CfrDepthConfig::new(depth_hands.clone());
                 let action_config = PreflopChartActionConfig {
                     preflop_config: resolved_preflop_config,
@@ -666,7 +663,7 @@ impl ConfigAgentBuilder {
                 let builder = CFRAgentBuilder::<PreflopChartActionGenerator>::new()
                     .name(resolve_agent_name(name, "CFRPreflopChartAgent", player_idx))
                     .player_idx(player_idx)
-                    .cfr_states(cfr_states)
+                    .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .depth_config(depth_config)
                     .action_gen_config(action_config);
@@ -698,16 +695,16 @@ impl ConfigAgentBuilder {
     /// # Panics
     ///
     /// Panics if neither `cfr_context()` nor `game_state()` was called.
-    fn resolve_cfr_context(&self) -> (Vec<CFRState>, TraversalSet) {
-        let cfr_states = self
-            .cfr_states
+    fn resolve_cfr_context(&self) -> (CFRState, TraversalSet) {
+        let cfr_state = self
+            .cfr_state
             .clone()
             .expect("cfr_context() or game_state() is required for CFR agents");
         let traversal_set = self
             .traversal_set
             .clone()
             .expect("cfr_context() or game_state() is required for CFR agents");
-        (cfr_states, traversal_set)
+        (cfr_state, traversal_set)
     }
 }
 

--- a/src/arena/cfr/action_bit_set.rs
+++ b/src/arena/cfr/action_bit_set.rs
@@ -1,13 +1,8 @@
-/// A bit set for tracking action indices (0-51).
+/// A bit set for tracking action indices (0-15) and card indices (0-51).
 ///
-/// This is optimized for the CFR action space which has 52 possible action indices:
-/// - Index 0: Fold
-/// - Index 1: Call/Check
-/// - Indices 2-50: Raises (logarithmic distribution)
-/// - Index 51: All-in
-///
-/// Using a `u64` allows O(1) insert and contains operations with no heap allocation,
-/// which is much faster than `HashSet<usize>` for this use case.
+/// Used for the CFR action space (16 action indices) and for card tracking.
+/// Using a `u64` allows O(1) insert and contains operations with no heap
+/// allocation, supporting up to 64 indices.
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ActionBitSet {
     bits: u64,
@@ -30,7 +25,7 @@ impl ActionBitSet {
     /// Panics in debug mode if `idx >= 52`.
     #[inline]
     pub fn insert(&mut self, idx: usize) -> bool {
-        debug_assert!(idx < 52, "Action index must be < 52, got {}", idx);
+        debug_assert!(idx < 64, "Bit index must be < 64, got {}", idx);
         let mask = 1u64 << idx;
         let was_present = (self.bits & mask) != 0;
         self.bits |= mask;
@@ -40,7 +35,7 @@ impl ActionBitSet {
     /// Returns `true` if the set contains the given action index.
     #[inline]
     pub fn contains(&self, idx: usize) -> bool {
-        debug_assert!(idx < 52, "Action index must be < 52, got {}", idx);
+        debug_assert!(idx < 64, "Bit index must be < 64, got {}", idx);
         (self.bits & (1u64 << idx)) != 0
     }
 

--- a/src/arena/cfr/action_generator/preflop_chart.rs
+++ b/src/arena/cfr/action_generator/preflop_chart.rs
@@ -747,10 +747,8 @@ mod tests {
         let config = create_simple_config();
         let depth_config = CfrDepthConfig::new(vec![1]);
 
-        // Create CFR agents with PreflopChartActionGenerator sharing the same CFR states
-        let cfr_states: Vec<CFRState> = (0..game_state.num_players)
-            .map(|_| CFRState::new(game_state.clone()))
-            .collect();
+        // Create CFR agents with PreflopChartActionGenerator sharing a single CFR state
+        let cfr_state = CFRState::new(game_state.clone());
         let traversal_set = TraversalSet::new(game_state.num_players);
         let agents: Vec<Box<dyn Agent>> = (0..2)
             .map(|idx| {
@@ -758,7 +756,7 @@ mod tests {
                     CFRAgentBuilder::<PreflopChartActionGenerator>::new()
                         .name(format!("PreflopChartAgent-{idx}"))
                         .player_idx(idx)
-                        .cfr_states(cfr_states.clone())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(depth_config.clone())
                         .action_gen_config(config.clone())
@@ -772,7 +770,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state, traversal_set, true)
             .build()
             .unwrap();
 
@@ -800,9 +798,7 @@ mod tests {
                 .build()
                 .unwrap();
 
-            let cfr_states: Vec<CFRState> = (0..game_state.num_players)
-                .map(|_| CFRState::new(game_state.clone()))
-                .collect();
+            let cfr_state = CFRState::new(game_state.clone());
             let traversal_set = TraversalSet::new(game_state.num_players);
             let agents: Vec<Box<dyn Agent>> = (0..2)
                 .map(|idx| {
@@ -810,7 +806,7 @@ mod tests {
                         CFRAgentBuilder::<PreflopChartActionGenerator>::new()
                             .name(format!("PreflopChartAgent-game{game_idx}-p{idx}"))
                             .player_idx(idx)
-                            .cfr_states(cfr_states.clone())
+                            .cfr_state(cfr_state.clone())
                             .traversal_set(traversal_set.clone())
                             .depth_config(depth_config.clone())
                             .action_gen_config(config.clone())
@@ -824,7 +820,7 @@ mod tests {
             let mut sim = HoldemSimulationBuilder::default()
                 .game_state(game_state)
                 .agents(agents)
-                .cfr_context(cfr_states, traversal_set, true)
+                .cfr_context(cfr_state, traversal_set, true)
                 .build()
                 .unwrap();
 

--- a/src/arena/cfr/action_index_mapper.rs
+++ b/src/arena/cfr/action_index_mapper.rs
@@ -5,9 +5,15 @@ use crate::arena::{GameState, action::AgentAction};
 /// Total number of action indices in the fixed mapping scheme.
 /// - Index 0: Fold
 /// - Index 1: Call/Check
-/// - Indices 2-50: Raises (spread from min to max using logarithmic distribution)
-/// - Index 51: All-in
-pub const NUM_ACTION_INDICES: usize = 52;
+/// - Indices 2-13: Raises (spread from min to max using logarithmic distribution)
+/// - Index 14: All-in
+/// - Index 15: Reserved
+///
+/// 16 indices is sufficient for typical poker action generators which produce
+/// 4-8 distinct bet sizes. The 12 raise slots provide ~38% log-space resolution,
+/// enough to distinguish standard pot-fraction bets (0.33x, 0.67x, 1.0x, 1.5x).
+/// This compact layout reduces regret matcher memory by ~69% compared to 52 indices.
+pub const NUM_ACTION_INDICES: usize = 16;
 
 /// Index for fold action.
 pub const ACTION_IDX_FOLD: usize = 0;
@@ -19,14 +25,14 @@ pub const ACTION_IDX_CALL: usize = 1;
 pub const ACTION_IDX_RAISE_MIN: usize = 2;
 
 /// Last index for raise actions.
-pub const ACTION_IDX_RAISE_MAX: usize = 50;
+pub const ACTION_IDX_RAISE_MAX: usize = 13;
 
 /// Index for all-in action.
-pub const ACTION_IDX_ALL_IN: usize = 51;
+pub const ACTION_IDX_ALL_IN: usize = 14;
 
 /// Configuration for the ActionIndexMapper.
 ///
-/// Defines the effective range of bet amounts that will be mapped to indices 2-50.
+/// Defines the effective range of bet amounts that will be mapped to raise indices.
 /// Amounts outside this range will be clamped to the boundary indices.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -89,17 +95,18 @@ pub fn compute_effective_range(game_state: &GameState) -> (f32, f32) {
 /// Maps poker actions to fixed indices for the CFR tree.
 ///
 /// This mapper uses a fixed absolute-amount mapping that spreads raises
-/// across indices 2-50 based on the actual bet amount using logarithmic
+/// across indices 2-13 based on the actual bet amount using logarithmic
 /// distribution.
 ///
-/// ## Index Layout (52 total)
+/// ## Index Layout (16 total)
 ///
 /// | Index | Action |
 /// |-------|--------|
 /// | 0 | Fold |
 /// | 1 | Call/Check |
-/// | 2-50 | Raises (spread from min to max using log scale) |
-/// | 51 | All-in |
+/// | 2-13 | Raises (spread from min to max using log scale) |
+/// | 14 | All-in |
+/// | 15 | Reserved |
 ///
 /// The logarithmic distribution is used because poker bet sizing often
 /// grows exponentially (e.g., 3x, 9x, 27x patterns).
@@ -196,9 +203,9 @@ impl ActionIndexMapper {
 
     /// Map a bet amount to an index using logarithmic distribution.
     ///
-    /// Bets <= min_bet map to index 2 (ACTION_IDX_RAISE_MIN).
-    /// Bets >= max_bet map to index 50 (ACTION_IDX_RAISE_MAX).
-    /// Bets in between are distributed logarithmically across indices 2-50.
+    /// Bets <= min_bet map to ACTION_IDX_RAISE_MIN.
+    /// Bets >= max_bet map to ACTION_IDX_RAISE_MAX.
+    /// Bets in between are distributed logarithmically across the raise range.
     fn bet_to_index(&self, bet: f32) -> usize {
         let min_bet = self.config.min_bet;
         let max_bet = self.config.max_bet;
@@ -218,7 +225,7 @@ impl ActionIndexMapper {
         // Compute fraction in log space
         let fraction = (log_bet - log_min) / (log_max - log_min);
 
-        // Map to indices 2-50 (49 slots)
+        // Map to raise index range
         let num_slots = (ACTION_IDX_RAISE_MAX - ACTION_IDX_RAISE_MIN) as f32;
         let index = ACTION_IDX_RAISE_MIN + (fraction * num_slots).round() as usize;
 
@@ -295,7 +302,7 @@ mod tests {
     }
 
     #[test]
-    fn test_all_in_always_maps_to_51() {
+    fn test_all_in_always_maps_to_all_in_idx() {
         let mapper = create_mapper();
         let game_state = create_test_game_state();
 
@@ -318,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bet_matching_all_in_maps_to_51() {
+    fn test_bet_matching_all_in_maps_to_all_in_idx() {
         let mapper = create_mapper();
         let game_state = create_test_game_state();
 
@@ -554,12 +561,12 @@ mod tests {
     fn test_index_to_bet_returns_none_for_out_of_range() {
         let mapper = create_mapper();
 
-        assert!(mapper.index_to_bet(52).is_none());
+        assert!(mapper.index_to_bet(16).is_none());
         assert!(mapper.index_to_bet(100).is_none());
     }
 
     #[test]
     fn test_num_action_indices_constant() {
-        assert_eq!(NUM_ACTION_INDICES, 52);
+        assert_eq!(NUM_ACTION_INDICES, 16);
     }
 }

--- a/src/arena/cfr/action_picker.rs
+++ b/src/arena/cfr/action_picker.rs
@@ -268,7 +268,9 @@ pub fn get_regret_matcher_from_node(node_data: &NodeData) -> Option<&PcfrPlusReg
 mod tests {
     use super::*;
     use crate::arena::GameStateBuilder;
-    use crate::arena::cfr::ActionIndexMapperConfig;
+    use crate::arena::cfr::{
+        ACTION_IDX_ALL_IN, ACTION_IDX_RAISE_MIN, ActionIndexMapperConfig, NUM_ACTION_INDICES,
+    };
 
     fn create_test_game_state() -> GameState {
         GameStateBuilder::new()
@@ -321,13 +323,13 @@ mod tests {
         let mut rng = create_seeded_rng();
 
         // Create a regret matcher with 52 experts (our standard action space)
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
 
         // Update with rewards that heavily favor fold (index 0)
-        let mut rewards = vec![0.0; 52];
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[0] = 100.0; // Fold
         rewards[1] = 0.0; // Call
-        rewards[51] = 0.0; // All-in
+        rewards[ACTION_IDX_ALL_IN] = 0.0; // All-in
         matcher.update_regret(&rewards);
 
         let picker = ActionPicker::new(&mapper, &actions, Some(&matcher), &game_state);
@@ -377,11 +379,11 @@ mod tests {
         ];
 
         // Create a regret matcher that favors all-in
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
-        let mut rewards = vec![0.0; 52];
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[0] = 10.0; // Fold
         rewards[1] = 20.0; // Call
-        rewards[51] = 100.0; // All-in
+        rewards[ACTION_IDX_ALL_IN] = 100.0; // All-in
         matcher.update_regret(&rewards);
 
         let picker = ActionPicker::new(&mapper, &actions, Some(&matcher), &game_state);
@@ -400,11 +402,11 @@ mod tests {
         let actions = vec![AgentAction::Bet(10.0)];
 
         // Create a regret matcher that would favor other actions
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
-        let mut rewards = vec![0.0; 52];
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[0] = 1000.0; // Fold has high weight
         rewards[1] = 1.0; // Call has low weight
-        rewards[51] = 1000.0; // All-in has high weight
+        rewards[ACTION_IDX_ALL_IN] = 1000.0; // All-in has high weight
         matcher.update_regret(&rewards);
 
         let picker = ActionPicker::new(&mapper, &actions, Some(&matcher), &game_state);
@@ -427,7 +429,7 @@ mod tests {
         let mut rng = create_seeded_rng();
 
         // Create a regret matcher with all zero weights
-        let matcher = PcfrPlusRegretMatcher::new(52);
+        let matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
 
         let picker = ActionPicker::new(&mapper, &actions, Some(&matcher), &game_state);
 
@@ -451,8 +453,8 @@ mod tests {
         ];
 
         // Create a regret matcher that strongly favors fold
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
-        let mut rewards = vec![0.0; 52];
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[0] = 1000.0; // Fold
         matcher.update_regret(&rewards);
 
@@ -533,7 +535,7 @@ mod tests {
         let allin_idx = mapper.action_to_idx(&AgentAction::AllIn, &game_state);
         assert_eq!(
             allin_idx, ACTION_IDX_ALL_IN,
-            "AllIn should always map to index 51"
+            "AllIn should always map to ACTION_IDX_ALL_IN"
         );
     }
 
@@ -546,8 +548,8 @@ mod tests {
         let actions = vec![AgentAction::Fold, AgentAction::Bet(10.0)];
 
         // Matcher strongly prefers call (index 1 = check/call)
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
-        let mut rewards = vec![0.0; 52];
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[0] = -50.0; // Fold is bad
         rewards[1] = 50.0; // Call is good
 
@@ -588,12 +590,12 @@ mod tests {
         ];
 
         // All actions have equal weight
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
-        let mut rewards = vec![0.0; 52];
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[0] = 10.0; // Fold
         let bet_idx = mapper.action_to_idx(&AgentAction::Bet(50.0), &game_state);
         rewards[bet_idx] = 10.0; // Same weight
-        rewards[51] = 10.0; // All-in same weight
+        rewards[ACTION_IDX_ALL_IN] = 10.0; // All-in same weight
         matcher.update_regret(&rewards);
 
         let picker = ActionPicker::new(&mapper, &actions, Some(&matcher), &game_state);
@@ -623,8 +625,8 @@ mod tests {
         // the same weight as the call index; if the picker double-counts
         // the raise it will be sampled with probability 2/3 instead of
         // 1/2.
-        let bet_a = AgentAction::Bet(90.0);
-        let bet_b = AgentAction::Bet(91.0);
+        let bet_a = AgentAction::Bet(60.0);
+        let bet_b = AgentAction::Bet(63.0);
         let bet_a_idx = mapper.action_to_idx(&bet_a, &game_state);
         let bet_b_idx = mapper.action_to_idx(&bet_b, &game_state);
         assert_eq!(
@@ -635,8 +637,8 @@ mod tests {
         let call_idx = mapper.action_to_idx(&AgentAction::Bet(10.0), &game_state);
         let actions = vec![AgentAction::Bet(10.0), bet_a.clone(), bet_b.clone()];
 
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
-        let mut rewards = vec![0.0; 52];
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[call_idx] = 50.0;
         rewards[bet_a_idx] = 50.0;
         matcher.update_regret(&rewards);
@@ -673,10 +675,10 @@ mod tests {
         let actions = vec![AgentAction::AllIn];
 
         // Even with a matcher that dislikes this action
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
-        let mut rewards = vec![0.0; 52];
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
+        let mut rewards = vec![0.0; NUM_ACTION_INDICES];
         rewards[0] = 1000.0; // Fold is great (but not available)
-        rewards[51] = -1000.0; // All-in is terrible
+        rewards[ACTION_IDX_ALL_IN] = -1000.0; // All-in is terrible
         matcher.update_regret(&rewards);
 
         let picker = ActionPicker::new(&mapper, &actions, Some(&matcher), &game_state);
@@ -703,7 +705,7 @@ mod tests {
         // Scenario: Fold (idx 0) or Call (idx 1), only these are valid
         let actions = vec![AgentAction::Fold, AgentAction::Bet(10.0)]; // Bet(current_bet) = Call
 
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
 
         // Simulate multiple CFR iterations where Call wins +900 and Fold wins 0
         // Invalid actions get -100 penalty
@@ -714,7 +716,7 @@ mod tests {
         let bet_idx = mapper.action_to_idx(&AgentAction::Bet(10.0), &game_state);
 
         for _ in 0..100 {
-            let mut rewards = vec![invalid_penalty; 52];
+            let mut rewards = vec![invalid_penalty; NUM_ACTION_INDICES];
             rewards[0] = fold_reward;
             rewards[bet_idx] = call_reward;
             matcher.update_regret(&rewards);
@@ -749,13 +751,13 @@ mod tests {
 
         let actions = vec![AgentAction::Fold, AgentAction::Bet(10.0)];
 
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
 
         let bet_idx = mapper.action_to_idx(&AgentAction::Bet(10.0), &game_state);
 
         // Both valid actions have equal reward
         for _ in 0..100 {
-            let mut rewards = vec![-100.0; 52];
+            let mut rewards = vec![-100.0; NUM_ACTION_INDICES];
             rewards[0] = 50.0;
             rewards[bet_idx] = 50.0;
             matcher.update_regret(&rewards);
@@ -786,7 +788,7 @@ mod tests {
         let game_state = create_test_game_state();
         let mapper = create_mapper();
 
-        let mut matcher = PcfrPlusRegretMatcher::new(52);
+        let mut matcher = PcfrPlusRegretMatcher::new(NUM_ACTION_INDICES);
 
         // Get the actual call index (should be 1 for ACTION_IDX_CALL)
         let bet_idx = mapper.action_to_idx(&AgentAction::Bet(10.0), &game_state);
@@ -794,7 +796,7 @@ mod tests {
 
         // Clear winner: Call gets +900, Fold gets 0
         for i in 0..10 {
-            let mut rewards = vec![-100.0; 52];
+            let mut rewards = vec![-100.0; NUM_ACTION_INDICES];
             rewards[0] = 0.0; // Fold (idx 0)
             rewards[1] = 900.0; // Call (idx 1)
 
@@ -804,8 +806,10 @@ mod tests {
             let fold_weight = weights[0];
             let call_weight = weights[1];
             // Sum only the truly invalid indices (2-50, excluding 51 for all-in)
-            let invalid_weight: f32 = weights[2..51].iter().sum();
-            let allin_weight = weights[51];
+            let invalid_weight: f32 = weights[ACTION_IDX_RAISE_MIN..ACTION_IDX_ALL_IN]
+                .iter()
+                .sum();
+            let allin_weight = weights[ACTION_IDX_ALL_IN];
 
             println!(
                 "Iteration {}: fold={:.4}, call={:.4}, invalid_sum={:.4}, allin={:.4}",
@@ -830,7 +834,9 @@ mod tests {
         );
 
         // Invalid actions should have ~0 weight
-        let invalid_weight: f32 = final_weights[2..51].iter().sum();
+        let invalid_weight: f32 = final_weights[ACTION_IDX_RAISE_MIN..ACTION_IDX_ALL_IN]
+            .iter()
+            .sum();
         assert!(
             invalid_weight < 0.01,
             "Invalid actions should have near-zero total weight, got {}",
@@ -882,7 +888,10 @@ mod tests {
 
         // All-in should map to 51
         let allin_idx = mapper.action_to_idx(&AgentAction::AllIn, &game_state);
-        assert_eq!(allin_idx, ACTION_IDX_ALL_IN, "AllIn should map to index 51");
+        assert_eq!(
+            allin_idx, ACTION_IDX_ALL_IN,
+            "AllIn should map to ACTION_IDX_ALL_IN"
+        );
 
         // Player 1's all-in amount (bet = player_bet + stack = 100 + 900 = 1000)
         // But wait, Bet(1000) should map to AllIn since that's the player's all-in amount

--- a/src/arena/cfr/agent.rs
+++ b/src/arena/cfr/agent.rs
@@ -29,7 +29,7 @@ use super::{
 struct ComputeRewardContext<'a, T: ActionGenerator> {
     traversal_set: &'a TraversalSet,
     traversal_state: &'a TraversalState,
-    cfr_states: &'a Arc<[CFRState]>,
+    cfr_state: &'a CFRState,
     depth_config: &'a Arc<CfrDepthConfig>,
     action_gen_config: &'a Arc<T::Config>,
     action_index_mapper: &'a ActionIndexMapper,
@@ -53,7 +53,6 @@ where
     R: Rng + SeedableRng,
 {
     name: Cow<'static, str>,
-    cfr_states: Arc<[CFRState]>,
     traversal_set: TraversalSet,
     traversal_state: TraversalState,
     cfr_state: CFRState,
@@ -93,7 +92,7 @@ where
 
 /// Builder for creating CFR agents with a fluent API.
 ///
-/// All CFR agents in a simulation should share the same `Vec<CFRState>` and
+/// All CFR agents in a simulation should share the same `CFRState` and
 /// `TraversalSet` to enable shared learning and coordinated tree traversal.
 ///
 /// # Type Parameters
@@ -108,9 +107,8 @@ where
     player_idx: Option<usize>,
     depth_config: Option<Arc<CfrDepthConfig>>,
     action_gen_config: Option<Arc<T::Config>>,
-    cfr_states: Option<Arc<[CFRState]>>,
     traversal_set: Option<TraversalSet>,
-    /// Pre-fetched CFR state to avoid lock acquisition in build().
+    /// Single shared CFR state for the entire game tree.
     cfr_state: Option<CFRState>,
     /// Pre-fetched mapper config to avoid lock acquisition in build().
     mapper_config: Option<ActionIndexMapperConfig>,
@@ -138,7 +136,6 @@ where
             player_idx: None,
             depth_config: None,
             action_gen_config: None,
-            cfr_states: None,
             traversal_set: None,
             cfr_state: None,
             mapper_config: None,
@@ -200,19 +197,12 @@ where
         self
     }
 
-    /// Set the shared CFR states for this agent.
+    /// Set the shared CFR state for this agent.
     ///
-    /// All CFR agents in a simulation should share the same Vec<CFRState>.
+    /// All CFR agents in a simulation should share the same CFRState.
     /// CFRState is cheap to clone (just Arc bumps).
-    pub fn cfr_states(mut self, cfr_states: Vec<CFRState>) -> Self {
-        self.cfr_states = Some(cfr_states.into());
-        self
-    }
-
-    /// Set the shared CFR states from a pre-built Arc.
-    /// Used internally by sub-agent construction to avoid re-allocating.
-    fn cfr_states_arc(mut self, cfr_states: Arc<[CFRState]>) -> Self {
-        self.cfr_states = Some(cfr_states);
+    pub fn cfr_state(mut self, cfr_state: CFRState) -> Self {
+        self.cfr_state = Some(cfr_state);
         self
     }
 
@@ -258,28 +248,21 @@ where
     /// Panics if any required fields are not set:
     /// - name
     /// - player_idx
-    /// - cfr_states
+    /// - cfr_state
     /// - traversal_set
     /// - depth_config
     /// - action_gen_config
     pub fn build(self) -> CFRAgent<T, R> {
         let name = self.name.expect("name is required");
-        let player_idx = self.player_idx.expect("player_idx is required");
-        let cfr_states = self.cfr_states.expect("cfr_states is required");
+        let _player_idx = self.player_idx.expect("player_idx is required");
+        let cfr_state = self.cfr_state.expect("cfr_state is required");
         let traversal_set = self.traversal_set.expect("traversal_set is required");
         let depth_config = self.depth_config.expect("depth_config is required");
         let action_gen_config = self
             .action_gen_config
             .expect("action_gen_config is required");
 
-        // Use pre-fetched CFR state if available, otherwise get from the vec
-        let cfr_state = self.cfr_state.unwrap_or_else(|| {
-            cfr_states
-                .get(player_idx)
-                .cloned()
-                .expect("CFR state for player not found")
-        });
-        let traversal_state = traversal_set.get(player_idx);
+        let traversal_state = traversal_set.get(_player_idx);
         let action_generator = T::new(
             cfr_state.clone(),
             traversal_state.clone(),
@@ -297,7 +280,6 @@ where
 
         CFRAgent {
             name,
-            cfr_states,
             traversal_set,
             cfr_state,
             traversal_state,
@@ -311,13 +293,6 @@ where
             thread_pool: self.thread_pool,
             rng,
         }
-    }
-
-    /// Set a pre-fetched CFR state for this agent.
-    /// Used internally by sub-agent construction to avoid re-indexing.
-    fn cfr_state(mut self, cfr_state: CFRState) -> Self {
-        self.cfr_state = Some(cfr_state);
-        self
     }
 
     /// Set a pre-fetched mapper config for this agent.
@@ -374,11 +349,6 @@ where
     /// Returns a clone of this agent's traversal set.
     pub fn traversal_set(&self) -> &TraversalSet {
         &self.traversal_set
-    }
-
-    /// Returns a reference to this agent's CFR states.
-    pub fn cfr_states(&self) -> &[CFRState] {
-        &self.cfr_states
     }
 
     /// Returns whether this agent allows node mutation.
@@ -461,18 +431,20 @@ where
         let action_config = ctx.action_gen_config.clone();
         let cached_mapper_config = *ctx.action_index_mapper.config();
 
+        // All sub-agents share the same CFR state (single shared tree).
+        let shared_cfr_state = ctx.cfr_state.clone();
+
         // Build directly into Vec<Box<dyn Agent>> to avoid an intermediate Vec
         let mut agents: Vec<Box<dyn Agent>> = Vec::with_capacity(num_agents);
-        for (i, cfr_state_i) in ctx.cfr_states.iter().cloned().enumerate() {
+        for i in 0..num_agents {
             let sub_rng = R::from_rng(rng);
             let mut builder = CFRAgentBuilder::<T, R>::new()
                 .name("CFRAgent-sub")
                 .player_idx(i)
-                .cfr_state(cfr_state_i)
+                .cfr_state(shared_cfr_state.clone())
                 .mapper_config(cached_mapper_config)
                 .depth_config_arc(depth_config.clone())
                 .action_gen_config_arc(action_config.clone())
-                .cfr_states_arc(ctx.cfr_states.clone())
                 .traversal_set(forked_traversal_set.clone())
                 .depth(sub_depth)
                 .rng(sub_rng);
@@ -491,8 +463,8 @@ where
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state.clone())
             .agents(agents)
-            .cfr_context_arc(
-                ctx.cfr_states.clone(),
+            .cfr_context(
+                shared_cfr_state,
                 forked_traversal_set,
                 ctx.allow_node_mutation,
             )
@@ -540,9 +512,50 @@ where
     ) -> f32 {
         let mut gs = game_state.clone();
         fast_forward_apply_action(&mut gs, action);
-        fast_forward_run_to_showdown(&mut gs, rng);
-        fast_forward_distribute_pot(&mut gs);
-        gs.player_reward(player_idx)
+
+        // Check if at most one player can contest the pot after the action.
+        let contenders = gs.player_active.count() + gs.player_all_in.count();
+        if contenders <= 1 {
+            fast_forward_run_to_showdown(&mut gs, rng);
+            fast_forward_distribute_pot(&mut gs);
+            return gs.player_reward(player_idx);
+        }
+
+        // Try exhaustive board enumeration for improved reward accuracy.
+        // Advance through any remaining betting (everyone calls) to reach
+        // a deal round or showdown, then enumerate remaining community cards
+        // instead of sampling.
+        fast_forward_advance_betting(&mut gs);
+
+        let cards_needed = match gs.round {
+            Round::Showdown | Round::Complete => 0,
+            Round::DealFlop => 3,
+            Round::DealTurn => 2, // turn + river
+            Round::DealRiver => 1,
+            _ => {
+                // Unexpected round after advancing betting. Fall back.
+                fast_forward_run_to_showdown(&mut gs, rng);
+                fast_forward_distribute_pot(&mut gs);
+                return gs.player_reward(player_idx);
+            }
+        };
+
+        // Enumerate all remaining board completions for zero-variance rewards.
+        // Eliminating sampling noise from board completions produces
+        // deterministic reward signals, improving CFR convergence.
+        //
+        // 0 cards: deterministic showdown (1 eval).
+        // 1 card: ~46 evaluations (river only).
+        // 2 cards: ~C(46,2) ≈ 1035 evaluations (turn + river).
+        // 3 cards: sample FLOP_SAMPLES random flops, then enumerate all
+        //   turn+river combinations for each (~1035 evals per flop).
+        //   This gives low-variance rewards without the cost of full
+        //   C(47,3) ≈ 16K enumeration.
+        if cards_needed <= 2 {
+            fast_forward_enumerate_showdowns(&gs, player_idx, cards_needed)
+        } else {
+            fast_forward_sample_flop_enumerate_runout(&gs, player_idx, rng)
+        }
     }
 
     fn target_node_idx(&self) -> Option<usize> {
@@ -679,12 +692,35 @@ where
         // repeated Vec allocations.
         let mut rewards: Vec<f32> = vec![invalid_action_penalty; NUM_ACTION_INDICES];
 
+        // ── Regret-Based Pruning (Brown & Sandholm, NeurIPS 2015) ────
+        //
+        // After a warmup period, read the regret matcher's current strategy
+        // to identify actions with zero strategy weight. These are actions
+        // whose cumulative regret has been driven to 0 by PCFR+ clamping
+        // and whose predicted future regret is also non-positive. Skipping
+        // their reward computation (which involves expensive sub-simulations)
+        // saves significant computation. Pruned actions keep the penalty
+        // reward, which naturally maintains their zero cumulative regret.
+        //
+        // Every REPROBE_INTERVAL-th iteration, all actions are explored to
+        // detect actions that may have become relevant again.
+        //
+        // Pruning is only applied when:
+        // - The regret matcher has enough history (>= PRUNE_WARMUP updates)
+        // - There are more than 2 actions (with only 2, pruning saves little)
+        // - It's not a reprobe iteration
+        const PRUNE_WARMUP: usize = 3;
+        const REPROBE_INTERVAL: usize = 4;
+
+        let (initial_active, initial_updates) = self.cfr_state.get_pruning_info(target_node_idx);
+        let can_prune = indexed_actions.len() > 2 && initial_updates >= PRUNE_WARMUP;
+
         // Build context struct from self fields for Sync closure capture.
         // CFRAgent is not Sync (StdRng is not Sync), but all context fields are.
         let ctx = ComputeRewardContext::<T> {
             traversal_set: &self.traversal_set,
             traversal_state: &self.traversal_state,
-            cfr_states: &self.cfr_states,
+            cfr_state: &self.cfr_state,
             depth_config: &self.depth_config,
             action_gen_config: &self.action_gen_config,
             action_index_mapper: &self.action_index_mapper,
@@ -694,32 +730,43 @@ where
         };
 
         if let Some(pool) = &self.thread_pool {
+            // ── Parallel path with regret-based pruning ──
+            //
+            // All iterations run in parallel. When the regret matcher has
+            // enough history (can_prune=true from a prior visit to this
+            // node), non-reprobe iterations skip actions with zero strategy
+            // weight. Otherwise all actions are explored.
+            //
+            // Reprobe iterations (every REPROBE_INTERVAL-th) always explore
+            // all actions to detect changes in the active set.
             let num_actions = indexed_actions.len();
             let total_tasks = num_iterations * num_actions;
 
             // Pre-generate one RNG per task from the parent RNG.
-            // Each parallel task gets its own RNG — no sharing, no locking.
             let task_rngs: Vec<R> = (0..total_tasks)
                 .map(|_| R::from_rng(&mut self.rng))
                 .collect();
 
-            // Run ALL iterations × actions in parallel.
-            // Results are ordered by task_id (iter_idx * num_actions + action_pos)
-            // because Rayon's indexed parallel iterators preserve ordering.
+            let active_actions = if can_prune {
+                initial_active
+            } else {
+                seen_indices // all valid actions
+            };
+
             let results: Vec<(usize, f32)> = pool.install(|| {
                 task_rngs
                     .into_par_iter()
                     .enumerate()
                     .map(|(task_id, mut rng)| {
+                        let iter_idx = task_id / num_actions;
                         let action_pos = task_id % num_actions;
                         let (action, reward_idx) = &indexed_actions[action_pos];
 
-                        debug_assert!(
-                            *reward_idx < NUM_ACTION_INDICES,
-                            "Action index {} should be less than number of potential actions {}",
-                            reward_idx,
-                            NUM_ACTION_INDICES
-                        );
+                        // Skip pruned actions on non-reprobe iterations
+                        let is_reprobe = iter_idx.is_multiple_of(REPROBE_INTERVAL);
+                        if can_prune && !is_reprobe && !active_actions.contains(*reward_idx) {
+                            return (*reward_idx, invalid_action_penalty);
+                        }
 
                         let reward = Self::compute_reward(game_state, action, &mut rng, &ctx);
                         (*reward_idx, reward)
@@ -728,8 +775,6 @@ where
             });
 
             // Apply regret updates sequentially, grouped by iteration.
-            // Results are ordered by task_id (iter_idx * num_actions + action_pos),
-            // so we can process them in chunks of num_actions — O(n * actions).
             for chunk in results.chunks(num_actions) {
                 rewards.fill(invalid_action_penalty);
                 for &(reward_idx, reward) in chunk {
@@ -738,26 +783,41 @@ where
                 self.update_regret_at_node(target_node_idx, &rewards);
             }
         } else {
-            // Sequential path — used when no thread pool is configured.
-            // Process each iteration independently and update regret immediately.
-            // This helps the regret matcher converge better than averaging rewards
-            // across all iterations before updating.
-            for _ in 0..num_iterations {
+            // ── Sequential path with regret-based pruning ──
+            //
+            // Track the active action set. It starts from the initial read
+            // and gets refreshed after each reprobe iteration so the pruning
+            // mask stays current as regrets evolve within this call.
+            let mut active_actions = initial_active;
+            let mut updates_since_warmup = initial_updates;
+
+            for iter_idx in 0..num_iterations {
                 // Reset to penalty for all actions, valid ones get overwritten
                 rewards.fill(invalid_action_penalty);
 
+                // Decide whether to prune this iteration.
+                // On reprobe iterations (every REPROBE_INTERVAL-th), explore all actions.
+                let prune_this_iter = can_prune || updates_since_warmup >= PRUNE_WARMUP;
+                let is_reprobe = iter_idx % REPROBE_INTERVAL == 0;
+                let skip_pruned = prune_this_iter && !is_reprobe;
+
                 for (action, reward_idx) in &indexed_actions {
+                    // Regret-based pruning: skip actions with zero strategy weight
+                    if skip_pruned && !active_actions.contains(*reward_idx) {
+                        event!(
+                            tracing::Level::TRACE,
+                            action_idx = reward_idx,
+                            iter = iter_idx,
+                            "RBP: skipping pruned action"
+                        );
+                        continue;
+                    }
+
                     debug_assert!(
                         *reward_idx < rewards.len(),
                         "Action index {} should be less than number of potential actions {}",
                         reward_idx,
                         rewards.len()
-                    );
-                    debug_assert!(
-                        seen_indices.contains(*reward_idx),
-                        "Action {:?} mapped to index {} which should be in seen_indices",
-                        action,
-                        reward_idx
                     );
 
                     rewards[*reward_idx] =
@@ -766,6 +826,14 @@ where
 
                 // Update regret immediately for this game state
                 self.update_regret_at_node(target_node_idx, &rewards);
+                updates_since_warmup += 1;
+
+                // After a reprobe iteration, refresh the active action set
+                // from the updated regret matcher.
+                if is_reprobe && (can_prune || updates_since_warmup >= PRUNE_WARMUP) {
+                    let (new_active, _) = self.cfr_state.get_pruning_info(target_node_idx);
+                    active_actions = new_active;
+                }
             }
         }
     }
@@ -932,6 +1000,274 @@ fn fast_forward_distribute_pot(gs: &mut GameState) {
     gs.total_pot = 0.0;
 }
 
+/// Advance the game state through all remaining betting rounds (everyone
+/// calls/checks) until a deal round or showdown is reached. This separates
+/// the deterministic betting from the stochastic card dealing, allowing
+/// the caller to enumerate board completions instead of sampling.
+fn fast_forward_advance_betting(gs: &mut GameState) {
+    // Safety cap: at most 8 round advances to prevent infinite loops.
+    for _ in 0..8 {
+        match gs.round {
+            // Stop at deal rounds — the caller will enumerate cards.
+            Round::DealFlop | Round::DealTurn | Round::DealRiver => return,
+            // Stop at terminal states.
+            Round::Showdown | Round::Complete => return,
+            // Skip non-betting advance rounds.
+            Round::Starting | Round::Ante | Round::DealPreflop => gs.advance_round(),
+            // Betting rounds: everyone calls, then advance.
+            Round::Preflop | Round::Flop | Round::Turn | Round::River => {
+                fast_forward_everyone_calls(gs);
+                gs.advance_round();
+            }
+        }
+    }
+}
+
+/// Enumerate all possible board completions and compute the exact expected
+/// reward for `player_idx`.
+///
+/// This replaces the random-sample approach in `fast_forward_run_to_showdown`
+/// with deterministic enumeration when the number of remaining cards is small
+/// enough (0, 1, or 2 cards). The result is zero variance in the reward
+/// signal, which dramatically improves CFR convergence quality.
+///
+/// # Arguments
+///
+/// * `gs` - Game state positioned at a deal round (or showdown) after all
+///   betting is resolved. The `total_pot` must already reflect all bets.
+/// * `player_idx` - The player whose reward we compute.
+/// * `cards_needed` - Number of community cards still to be dealt (0, 1, or 2).
+fn fast_forward_enumerate_showdowns(gs: &GameState, player_idx: usize, cards_needed: usize) -> f32 {
+    let contenders = gs.player_active | gs.player_all_in;
+    let contender_count = contenders.count();
+
+    // No contenders means everyone folded; the pot was already awarded.
+    if contender_count == 0 {
+        return gs.player_reward(player_idx);
+    }
+
+    // Single contender: they win everything regardless of board.
+    if contender_count == 1 {
+        let winner = contenders.ones().next().unwrap();
+        let pot = gs.total_pot;
+        let winnings = if winner == player_idx { pot } else { 0.0 };
+        return winnings - gs.starting_stacks[player_idx];
+    }
+
+    let pot = gs.total_pot;
+    if pot <= 0.0 {
+        return gs.player_reward(player_idx);
+    }
+
+    // Collect the remaining deck into a Vec for indexed access.
+    let deck = fast_forward_remaining_deck(gs);
+    let remaining: Vec<crate::core::Card> = deck.iter().collect();
+
+    if cards_needed == 0 {
+        // Board is complete — just evaluate the showdown.
+        return evaluate_showdown_reward(gs, &contenders, pot, player_idx);
+    }
+
+    let starting_stack = gs.starting_stacks[player_idx];
+    let mut total_reward = 0.0f64;
+    let mut count = 0u32;
+
+    if cards_needed == 1 {
+        // Enumerate single card (river).
+        for &card in &remaining {
+            let reward = evaluate_with_extra_cards(gs, &contenders, pot, player_idx, &[card]);
+            total_reward += f64::from(reward - starting_stack);
+            count += 1;
+        }
+    } else {
+        // cards_needed == 2: enumerate all ordered pairs (turn + river).
+        // We use ordered pairs (i < j) since card order doesn't matter for
+        // hand evaluation, but we count each pair once.
+        for i in 0..remaining.len() {
+            for j in (i + 1)..remaining.len() {
+                let reward = evaluate_with_extra_cards(
+                    gs,
+                    &contenders,
+                    pot,
+                    player_idx,
+                    &[remaining[i], remaining[j]],
+                );
+                total_reward += f64::from(reward - starting_stack);
+                count += 1;
+            }
+        }
+    }
+
+    (total_reward / f64::from(count)) as f32
+}
+
+/// Number of random flop samples to draw when 3 community cards remain.
+/// For each sampled flop, all turn+river combinations are enumerated
+/// exhaustively (~C(44,2) ≈ 946 evals per flop). This hybrid approach
+/// gives much lower variance than a single random runout at modest cost.
+const FLOP_SAMPLES: usize = 3;
+
+/// Sample random flops and enumerate all turn+river completions for each.
+///
+/// When 3 community cards remain (pre-flop fast-forward), full enumeration
+/// costs C(47,3) ≈ 16K evaluations — too expensive per action. Instead we
+/// sample `FLOP_SAMPLES` random flop combinations and for each one
+/// exhaustively enumerate all C(remaining,2) turn+river pairs. This
+/// eliminates variance from 2 of the 3 unknown cards while keeping cost
+/// at roughly `FLOP_SAMPLES × 1000` evaluations.
+fn fast_forward_sample_flop_enumerate_runout<R: Rng>(
+    gs: &GameState,
+    player_idx: usize,
+    rng: &mut R,
+) -> f32 {
+    fast_forward_sample_flop_enumerate_runout_n(gs, player_idx, rng, FLOP_SAMPLES)
+}
+
+/// Inner implementation parameterized by sample count for benchmarking.
+fn fast_forward_sample_flop_enumerate_runout_n<R: Rng>(
+    gs: &GameState,
+    player_idx: usize,
+    rng: &mut R,
+    num_samples: usize,
+) -> f32 {
+    let contenders = gs.player_active | gs.player_all_in;
+    let contender_count = contenders.count();
+
+    if contender_count <= 1 {
+        if contender_count == 0 {
+            return gs.player_reward(player_idx);
+        }
+        let winner = contenders.ones().next().unwrap();
+        let pot = gs.total_pot;
+        let winnings = if winner == player_idx { pot } else { 0.0 };
+        return winnings - gs.starting_stacks[player_idx];
+    }
+
+    let pot = gs.total_pot;
+    if pot <= 0.0 {
+        return gs.player_reward(player_idx);
+    }
+
+    let mut deck = fast_forward_remaining_deck(gs);
+    let starting_stack = gs.starting_stacks[player_idx];
+    let mut total_reward = 0.0f64;
+    let mut total_count = 0u64;
+
+    for _ in 0..num_samples {
+        // Deal 3 random flop cards from the deck.
+        let flop_cards: Vec<crate::core::Card> = (0..3).filter_map(|_| deck.deal(rng)).collect();
+        if flop_cards.len() < 3 {
+            // Not enough cards — shouldn't happen in practice.
+            break;
+        }
+
+        // Build a temporary game state with the flop applied to hands.
+        let mut gs_with_flop = gs.clone();
+        for &card in &flop_cards {
+            gs_with_flop.board.push(card);
+            for hand in gs_with_flop.hands.iter_mut() {
+                hand.insert(card);
+            }
+        }
+
+        // Collect remaining cards (excluding the sampled flop).
+        let flop_deck = fast_forward_remaining_deck(&gs_with_flop);
+        let remaining: Vec<crate::core::Card> = flop_deck.iter().collect();
+
+        // Enumerate all turn+river combinations exhaustively.
+        for i in 0..remaining.len() {
+            for j in (i + 1)..remaining.len() {
+                let reward = evaluate_with_extra_cards(
+                    &gs_with_flop,
+                    &contenders,
+                    pot,
+                    player_idx,
+                    &[remaining[i], remaining[j]],
+                );
+                total_reward += f64::from(reward - starting_stack);
+                total_count += 1;
+            }
+        }
+
+        // Put flop cards back in the deck for the next sample.
+        for &card in &flop_cards {
+            deck.insert(card);
+        }
+    }
+
+    if total_count == 0 {
+        return gs.player_reward(player_idx);
+    }
+
+    (total_reward / total_count as f64) as f32
+}
+
+/// Evaluate the showdown reward for a specific board completion.
+///
+/// Temporarily adds the given extra cards to each contender's hand,
+/// ranks the hands, determines the winner(s), and returns the winnings
+/// for `player_idx` (pot share if winner, 0 otherwise).
+fn evaluate_with_extra_cards(
+    gs: &GameState,
+    contenders: &PlayerBitSet,
+    pot: f32,
+    player_idx: usize,
+    extra_cards: &[crate::core::Card],
+) -> f32 {
+    use crate::core::Rankable;
+
+    let mut best_rank = None;
+    let mut winners = PlayerBitSet::default();
+    let mut player_rank = None;
+
+    for idx in contenders.ones() {
+        let mut hand = gs.hands[idx];
+        for &card in extra_cards {
+            hand.insert(card);
+        }
+        let rank = hand.rank();
+
+        if idx == player_idx {
+            player_rank = Some(rank);
+        }
+
+        match best_rank {
+            None => {
+                best_rank = Some(rank);
+                winners.enable(idx);
+            }
+            Some(current) if rank > current => {
+                best_rank = Some(rank);
+                winners = PlayerBitSet::default();
+                winners.enable(idx);
+            }
+            Some(current) if rank == current => {
+                winners.enable(idx);
+            }
+            _ => {}
+        }
+    }
+
+    // Check if player_idx is among the winners.
+    let _ = player_rank; // Used only if we wanted EV-based metrics.
+    if winners.ones().any(|w| w == player_idx) {
+        pot / winners.count() as f32
+    } else {
+        0.0
+    }
+}
+
+/// Evaluate showdown with the current board (no extra cards).
+fn evaluate_showdown_reward(
+    gs: &GameState,
+    contenders: &PlayerBitSet,
+    pot: f32,
+    player_idx: usize,
+) -> f32 {
+    let reward = evaluate_with_extra_cards(gs, contenders, pot, player_idx, &[]);
+    reward - gs.starting_stacks[player_idx]
+}
+
 impl<T, R> Agent for CFRAgent<T, R>
 where
     T: ActionGenerator + 'static,
@@ -1068,10 +1404,8 @@ mod tests {
     use super::*;
 
     /// Helper to create CFR states for all players from a game state.
-    fn make_cfr_states(game_state: &GameState) -> Vec<CFRState> {
-        (0..game_state.num_players)
-            .map(|_| CFRState::new(game_state.clone()))
-            .collect()
+    fn make_cfr_state(game_state: &GameState) -> CFRState {
+        CFRState::new(game_state.clone())
     }
 
     /// Test that a CFR agent can play against a non-CFR agent.
@@ -1090,14 +1424,14 @@ mod tests {
             .unwrap();
 
         // Create shared CFR states and TraversalSet
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
 
         let cfr_agent = Box::new(
             CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                 .name("CFRAgent-player1")
                 .player_idx(1)
-                .cfr_states(cfr_states.clone())
+                .cfr_state(cfr_state.clone())
                 .traversal_set(traversal_set.clone())
                 .depth_config(CfrDepthConfig::new(vec![1]))
                 .action_gen_config(())
@@ -1114,7 +1448,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state.clone(), traversal_set, true)
             .build()
             .unwrap();
 
@@ -1165,13 +1499,13 @@ mod tests {
         game_state.round_data.total_raise_count = 2;
         assert!(game_state.is_raise_capped());
 
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
 
         let mut agent = CFRAgentBuilder::<ConfigurableActionGenerator>::new()
             .name("CFRAgent-cap-test")
             .player_idx(game_state.to_act_idx())
-            .cfr_states(cfr_states)
+            .cfr_state(cfr_state.clone())
             .traversal_set(traversal_set)
             .depth_config(CfrDepthConfig::new(vec![1]))
             .action_gen_config(ConfigurableActionConfig::default())
@@ -1204,12 +1538,12 @@ mod tests {
             .blinds(10.0, 5.0)
             .build()
             .unwrap();
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
         let _ = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
             .name("CFRAgent-test")
             .player_idx(0)
-            .cfr_states(cfr_states)
+            .cfr_state(cfr_state.clone())
             .traversal_set(traversal_set)
             .depth_config(CfrDepthConfig::new(vec![1]))
             .action_gen_config(())
@@ -1227,7 +1561,7 @@ mod tests {
             .unwrap();
 
         // All CFR agents share the same CFR states and TraversalSet.
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
         let agents: Vec<Box<dyn Agent>> = (0..num_agents)
             .map(|i| {
@@ -1235,7 +1569,7 @@ mod tests {
                     CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                         .name(format!("CFRAgent-test-{i}"))
                         .player_idx(i)
-                        .cfr_states(cfr_states.clone())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(CfrDepthConfig::new(vec![2, 1]))
                         .action_gen_config(())
@@ -1249,7 +1583,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state.clone(), traversal_set, true)
             .build()
             .unwrap();
 
@@ -1267,7 +1601,7 @@ mod tests {
             .unwrap();
 
         // Create shared CFR states and traversal set
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
 
         let depth_config = CfrDepthConfig::new(vec![1]);
@@ -1276,7 +1610,7 @@ mod tests {
         let agent0 = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
             .name("Agent0")
             .player_idx(0)
-            .cfr_states(cfr_states.clone())
+            .cfr_state(cfr_state.clone())
             .traversal_set(traversal_set.clone())
             .depth_config(depth_config.clone())
             .action_gen_config(())
@@ -1285,7 +1619,7 @@ mod tests {
         let agent1 = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
             .name("Agent1")
             .player_idx(1)
-            .cfr_states(cfr_states)
+            .cfr_state(cfr_state.clone())
             .traversal_set(traversal_set)
             .depth_config(depth_config)
             .action_gen_config(())
@@ -1316,7 +1650,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
 
         let pool = Arc::new(
@@ -1332,7 +1666,7 @@ mod tests {
                     CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                         .name(format!("CFRAgent-par-{i}"))
                         .player_idx(i)
-                        .cfr_states(cfr_states.clone())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(CfrDepthConfig::new(vec![2, 1]))
                         .action_gen_config(())
@@ -1347,7 +1681,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state.clone(), traversal_set, true)
             .build()
             .unwrap();
 
@@ -1365,7 +1699,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
 
         let pool = Arc::new(
@@ -1381,7 +1715,7 @@ mod tests {
                     CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                         .name(format!("CFRAgent-par-{i}"))
                         .player_idx(i)
-                        .cfr_states(cfr_states.clone())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(CfrDepthConfig::new(vec![2, 1]))
                         .action_gen_config(())
@@ -1396,19 +1730,17 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(agents)
-            .cfr_context(cfr_states.clone(), traversal_set, true)
+            .cfr_context(cfr_state.clone(), traversal_set, true)
             .build()
             .unwrap();
 
         sim.run(&mut rng);
 
-        // After running, the CFR tree should have grown beyond just the root node
-        for state in &cfr_states {
-            assert!(
-                state.arena().len() > 1,
-                "CFR tree should have grown during simulation"
-            );
-        }
+        // After running, the shared CFR tree should have grown beyond just the root node
+        assert!(
+            cfr_state.arena().len() > 1,
+            "CFR tree should have grown during simulation"
+        );
     }
 
     /// Test that TraversalSet fork() provides proper sub-simulation isolation.
@@ -1541,7 +1873,7 @@ mod tests {
         assert_eq!(game_state.current_player_stack(), 300.0); // P1's stack
 
         // Create CFR agent for Player 1
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
 
         // Use the configurable action generator (same as preflop chart post-flop)
@@ -1550,7 +1882,7 @@ mod tests {
         let mut agent = CFRAgentBuilder::<ConfigurableActionGenerator, StdRng>::new()
             .name("TestCFRAgent")
             .player_idx(1)
-            .cfr_states(cfr_states.clone())
+            .cfr_state(cfr_state.clone())
             .traversal_set(traversal_set.clone())
             .depth_config(CfrDepthConfig::new(vec![24, 3, 1]))
             .action_gen_config(action_config)
@@ -1659,13 +1991,13 @@ mod tests {
         game_state.starting_stacks = starting_stacks;
         game_state.total_pot = 1100.0;
 
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
 
         let mut agent = CFRAgentBuilder::<ConfigurableActionGenerator, StdRng>::new()
             .name("CFR-ff")
             .player_idx(1)
-            .cfr_states(cfr_states)
+            .cfr_state(cfr_state.clone())
             .traversal_set(traversal_set)
             .depth_config(CfrDepthConfig::new(vec![]))
             .action_gen_config(ConfigurableActionConfig::default())
@@ -1923,5 +2255,458 @@ mod tests {
         // point is that we reached showdown (board has 5 cards) instead of
         // panicking on an empty deck / missing cards.
         assert_eq!(gs.board.len(), 5);
+    }
+
+    /// Test that regret-based pruning produces the same correct result
+    /// as the unpruned path. With enough iterations, the agent should
+    /// still fold K-high facing an all-in.
+    #[test]
+    fn test_rbp_preserves_fold_decision() {
+        use crate::arena::cfr::action_generator::{
+            ConfigurableActionConfig, ConfigurableActionGenerator,
+        };
+        use crate::arena::game_state::Round;
+        use crate::core::{Card, Hand, PlayerBitSet, Suit, Value};
+        use rand::SeedableRng;
+
+        let board_cards = vec![
+            Card::new(Value::Four, Suit::Spade),
+            Card::new(Value::Four, Suit::Diamond),
+            Card::new(Value::Nine, Suit::Diamond),
+            Card::new(Value::Ace, Suit::Heart),
+            Card::new(Value::Jack, Suit::Diamond),
+        ];
+        let p0_hole = vec![
+            Card::new(Value::Nine, Suit::Heart),
+            Card::new(Value::Queen, Suit::Spade),
+        ];
+        let p1_hole = vec![
+            Card::new(Value::Seven, Suit::Spade),
+            Card::new(Value::King, Suit::Spade),
+        ];
+        let mut p0_hand = Hand::new_with_cards(p0_hole);
+        p0_hand.extend(board_cards.iter().copied());
+        let mut p1_hand = Hand::new_with_cards(p1_hole);
+        p1_hand.extend(board_cards.iter().copied());
+
+        let stacks = vec![0.0, 300.0];
+        let starting_stacks = vec![700.0, 700.0];
+        let player_bet = vec![700.0, 400.0];
+        let round_player_bet = vec![500.0, 0.0];
+        let mut active = PlayerBitSet::new(2);
+        active.disable(0);
+        let round_data =
+            crate::arena::game_state::RoundData::new_with_bets(10.0, active, 1, round_player_bet);
+
+        let mut game_state = GameStateBuilder::new()
+            .round(Round::River)
+            .round_data(round_data)
+            .stacks(stacks)
+            .player_bet(player_bet)
+            .big_blind(10.0)
+            .small_blind(5.0)
+            .hands(vec![p0_hand, p1_hand])
+            .board(board_cards)
+            .build()
+            .unwrap();
+        game_state.starting_stacks = starting_stacks;
+
+        // Use 24 iterations — enough for RBP to kick in (warmup=3, reprobe every 4th).
+        // Pruning should skip computing rewards for clearly-bad actions after warmup.
+        let cfr_state = make_cfr_state(&game_state);
+        let traversal_set = TraversalSet::new(game_state.num_players);
+
+        let mut agent = CFRAgentBuilder::<ConfigurableActionGenerator, StdRng>::new()
+            .name("CFR-RBP-test")
+            .player_idx(1)
+            .cfr_state(cfr_state.clone())
+            .traversal_set(traversal_set)
+            .depth_config(CfrDepthConfig::new(vec![24, 3, 1]))
+            .action_gen_config(ConfigurableActionConfig::default())
+            .rng(StdRng::seed_from_u64(42))
+            .build();
+
+        let chosen = agent.act(0, &game_state);
+        assert!(
+            matches!(chosen, AgentAction::Fold),
+            "RBP should preserve the fold decision for K-high vs pair, got {:?}",
+            chosen
+        );
+    }
+
+    /// Test that regret-based pruning actually activates by verifying
+    /// that the pruning info bitset becomes sparse after warmup.
+    #[test]
+    fn test_rbp_reduces_active_actions() {
+        use crate::arena::cfr::action_generator::{
+            ConfigurableActionConfig, ConfigurableActionGenerator,
+        };
+        use crate::arena::game_state::Round;
+        use crate::core::{Card, Hand, PlayerBitSet, Suit, Value};
+        use rand::SeedableRng;
+
+        let board_cards = vec![
+            Card::new(Value::Four, Suit::Spade),
+            Card::new(Value::Four, Suit::Diamond),
+            Card::new(Value::Nine, Suit::Diamond),
+            Card::new(Value::Ace, Suit::Heart),
+            Card::new(Value::Jack, Suit::Diamond),
+        ];
+        let p0_hole = vec![
+            Card::new(Value::Nine, Suit::Heart),
+            Card::new(Value::Queen, Suit::Spade),
+        ];
+        let p1_hole = vec![
+            Card::new(Value::Seven, Suit::Spade),
+            Card::new(Value::King, Suit::Spade),
+        ];
+        let mut p0_hand = Hand::new_with_cards(p0_hole);
+        p0_hand.extend(board_cards.iter().copied());
+        let mut p1_hand = Hand::new_with_cards(p1_hole);
+        p1_hand.extend(board_cards.iter().copied());
+
+        let stacks = vec![0.0, 300.0];
+        let starting_stacks = vec![700.0, 700.0];
+        let player_bet = vec![700.0, 400.0];
+        let round_player_bet = vec![500.0, 0.0];
+        let mut active = PlayerBitSet::new(2);
+        active.disable(0);
+        let round_data =
+            crate::arena::game_state::RoundData::new_with_bets(10.0, active, 1, round_player_bet);
+
+        let mut game_state = GameStateBuilder::new()
+            .round(Round::River)
+            .round_data(round_data)
+            .stacks(stacks)
+            .player_bet(player_bet)
+            .big_blind(10.0)
+            .small_blind(5.0)
+            .hands(vec![p0_hand, p1_hand])
+            .board(board_cards)
+            .build()
+            .unwrap();
+        game_state.starting_stacks = starting_stacks;
+
+        let cfr_state = make_cfr_state(&game_state);
+        let traversal_set = TraversalSet::new(game_state.num_players);
+
+        let mut agent = CFRAgentBuilder::<ConfigurableActionGenerator, StdRng>::new()
+            .name("CFR-RBP-sparse")
+            .player_idx(1)
+            .cfr_state(cfr_state.clone())
+            .traversal_set(traversal_set)
+            .depth_config(CfrDepthConfig::new(vec![24, 3, 1]))
+            .action_gen_config(ConfigurableActionConfig::default())
+            .rng(StdRng::seed_from_u64(42))
+            .build();
+
+        // Run exploration
+        let _ = agent.act(0, &game_state);
+
+        // After 24 iterations with clear fold > call, the active set
+        // should have fewer actions than the total valid set.
+        let target_node_idx = agent.target_node_idx().unwrap();
+        let (active_set, num_updates) = agent.cfr_state.get_pruning_info(target_node_idx);
+
+        println!(
+            "After exploration: {} active actions, {} updates",
+            active_set.count(),
+            num_updates
+        );
+
+        // The regret matcher should have been updated at least 24 times
+        assert!(
+            num_updates >= 24,
+            "Expected >= 24 updates, got {}",
+            num_updates
+        );
+
+        // With a clear fold vs call scenario, not all actions should remain active.
+        // Fold should dominate, so call and other actions should have 0 weight.
+        // We expect at most 2 active actions (fold + possibly one other)
+        // in this lopsided scenario.
+        assert!(
+            active_set.count() <= 3,
+            "Expected <= 3 active actions after pruning, got {}. \
+             In this lopsided fold-vs-call scenario, most actions should be pruned.",
+            active_set.count()
+        );
+    }
+
+    /// Test that multi-sample flop + exhaustive runout produces lower
+    /// variance than single-sample for a preflop scenario.
+    ///
+    /// Runs both approaches many times with different RNG seeds and
+    /// compares the standard deviation of the rewards.
+    #[test]
+    fn test_flop_sample_variance_vs_single_sample() {
+        use crate::arena::game_state::Round;
+        use crate::core::{Card, Hand, Suit, Value};
+        use rand::SeedableRng;
+
+        // Set up a preflop-like game state where both players are all-in
+        // and we need to deal flop+turn+river.
+        let p0_hole = vec![
+            Card::new(Value::Ace, Suit::Spade),
+            Card::new(Value::King, Suit::Spade),
+        ];
+        let p1_hole = vec![
+            Card::new(Value::Queen, Suit::Heart),
+            Card::new(Value::Jack, Suit::Heart),
+        ];
+        let p0_hand = Hand::new_with_cards(p0_hole);
+        let p1_hand = Hand::new_with_cards(p1_hole);
+
+        // stacks=0 + bets>0 in a non-Starting round → both players all-in
+        let mut game_state = GameStateBuilder::new()
+            .round(Round::DealFlop)
+            .stacks(vec![0.0, 0.0])
+            .player_bet(vec![500.0, 500.0])
+            .big_blind(10.0)
+            .small_blind(5.0)
+            .hands(vec![p0_hand, p1_hand])
+            .build()
+            .unwrap();
+        game_state.starting_stacks = vec![500.0, 500.0];
+
+        let num_trials = 50;
+
+        // Multi-sample flop + exhaustive runout (current approach)
+        let multi_results: Vec<f32> = (0..num_trials)
+            .map(|seed| {
+                let mut rng = StdRng::seed_from_u64(seed);
+                fast_forward_sample_flop_enumerate_runout(&game_state, 0, &mut rng)
+            })
+            .collect();
+
+        // Single-sample baseline (old approach: random runout)
+        let single_results: Vec<f32> = (0..num_trials)
+            .map(|seed| {
+                let mut gs = game_state.clone();
+                let mut rng = StdRng::seed_from_u64(seed);
+                fast_forward_run_to_showdown(&mut gs, &mut rng);
+                fast_forward_distribute_pot(&mut gs);
+                gs.player_reward(0)
+            })
+            .collect();
+
+        fn std_dev(vals: &[f32]) -> f64 {
+            let n = vals.len() as f64;
+            let mean = vals.iter().map(|&v| v as f64).sum::<f64>() / n;
+            let var = vals.iter().map(|&v| (v as f64 - mean).powi(2)).sum::<f64>() / n;
+            var.sqrt()
+        }
+
+        let multi_std = std_dev(&multi_results);
+        let single_std = std_dev(&single_results);
+
+        let multi_mean: f64 =
+            multi_results.iter().map(|&v| v as f64).sum::<f64>() / num_trials as f64;
+        let single_mean: f64 =
+            single_results.iter().map(|&v| v as f64).sum::<f64>() / num_trials as f64;
+
+        println!(
+            "Multi-sample flop (k={}): mean={:.2}, std={:.2}",
+            FLOP_SAMPLES, multi_mean, multi_std
+        );
+        println!(
+            "Single-sample runout:     mean={:.2}, std={:.2}",
+            single_mean, single_std
+        );
+        println!(
+            "Variance reduction: {:.1}x",
+            if multi_std > 0.0 {
+                single_std / multi_std
+            } else {
+                f64::INFINITY
+            }
+        );
+
+        // The multi-sample approach should have meaningfully lower variance.
+        // With k=3 flops and exact runout, we expect at least 2x reduction.
+        assert!(
+            multi_std < single_std,
+            "Multi-sample flop should have lower variance than single-sample. \
+             multi_std={:.2}, single_std={:.2}",
+            multi_std,
+            single_std
+        );
+
+        // Both means should be in roughly the same ballpark (same underlying EV).
+        // AKs vs QJs preflop is roughly 60/40, so EV for player 0 ≈ +200 (win 1000 * 0.6 - 500).
+        // Allow a wide range since we're measuring with limited trials.
+        assert!(
+            (multi_mean - single_mean).abs() < 200.0,
+            "Means should be broadly similar: multi={:.2}, single={:.2}",
+            multi_mean,
+            single_mean
+        );
+    }
+
+    /// Test that multi-sample flop enumeration produces correct sign
+    /// for a strongly dominated hand. AKs should beat 72o.
+    #[test]
+    fn test_flop_sample_dominated_hand() {
+        use crate::arena::game_state::Round;
+        use crate::core::{Card, Hand, Suit, Value};
+        use rand::SeedableRng;
+
+        let p0_hole = vec![
+            Card::new(Value::Ace, Suit::Spade),
+            Card::new(Value::King, Suit::Spade),
+        ];
+        let p1_hole = vec![
+            Card::new(Value::Seven, Suit::Diamond),
+            Card::new(Value::Two, Suit::Club),
+        ];
+        let p0_hand = Hand::new_with_cards(p0_hole);
+        let p1_hand = Hand::new_with_cards(p1_hole);
+
+        // stacks=0 + bets>0 in a non-Starting round → both players all-in
+        let mut game_state = GameStateBuilder::new()
+            .round(Round::DealFlop)
+            .stacks(vec![0.0, 0.0])
+            .player_bet(vec![500.0, 500.0])
+            .big_blind(10.0)
+            .small_blind(5.0)
+            .hands(vec![p0_hand, p1_hand])
+            .build()
+            .unwrap();
+        game_state.starting_stacks = vec![500.0, 500.0];
+
+        // Average over multiple seeds — AKs should consistently beat 72o.
+        let num_trials = 20;
+        let total_reward: f64 = (0..num_trials)
+            .map(|seed| {
+                let mut rng = StdRng::seed_from_u64(seed + 100);
+                fast_forward_sample_flop_enumerate_runout(&game_state, 0, &mut rng) as f64
+            })
+            .sum();
+        let avg_reward = total_reward / num_trials as f64;
+
+        println!("AKs vs 72o avg reward for AKs: {:.2}", avg_reward);
+
+        // AKs vs 72o has ~66% equity, so EV ≈ 1000 * 0.66 - 500 = +160.
+        // Should be solidly positive.
+        assert!(
+            avg_reward > 50.0,
+            "AKs should have positive EV vs 72o, got {:.2}",
+            avg_reward
+        );
+    }
+
+    /// Compare variance and cost across different flop sample counts.
+    /// Run with `--nocapture` to see the table:
+    ///   cargo test --all-features test_flop_sample_count_comparison -- --nocapture
+    #[test]
+    fn test_flop_sample_count_comparison() {
+        use crate::arena::game_state::Round;
+        use crate::core::{Card, Hand, Suit, Value};
+        use rand::SeedableRng;
+        use std::time::Instant;
+
+        let p0_hole = vec![
+            Card::new(Value::Ace, Suit::Spade),
+            Card::new(Value::King, Suit::Spade),
+        ];
+        let p1_hole = vec![
+            Card::new(Value::Queen, Suit::Heart),
+            Card::new(Value::Jack, Suit::Heart),
+        ];
+        let p0_hand = Hand::new_with_cards(p0_hole);
+        let p1_hand = Hand::new_with_cards(p1_hole);
+
+        let mut game_state = GameStateBuilder::new()
+            .round(Round::DealFlop)
+            .stacks(vec![0.0, 0.0])
+            .player_bet(vec![500.0, 500.0])
+            .big_blind(10.0)
+            .small_blind(5.0)
+            .hands(vec![p0_hand, p1_hand])
+            .build()
+            .unwrap();
+        game_state.starting_stacks = vec![500.0, 500.0];
+
+        let num_trials = 100;
+
+        fn std_dev(vals: &[f32]) -> f64 {
+            let n = vals.len() as f64;
+            let mean = vals.iter().map(|&v| v as f64).sum::<f64>() / n;
+            let var = vals.iter().map(|&v| (v as f64 - mean).powi(2)).sum::<f64>() / n;
+            var.sqrt()
+        }
+
+        println!(
+            "\n{:<8} {:>10} {:>10} {:>12} {:>10}",
+            "k", "mean", "std", "var_red", "time_us"
+        );
+        println!("{}", "-".repeat(56));
+
+        // Single-sample baseline
+        let start = Instant::now();
+        let single_results: Vec<f32> = (0..num_trials)
+            .map(|seed| {
+                let mut gs = game_state.clone();
+                let mut rng = StdRng::seed_from_u64(seed);
+                fast_forward_run_to_showdown(&mut gs, &mut rng);
+                fast_forward_distribute_pot(&mut gs);
+                gs.player_reward(0)
+            })
+            .collect();
+        let single_time = start.elapsed();
+        let single_std = std_dev(&single_results);
+        let single_mean: f64 =
+            single_results.iter().map(|&v| v as f64).sum::<f64>() / num_trials as f64;
+
+        println!(
+            "{:<8} {:>10.2} {:>10.2} {:>12} {:>10}",
+            "1-samp",
+            single_mean,
+            single_std,
+            "baseline",
+            single_time.as_micros()
+        );
+
+        // Test k = 1, 2, 3, 5, 8, 13
+        for k in [1, 2, 3, 5, 8, 13] {
+            let start = Instant::now();
+            let results: Vec<f32> = (0..num_trials)
+                .map(|seed| {
+                    let mut rng = StdRng::seed_from_u64(seed);
+                    fast_forward_sample_flop_enumerate_runout_n(&game_state, 0, &mut rng, k)
+                })
+                .collect();
+            let elapsed = start.elapsed();
+
+            let multi_std = std_dev(&results);
+            let multi_mean: f64 =
+                results.iter().map(|&v| v as f64).sum::<f64>() / num_trials as f64;
+            let var_reduction = if multi_std > 0.0 {
+                single_std / multi_std
+            } else {
+                f64::INFINITY
+            };
+
+            println!(
+                "{:<8} {:>10.2} {:>10.2} {:>11.1}x {:>10}",
+                format!("k={k}"),
+                multi_mean,
+                multi_std,
+                var_reduction,
+                elapsed.as_micros()
+            );
+        }
+
+        // Sanity: k=3 should reduce variance vs single sample
+        let k3_results: Vec<f32> = (0..num_trials)
+            .map(|seed| {
+                let mut rng = StdRng::seed_from_u64(seed);
+                fast_forward_sample_flop_enumerate_runout_n(&game_state, 0, &mut rng, 3)
+            })
+            .collect();
+        assert!(
+            std_dev(&k3_results) < single_std,
+            "k=3 should reduce variance vs single sample"
+        );
     }
 }

--- a/src/arena/cfr/historian.rs
+++ b/src/arena/cfr/historian.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use tracing::event;
 
 use crate::arena::action::Action;
@@ -7,7 +5,6 @@ use crate::arena::action::PlayedActionPayload;
 use crate::arena::game_state::Round;
 
 use crate::arena::Historian;
-use crate::core::Card;
 
 use crate::arena::GameState;
 
@@ -24,17 +21,17 @@ use super::TraversalSet;
 /// within the Counterfactual Regret Minimization (CFR) algorithm for poker
 /// games.
 ///
-/// This historian updates ALL players' CFR states and traversal states when
-/// recording actions. Each player has their own tree, but the historian
-/// ensures they all advance appropriately based on the action type:
-/// - Public actions (bets, community cards): all players advance
-/// - Private actions (hole cards): all players advance (the full deal
+/// This historian updates ALL players' traversal states when recording actions.
+/// All players share a single CFR tree (NodeArena). The historian ensures
+/// traversal states advance appropriately based on the action type:
+/// - Public actions (bets, community cards): all traversal states advance
+/// - Private actions (hole cards): all traversal states advance (the full deal
 ///   sequence is recorded in the tree; there is no information hiding)
-/// - Terminal: each player records their own reward
+/// - Terminal: records reward in the shared terminal node
 pub struct CFRHistorian {
-    /// Shared CFR states for each player.
-    /// Uses Arc<[CFRState]> to avoid Vec allocation per sub-simulation.
-    cfr_states: Arc<[CFRState]>,
+    /// Single shared CFR state for the entire game tree.
+    /// All players share this tree; only regret data differs per player.
+    cfr_state: CFRState,
     traversal_set: TraversalSet,
     /// The action index mapper for consistent action-to-index mapping.
     action_index_mapper: ActionIndexMapper,
@@ -46,44 +43,36 @@ impl CFRHistorian {
     /// Create a new CFRHistorian.
     ///
     /// # Arguments
-    /// * `cfr_states` - The CFR states for all players
+    /// * `cfr_state` - The single shared CFR state for all players
     /// * `traversal_set` - The traversal set tracking each player's position
     /// * `allow_node_mutation` - Whether to allow mutating node types when a mismatch is found
     pub(crate) fn new(
-        cfr_states: &Arc<[CFRState]>,
+        cfr_state: &CFRState,
         traversal_set: TraversalSet,
         allow_node_mutation: bool,
     ) -> Self {
-        assert!(!cfr_states.is_empty(), "At least one player should exist");
-
-        // Create the action index mapper from the first player's mapper config
-        let action_index_mapper = ActionIndexMapper::new(*cfr_states[0].mapper_config());
+        // Create the action index mapper from the shared state's mapper config
+        let action_index_mapper = ActionIndexMapper::new(*cfr_state.mapper_config());
 
         CFRHistorian {
-            cfr_states: cfr_states.clone(),
+            cfr_state: cfr_state.clone(),
             traversal_set,
             action_index_mapper,
             allow_node_mutation,
         }
     }
 
-    /// Ensure target node exists for a specific player and return the node index.
+    /// Ensure target node exists in the shared tree using the first player's
+    /// traversal position, and return the node index.
     ///
-    /// Uses `CFRState::ensure_child` to handle the case where different bet amounts
-    /// map to the same index but lead to different outcomes (e.g., all-in vs not).
-    fn ensure_target_node_for_player(
-        &self,
-        player_idx: usize,
-        node_data: NodeData,
-    ) -> Result<usize, HistorianError> {
-        let cfr_state = &self.cfr_states[player_idx];
-        let traversal_state = self.traversal_set.get(player_idx);
-
-        // Get both fields in a single lock acquisition
+    /// Since all players share one tree and their traversal states are always
+    /// in sync (the historian moves them all together), we use player 0's
+    /// position to create/find the node.
+    fn ensure_target_node(&self, node_data: NodeData) -> Result<usize, HistorianError> {
+        let traversal_state = self.traversal_set.get(0);
         let (from_node_idx, from_child_idx) = traversal_state.get_position();
 
-        // Use ensure_child which handles node type mismatches
-        Ok(cfr_state.ensure_child(
+        Ok(self.cfr_state.ensure_child(
             from_node_idx,
             from_child_idx,
             node_data,
@@ -91,22 +80,24 @@ impl CFRHistorian {
         ))
     }
 
-    /// Move a specific player's traversal state to the target node.
-    fn move_player_to(&self, player_idx: usize, to_node_idx: usize, child_idx: usize) {
-        self.traversal_set
-            .get(player_idx)
-            .move_to(to_node_idx, child_idx);
+    /// Move all players' traversal states to the target node.
+    fn move_all_players_to(&self, to_node_idx: usize, child_idx: usize) {
+        for player_idx in 0..self.traversal_set.num_players() {
+            self.traversal_set
+                .get(player_idx)
+                .move_to(to_node_idx, child_idx);
+        }
     }
 
     /// Record a community card (flop, turn, river).
     /// All players' traversal states move since community cards are public.
-    pub(crate) fn record_community_card(&self, card: Card) -> Result<(), HistorianError> {
+    pub(crate) fn record_community_card(
+        &self,
+        card: crate::core::Card,
+    ) -> Result<(), HistorianError> {
         let card_value: u8 = card.into();
-
-        for player_idx in 0..self.traversal_set.num_players() {
-            let to_node_idx = self.ensure_target_node_for_player(player_idx, NodeData::Chance)?;
-            self.move_player_to(player_idx, to_node_idx, card_value as usize);
-        }
+        let to_node_idx = self.ensure_target_node(NodeData::Chance)?;
+        self.move_all_players_to(to_node_idx, card_value as usize);
         Ok(())
     }
 
@@ -114,15 +105,13 @@ impl CFRHistorian {
     ///
     /// All players' traversal states advance for every hole card dealt to any player.
     /// There is no information hiding - the full deal sequence is recorded in the tree.
-    /// This works because agents only look forward (at available actions), never backward
-    /// at the deal history, and it produces a cleaner tree for analysis.
-    pub(crate) fn record_starting_hand_card(&self, card: Card) -> Result<(), HistorianError> {
+    pub(crate) fn record_starting_hand_card(
+        &self,
+        card: crate::core::Card,
+    ) -> Result<(), HistorianError> {
         let card_value: u8 = card.into();
-
-        for idx in 0..self.traversal_set.num_players() {
-            let to_node_idx = self.ensure_target_node_for_player(idx, NodeData::Chance)?;
-            self.move_player_to(idx, to_node_idx, card_value as usize);
-        }
+        let to_node_idx = self.ensure_target_node(NodeData::Chance)?;
+        self.move_all_players_to(to_node_idx, card_value as usize);
         Ok(())
     }
 
@@ -138,15 +127,11 @@ impl CFRHistorian {
         _game_state: &GameState,
         payload: &PlayedActionPayload,
     ) -> Result<(), HistorianError> {
-        // Compute pre-action values needed for action indexing.
-        // We use the raw values directly instead of cloning the entire GameState.
         let pre_action_round_bet = payload.starting_bet;
         let pre_action_player_bet = payload.starting_player_bet;
-        // Compute pre-action stack: post-action stack + amount bet this action
         let amount_bet = payload.final_player_bet - payload.starting_player_bet;
         let pre_action_stack = payload.player_stack + amount_bet;
 
-        // Use the raw-value action-to-index mapping (avoids GameState clone)
         let action_idx = self.action_index_mapper.action_to_idx_raw(
             &payload.action,
             pre_action_round_bet,
@@ -165,43 +150,34 @@ impl CFRHistorian {
             "Recording action for all players"
         );
 
-        for player_idx in 0..self.traversal_set.num_players() {
-            let to_node_idx = self.ensure_target_node_for_player(
-                player_idx,
-                NodeData::Player(PlayerData {
-                    regret_matcher: Option::default(),
-                    player_idx: payload.idx as u8,
-                }),
-            )?;
-            self.move_player_to(player_idx, to_node_idx, action_idx);
-        }
+        let to_node_idx = self.ensure_target_node(NodeData::Player(PlayerData {
+            regret_matcher: Option::default(),
+            player_idx: payload.idx as u8,
+        }))?;
+        self.move_all_players_to(to_node_idx, action_idx);
         Ok(())
     }
 
     /// Record terminal state.
-    /// Each player records their own reward in their own tree.
+    /// Creates a single terminal node in the shared tree and accumulates
+    /// all players' rewards into it.
     pub(crate) fn record_terminal(&self, game_state: &GameState) -> Result<(), HistorianError> {
-        for player_idx in 0..self.traversal_set.num_players() {
-            let to_node_idx = self.ensure_target_node_for_player(
-                player_idx,
-                NodeData::Terminal(TerminalData::default()),
-            )?;
-            self.move_player_to(player_idx, to_node_idx, 0);
+        let to_node_idx = self.ensure_target_node(NodeData::Terminal(TerminalData::default()))?;
+        self.move_all_players_to(to_node_idx, 0);
 
-            let reward = game_state.player_reward(player_idx);
+        // Accumulate all players' rewards into the shared terminal node.
+        // Note: total_utility in a shared tree is the sum of all players' rewards
+        // (which should net to zero in a zero-sum game). This field is only used
+        // for export/visualization, not by the CFR algorithm itself.
+        let total_reward: f32 = (0..self.traversal_set.num_players())
+            .map(|idx| game_state.player_reward(idx))
+            .sum();
 
-            event!(
-                tracing::Level::TRACE,
-                to_node_idx,
-                reward,
-                player_idx,
-                "Recording terminal node"
-            );
-
-            self.cfr_states[player_idx]
+        if total_reward != 0.0 {
+            self.cfr_state
                 .update_node(to_node_idx, |data| {
                     if let NodeData::Terminal(td) = data {
-                        td.total_utility += reward;
+                        td.total_utility += total_reward;
                     }
                 })
                 .map_err(|_| HistorianError::CFRNodeNotFound)?;

--- a/src/arena/cfr/mod.rs
+++ b/src/arena/cfr/mod.rs
@@ -36,11 +36,11 @@
 //! ## Action Index Mapper
 //!
 //! The `ActionIndexMapper` provides a fixed absolute-amount mapping for actions
-//! to indices. It maps actions to indices 0-51:
+//! to indices. It maps actions to indices 0-15:
 //! - Index 0: Fold
 //! - Index 1: Call/Check
-//! - Indices 2-50: Raises (logarithmic distribution)
-//! - Index 51: All-in
+//! - Indices 2-13: Raises (logarithmic distribution)
+//! - Index 14: All-in
 //!
 //! ## Agent
 //!
@@ -48,6 +48,26 @@
 //! their turn. For that the agent looks in the tree. Then it will simulate all
 //! the possible actions and update the regret values for each action taken.
 //! Then it will use the CFR+ algorithm to choose the action to take.
+//!
+//! ## Algorithm Variants and Optimizations
+//!
+//! The implementation incorporates several key ideas from the CFR literature:
+//!
+//! - **PCFR+** (Farina et al., 2021): Predictive CFR+ with quadratic
+//!   weighting for faster convergence.
+//! - **Regret-Based Pruning** (Brown & Sandholm, NeurIPS 2015): Skip
+//!   reward computation for actions driven to zero strategy weight.
+//! - **External Sampling MCCFR** (Lanctot et al., NeurIPS 2009): In
+//!   recursive sub-simulations, only the traversing player explores all
+//!   actions; opponents play their current strategy without exploration.
+//!   This eliminates exponential branching from opponent exploration.
+//! - **Exhaustive Board Enumeration** (related to AIVAT, Burch et al.,
+//!   AAAI 2018): For fast-forward rewards with 0-2 remaining community
+//!   cards, enumerate all possible completions instead of sampling,
+//!   giving zero-variance reward signals.
+//! - **Single Shared Tree**: All players share one game tree (NodeArena)
+//!   since there is no information hiding in the traversal. This halves
+//!   memory for 2-player games and improves cache locality.
 //!
 //! ## Preflop Chart Action Generator
 //!
@@ -250,18 +270,16 @@ mod tests {
             .unwrap()
     }
 
-    /// Helper to create CFR states for all players from a game state.
-    fn make_cfr_states(game_state: &GameState) -> Vec<super::CFRState> {
-        (0..game_state.num_players)
-            .map(|_| super::CFRState::new(game_state.clone()))
-            .collect()
+    /// Helper to create a single shared CFR state from a game state.
+    fn make_cfr_state(game_state: &GameState) -> super::CFRState {
+        super::CFRState::new(game_state.clone())
     }
 
     fn run(game_state: GameState, num_hands: usize) -> HoldemSimulation {
         use rand::{SeedableRng, rngs::StdRng};
 
-        // All agents share the same CFR states and traversal set.
-        let cfr_states = make_cfr_states(&game_state);
+        // All agents share a single CFR state and traversal set.
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
         let depth_config = CfrDepthConfig::new(vec![num_hands, 1]);
         let agents: Vec<_> = (0..game_state.num_players)
@@ -270,7 +288,7 @@ mod tests {
                     CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                         .name(format!("CFRAgent-run-{idx}"))
                         .player_idx(idx)
-                        .cfr_states(cfr_states.clone())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(depth_config.clone())
                         .action_gen_config(())
@@ -288,7 +306,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(dyn_agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state, traversal_set, true)
             .build()
             .unwrap();
 
@@ -342,13 +360,13 @@ mod tests {
         );
 
         // Create a CFR agent for player 1 (the one who needs to decide)
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
         let depth_config = CfrDepthConfig::new(vec![100, 1]);
         let agent = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
             .name("CFRAgent-debug")
             .player_idx(1)
-            .cfr_states(cfr_states)
+            .cfr_state(cfr_state.clone())
             .traversal_set(traversal_set)
             .depth_config(depth_config)
             .action_gen_config(())
@@ -387,7 +405,7 @@ mod tests {
             .unwrap();
 
         // All agents share the same CFR states and traversal set
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
         let depth_config = CfrDepthConfig::new(vec![2, 1]);
         let agents: Vec<_> = (0..2)
@@ -396,7 +414,7 @@ mod tests {
                     CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                         .name(format!("CFRAgent-starting-{idx}"))
                         .player_idx(idx)
-                        .cfr_states(cfr_states.clone())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(depth_config.clone())
                         .action_gen_config(())
@@ -413,7 +431,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(dyn_agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state.clone(), traversal_set, true)
             .build()
             .unwrap();
 
@@ -438,14 +456,14 @@ mod tests {
             .unwrap();
 
         // Create shared CFR states and traversal set
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
         let depth_config = CfrDepthConfig::new(vec![2, 1]);
         let cfr_agent = Box::new(
             CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                 .name("CFRAgent")
                 .player_idx(0)
-                .cfr_states(cfr_states.clone())
+                .cfr_state(cfr_state.clone())
                 .traversal_set(traversal_set.clone())
                 .depth_config(depth_config)
                 .action_gen_config(())
@@ -461,7 +479,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state.clone(), traversal_set, true)
             .build()
             .unwrap();
 
@@ -487,7 +505,7 @@ mod tests {
                 .build()
                 .unwrap();
 
-            let cfr_states = make_cfr_states(&game_state);
+            let cfr_state = make_cfr_state(&game_state);
             let traversal_set = TraversalSet::new(game_state.num_players);
             let agents: Vec<Box<dyn Agent>> = (0..2)
                 .map(|idx| {
@@ -495,7 +513,7 @@ mod tests {
                         CFRAgentBuilder::<BasicCFRActionGenerator>::new()
                             .name(format!("CFRAgent-game{game_idx}-p{idx}"))
                             .player_idx(idx)
-                            .cfr_states(cfr_states.clone())
+                            .cfr_state(cfr_state.clone())
                             .traversal_set(traversal_set.clone())
                             .depth_config(depth_config.clone())
                             .action_gen_config(())
@@ -509,7 +527,7 @@ mod tests {
             let mut sim = HoldemSimulationBuilder::default()
                 .game_state(game_state)
                 .agents(agents)
-                .cfr_context(cfr_states, traversal_set, true)
+                .cfr_context(cfr_state.clone(), traversal_set, true)
                 .build()
                 .unwrap();
 
@@ -561,7 +579,7 @@ mod tests {
         };
 
         // All agents share the same CFR states and traversal set
-        let cfr_states = make_cfr_states(&game_state);
+        let cfr_state = make_cfr_state(&game_state);
         let traversal_set = TraversalSet::new(game_state.num_players);
         let depth_config = CfrDepthConfig::new(vec![2, 1]);
         let agents: Vec<_> = (0..2)
@@ -570,7 +588,7 @@ mod tests {
                     CFRAgentBuilder::<ConfigurableActionGenerator>::new()
                         .name(format!("CFRAgent-configurable-{idx}"))
                         .player_idx(idx)
-                        .cfr_states(cfr_states.clone())
+                        .cfr_state(cfr_state.clone())
                         .traversal_set(traversal_set.clone())
                         .depth_config(depth_config.clone())
                         .action_gen_config(action_config.clone())
@@ -587,7 +605,7 @@ mod tests {
         let mut sim = HoldemSimulationBuilder::default()
             .game_state(game_state)
             .agents(dyn_agents)
-            .cfr_context(cfr_states, traversal_set, true)
+            .cfr_context(cfr_state.clone(), traversal_set, true)
             .build()
             .unwrap();
 

--- a/src/arena/cfr/state.rs
+++ b/src/arena/cfr/state.rs
@@ -2,8 +2,19 @@ use std::sync::Arc;
 
 use crate::arena::{GameState, errors::CFRStateError};
 
+use super::action_bit_set::ActionBitSet;
 use super::node_arena::NodeArena;
 use super::{ActionIndexMapperConfig, Node, NodeData};
+
+/// Create an `ActionBitSet` with all action indices set.
+/// Used as fallback when no pruning information is available.
+fn full_action_bitset() -> ActionBitSet {
+    let mut bs = ActionBitSet::new();
+    for i in 0..super::NUM_ACTION_INDICES {
+        bs.insert(i);
+    }
+    bs
+}
 
 /// Counterfactual Regret Minimization (CFR) state tracker.
 ///
@@ -175,6 +186,44 @@ impl CFRState {
     /// operations like visualization and debugging.
     pub fn arena(&self) -> &Arc<NodeArena> {
         &self.arena
+    }
+
+    /// Read pruning information from a player node's regret matcher.
+    ///
+    /// Returns `(active_actions, num_updates)` where:
+    /// - `active_actions` is a bitset of action indices with non-zero current
+    ///   strategy weight (i.e., actions worth exploring)
+    /// - `num_updates` is how many times the regret matcher has been updated
+    ///
+    /// If the node is not a player node or has no regret matcher, returns
+    /// a full bitset (all actions active) and 0 updates.
+    ///
+    /// This is used by regret-based pruning (Brown & Sandholm, NeurIPS 2015)
+    /// to skip expensive sub-simulations for actions that have been driven
+    /// to zero strategy weight by CFR+.
+    pub fn get_pruning_info(
+        &self,
+        node_idx: usize,
+    ) -> (super::action_bit_set::ActionBitSet, usize) {
+        use little_sorry::RegretMinimizer;
+        self.with_node_data(node_idx, |data| {
+            if let NodeData::Player(pd) = data {
+                if let Some(rm) = pd.regret_matcher.as_ref() {
+                    let strategy = rm.current_strategy();
+                    let mut active = super::action_bit_set::ActionBitSet::new();
+                    for (i, &w) in strategy.iter().enumerate() {
+                        if w > 0.0 {
+                            active.insert(i);
+                        }
+                    }
+                    (active, rm.num_updates())
+                } else {
+                    (full_action_bitset(), 0)
+                }
+            } else {
+                (full_action_bitset(), 0)
+            }
+        })
     }
 
     /// Verify that an existing node's type matches `expected_data`, optionally

--- a/src/arena/comparison/runner.rs
+++ b/src/arena/comparison/runner.rs
@@ -271,11 +271,9 @@ impl ArenaComparison {
                 .any(|&agent_idx| agent_configs[agent_idx].is_cfr());
 
             let cfr_context = if has_cfr {
-                let cfr_states: Vec<CFRState> = (0..players_per_table)
-                    .map(|_| CFRState::new(game_state.clone()))
-                    .collect();
+                let cfr_state = CFRState::new(game_state.clone());
                 let traversal_set = TraversalSet::new(players_per_table);
-                Some((cfr_states, traversal_set))
+                Some((cfr_state, traversal_set))
             } else {
                 None
             };
@@ -290,8 +288,8 @@ impl ArenaComparison {
                         .player_idx(idx);
                     // Inject shared CFR context BEFORE game_state to avoid
                     // wasted eager allocation in game_state()
-                    if let Some((ref cfr_states, ref ts)) = cfr_context {
-                        builder = builder.cfr_context(cfr_states.clone(), ts.clone());
+                    if let Some((ref cfr_state, ref ts)) = cfr_context {
+                        builder = builder.cfr_context(cfr_state.clone(), ts.clone());
                     }
                     builder = builder.game_state(game_state.clone());
                     if let Some(ref pool) = self.config.thread_pool {
@@ -322,8 +320,8 @@ impl ArenaComparison {
                 .game_state(game_state.clone())
                 .agents(boxed_agents)
                 .historians(historians);
-            if let Some((cfr_states, traversal_set)) = cfr_context {
-                sim_builder = sim_builder.cfr_context(cfr_states, traversal_set, true);
+            if let Some((cfr_state, traversal_set)) = cfr_context {
+                sim_builder = sim_builder.cfr_context(cfr_state, traversal_set, true);
             }
             let mut sim = sim_builder.build()?;
 

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use rand::{Rng, RngExt};
 
 use crate::core::{CardBitSet, Deck};
@@ -93,7 +91,7 @@ pub struct HoldemSimulationBuilder {
     deck: Option<Deck>,
     panic_on_historian_error: bool,
     /// Optional CFR context for automatic historian creation.
-    cfr_states: Option<Arc<[CFRState]>>,
+    cfr_state: Option<CFRState>,
     cfr_traversal_set: Option<TraversalSet>,
     cfr_allow_node_mutation: bool,
 }
@@ -155,33 +153,20 @@ impl HoldemSimulationBuilder {
     /// Provide CFR context for this simulation.
     ///
     /// When set, the builder will automatically create a `CFRHistorian` and
-    /// add it to the simulation's historians. This replaces the old pattern
-    /// where each CFR agent returned its own historian via `Agent::historian()`.
+    /// add it to the simulation's historians. All players share a single
+    /// CFR tree (CFRState). CFRState is cheap to clone (just Arc bumps).
     ///
     /// # Arguments
-    /// * `cfr_states` - The CFR states for all players (cheap to clone via Arc)
+    /// * `cfr_state` - The single shared CFR state for all players
     /// * `traversal_set` - The traversal set tracking each player's position
     /// * `allow_node_mutation` - Whether to allow mutating node types on mismatch
     pub fn cfr_context(
-        self,
-        cfr_states: Vec<CFRState>,
-        traversal_set: TraversalSet,
-        allow_node_mutation: bool,
-    ) -> Self {
-        self.cfr_context_arc(cfr_states.into(), traversal_set, allow_node_mutation)
-    }
-
-    /// Provide CFR context using a pre-built `Arc<[CFRState]>`.
-    ///
-    /// This avoids a Vec allocation when the caller already has an Arc.
-    /// Used on the hot path in `compute_reward` where Arc clones are cheap.
-    pub fn cfr_context_arc(
         mut self,
-        cfr_states: Arc<[CFRState]>,
+        cfr_state: CFRState,
         traversal_set: TraversalSet,
         allow_node_mutation: bool,
     ) -> Self {
-        self.cfr_states = Some(cfr_states);
+        self.cfr_state = Some(cfr_state);
         self.cfr_traversal_set = Some(traversal_set);
         self.cfr_allow_node_mutation = allow_node_mutation;
         self
@@ -217,7 +202,7 @@ impl HoldemSimulationBuilder {
             .agents
             .unwrap_or_else(|| build_agents(game_state.hands.len()));
 
-        let has_cfr_context = self.cfr_states.is_some();
+        let has_cfr_context = self.cfr_state.is_some();
 
         // Skip agent historian collection when CFR context is set,
         // since CFR agents don't provide historians — the CFRHistorian
@@ -233,9 +218,9 @@ impl HoldemSimulationBuilder {
         };
 
         // If CFR context was provided, create and add a CFRHistorian.
-        if let (Some(cfr_states), Some(traversal_set)) = (self.cfr_states, self.cfr_traversal_set) {
+        if let (Some(cfr_state), Some(traversal_set)) = (self.cfr_state, self.cfr_traversal_set) {
             let cfr_historian =
-                CFRHistorian::new(&cfr_states, traversal_set, self.cfr_allow_node_mutation);
+                CFRHistorian::new(&cfr_state, traversal_set, self.cfr_allow_node_mutation);
             historians.push(Box::new(cfr_historian));
         }
 
@@ -262,7 +247,7 @@ impl Default for HoldemSimulationBuilder {
             game_state: None,
             deck: None,
             panic_on_historian_error: true,
-            cfr_states: None,
+            cfr_state: None,
             cfr_traversal_set: None,
             cfr_allow_node_mutation: true,
         }

--- a/src/bin/rsp/arena/generate.rs
+++ b/src/bin/rsp/arena/generate.rs
@@ -155,7 +155,7 @@ fn load_configs(dir: &Path) -> Result<Vec<AgentConfig>, GenerateError> {
 struct GameSetup {
     game_state: GameState,
     agents: Vec<Box<dyn Agent>>,
-    cfr_context: Option<(Vec<CFRState>, TraversalSet)>,
+    cfr_context: Option<(CFRState, TraversalSet)>,
     num_players: usize,
 }
 
@@ -227,11 +227,9 @@ impl<'a> GenerationContext<'a> {
 
         let has_cfr = selected_configs.iter().any(|c| c.is_cfr());
         let cfr_context = if has_cfr {
-            let cfr_states: Vec<CFRState> = (0..num_players)
-                .map(|_| CFRState::new(game_state.clone()))
-                .collect();
+            let cfr_state = CFRState::new(game_state.clone());
             let traversal_set = TraversalSet::new(num_players);
-            Some((cfr_states, traversal_set))
+            Some((cfr_state, traversal_set))
         } else {
             None
         };
@@ -243,8 +241,8 @@ impl<'a> GenerationContext<'a> {
                 let mut builder = ConfigAgentBuilder::new((*config).clone())?.player_idx(idx);
                 // Inject shared CFR context BEFORE game_state to avoid
                 // wasted eager allocation in game_state()
-                if let Some((ref cfr_states, ref ts)) = cfr_context {
-                    builder = builder.cfr_context(cfr_states.clone(), ts.clone());
+                if let Some((ref cfr_state, ref ts)) = cfr_context {
+                    builder = builder.cfr_context(cfr_state.clone(), ts.clone());
                 }
                 builder = builder.game_state(game_state.clone());
                 if let Some(ref pool) = self.thread_pool {
@@ -319,8 +317,8 @@ fn run_generation(args: &GenerateArgs, configs: &[AgentConfig]) -> Result<(), Ge
                 .game_state(setup.game_state)
                 .agents(setup.agents)
                 .historians(vec![Box::new(historian)]);
-            if let Some((cfr_states, traversal_set)) = setup.cfr_context {
-                builder = builder.cfr_context(cfr_states, traversal_set, true);
+            if let Some((cfr_state, traversal_set)) = setup.cfr_context {
+                builder = builder.cfr_context(cfr_state, traversal_set, true);
             }
             builder.build()
         };
@@ -416,8 +414,8 @@ fn run_generation_inner(
                 .game_state(setup.game_state)
                 .agents(setup.agents)
                 .historians(vec![Box::new(ohh_historian), Box::new(stats_historian)]);
-            if let Some((cfr_states, traversal_set)) = setup.cfr_context {
-                builder = builder.cfr_context(cfr_states, traversal_set, true);
+            if let Some((cfr_state, traversal_set)) = setup.cfr_context {
+                builder = builder.cfr_context(cfr_state, traversal_set, true);
             }
             builder.build()
         };


### PR DESCRIPTION
Implement four complementary optimizations from the CFR literature that
together reduce memory usage by ~80% and improve convergence quality.

## Single shared game tree

Previously each player maintained an independent CFR tree (`Vec<CFRState>`).
Since the traversal records all information (no information hiding), every
player's tree was structurally identical — duplicating all nodes and regret
data. This commit replaces the per-player vec with a single `CFRState`
shared by all players. For a 2-player game this halves the NodeArena
memory. The historian now creates nodes once and moves all traversal
states together, and sub-agent construction no longer clones a vec of
Arc-backed states.

## Compact action index space (52 → 16 indices)

The action index mapper allocated 52 slots per regret matcher (fold,
call, 49 raise buckets, all-in) but typical action generators produce
only 4-8 distinct bet sizes. The 49 raise slots provided ~2% log-space
resolution — far finer than needed. Reducing to 12 raise slots (indices
2-13) plus fold, call, all-in, and one reserved slot gives 16 total
indices with ~38% resolution, still sufficient to distinguish standard
pot-fraction bets (0.33x, 0.67x, 1.0x, 1.5x). Each regret matcher
stores a weight vector sized to NUM_ACTION_INDICES, so this change
reduces per-node regret storage by ~69%.

## Regret-Based Pruning (Brown & Sandholm, NeurIPS 2015)

After a warmup period (3 updates), actions whose cumulative regret has
been driven to zero by PCFR+ clamping are skipped during reward
computation. Computing rewards requires expensive recursive
sub-simulations, so skipping dead actions saves significant wall-clock
time. Every 4th iteration all actions are reprobed to detect actions
that have become relevant again. The pruning integrates into both the
sequential and parallel (rayon) reward computation paths.

## Exhaustive board enumeration (related to AIVAT, Burch et al., AAAI 2018)

When computing fast-forward rewards at leaf depth, the previous approach
sampled a single random board completion. This introduces variance into
the reward signal, which slows CFR convergence. For 0-2 remaining
community cards the new code enumerates all possible completions:
- 0 cards (showdown): 1 evaluation — deterministic.
- 1 card (river only): ~46 evaluations.
- 2 cards (turn + river): ~C(46,2) ≈ 1035 evaluations.
- 3+ cards (flop onward): still sampled (~16K+ combinations too expensive).

The zero-variance reward signal from exact enumeration produces
deterministic regret updates, directly improving convergence quality.

## API changes

- `CFRAgentBuilder::cfr_states(Vec<CFRState>)` → `cfr_state(CFRState)`
- `HoldemSimulationBuilder::cfr_context_arc()` removed; `cfr_context()`
  now takes a single `CFRState` instead of `Vec<CFRState>`
- `CFRHistorian::new()` takes `&CFRState` instead of `&Arc<[CFRState]>`
- `ConfigAgentBuilder::cfr_context()` takes `CFRState` instead of vec

## Tests

- `test_rbp_preserves_fold_decision`: verifies pruning still produces
  the correct fold for K-high facing an all-in on a paired board.
- `test_rbp_reduces_active_actions`: verifies the pruning bitset becomes
  sparse after warmup, confirming RBP activates and prunes dead actions.
- All existing CFR tests updated for the single-state API.
