### PR TITLE
feat(preflop-charts): scenario-scoped charts, TUI viewer, and verify command

### DIFF
--- a/examples/configs/preflop_6max_rfi.json
+++ b/examples/configs/preflop_6max_rfi.json
@@ -1,3700 +1,1740 @@
 {
   "type": "cfr_preflop_chart",
   "name": "6Max-RFI-GTO",
-  "depth_hands": [100, 5, 1],
+  "depth_hands": [
+    100,
+    5,
+    1
+  ],
   "preflop_config": {
     "raise_size_bb": 2.5,
     "three_bet_multiplier": 3.0,
-    "charts": [
+    "four_bet_plus_multiplier": 2.5,
+    "positions": [
       {
-        "strategies": {
+        "vs_open": {
           "AA": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.5
-              ],
-              [
-                "Call",
-                0.5
-              ]
-            ]
+            "raise": 0.5,
+            "call": 0.5
           },
           "KK": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.5
-              ],
-              [
-                "Call",
-                0.5
-              ]
-            ]
+            "raise": 0.5,
+            "call": 0.5
           },
           "QQ": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.3
-              ],
-              [
-                "Call",
-                0.7
-              ]
-            ]
+            "raise": 0.3,
+            "call": 0.7
           },
           "JJ": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.2
-              ],
-              [
-                "Call",
-                0.8
-              ]
-            ]
+            "raise": 0.2,
+            "call": 0.8
           },
           "TT": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "99": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "88": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "77": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "66": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "55": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "44": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "33": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "22": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "AKs": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.5
-              ],
-              [
-                "Call",
-                0.5
-              ]
-            ]
+            "raise": 0.5,
+            "call": 0.5
           },
           "AQs": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.3
-              ],
-              [
-                "Call",
-                0.7
-              ]
-            ]
+            "raise": 0.3,
+            "call": 0.7
           },
           "AJs": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "ATs": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A9s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A8s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A7s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A6s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A5s": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.3
-              ],
-              [
-                "Call",
-                0.7
-              ]
-            ]
+            "raise": 0.3,
+            "call": 0.7
           },
           "A4s": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.3
-              ],
-              [
-                "Call",
-                0.7
-              ]
-            ]
+            "raise": 0.3,
+            "call": 0.7
           },
           "A3s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A2s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "KQs": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.2
-              ],
-              [
-                "Call",
-                0.8
-              ]
-            ]
+            "raise": 0.2,
+            "call": 0.8
           },
           "KJs": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "KTs": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K9s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K8s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K7s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K6s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K5s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K4s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K3s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "K2s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "QJs": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "QTs": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "Q9s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "Q8s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "Q7s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "Q6s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "JTs": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "J9s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "J8s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "J7s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "T9s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "T8s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "T7s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "98s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "97s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "96s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "87s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "86s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "76s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "75s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "65s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "64s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "54s": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "53s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "43s": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "AKo": {
-            "frequencies": [
-              [
-                "ThreeBet",
-                0.5
-              ],
-              [
-                "Call",
-                0.5
-              ]
-            ]
+            "raise": 0.5,
+            "call": 0.5
           },
           "AQo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "AJo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "ATo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A9o": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "A8o": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "KQo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "KJo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "KTo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "K9o": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "QJo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "QTo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "Q9o": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "JTo": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "J9o": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "T9o": {
-            "frequencies": [
-              [
-                "Call",
-                1.0
-              ]
-            ]
+            "call": 1.0
           },
           "T8o": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "98o": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
           },
           "87o": {
-            "frequencies": [
-              [
-                "Call",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "call": 0.5
+          }
+        },
+        "vs_3bet": {
+          "AA": {
+            "call": 0.5
+          },
+          "KK": {
+            "call": 0.5
+          },
+          "QQ": {
+            "call": 0.7
+          },
+          "JJ": {
+            "call": 0.8
+          },
+          "TT": {
+            "call": 1.0
+          },
+          "99": {
+            "call": 1.0
+          },
+          "88": {
+            "call": 1.0
+          },
+          "77": {
+            "call": 1.0
+          },
+          "66": {
+            "call": 1.0
+          },
+          "55": {
+            "call": 1.0
+          },
+          "44": {
+            "call": 1.0
+          },
+          "33": {
+            "call": 1.0
+          },
+          "22": {
+            "call": 1.0
+          },
+          "AKs": {
+            "call": 0.5
+          },
+          "AQs": {
+            "call": 0.7
+          },
+          "AJs": {
+            "call": 1.0
+          },
+          "ATs": {
+            "call": 1.0
+          },
+          "A9s": {
+            "call": 1.0
+          },
+          "A8s": {
+            "call": 1.0
+          },
+          "A7s": {
+            "call": 1.0
+          },
+          "A6s": {
+            "call": 1.0
+          },
+          "A5s": {
+            "call": 0.7
+          },
+          "A4s": {
+            "call": 0.7
+          },
+          "A3s": {
+            "call": 1.0
+          },
+          "A2s": {
+            "call": 1.0
+          },
+          "KQs": {
+            "call": 0.8
+          },
+          "KJs": {
+            "call": 1.0
+          },
+          "KTs": {
+            "call": 1.0
+          },
+          "K9s": {
+            "call": 1.0
+          },
+          "K8s": {
+            "call": 1.0
+          },
+          "K7s": {
+            "call": 1.0
+          },
+          "K6s": {
+            "call": 1.0
+          },
+          "K5s": {
+            "call": 1.0
+          },
+          "K4s": {
+            "call": 1.0
+          },
+          "K3s": {
+            "call": 0.5
+          },
+          "K2s": {
+            "call": 0.5
+          },
+          "QJs": {
+            "call": 1.0
+          },
+          "QTs": {
+            "call": 1.0
+          },
+          "Q9s": {
+            "call": 1.0
+          },
+          "Q8s": {
+            "call": 1.0
+          },
+          "Q7s": {
+            "call": 0.5
+          },
+          "Q6s": {
+            "call": 0.5
+          },
+          "JTs": {
+            "call": 1.0
+          },
+          "J9s": {
+            "call": 1.0
+          },
+          "J8s": {
+            "call": 1.0
+          },
+          "J7s": {
+            "call": 0.5
+          },
+          "T9s": {
+            "call": 1.0
+          },
+          "T8s": {
+            "call": 1.0
+          },
+          "T7s": {
+            "call": 0.5
+          },
+          "98s": {
+            "call": 1.0
+          },
+          "97s": {
+            "call": 1.0
+          },
+          "96s": {
+            "call": 0.5
+          },
+          "87s": {
+            "call": 1.0
+          },
+          "86s": {
+            "call": 1.0
+          },
+          "76s": {
+            "call": 1.0
+          },
+          "75s": {
+            "call": 0.5
+          },
+          "65s": {
+            "call": 1.0
+          },
+          "64s": {
+            "call": 0.5
+          },
+          "54s": {
+            "call": 1.0
+          },
+          "53s": {
+            "call": 0.5
+          },
+          "43s": {
+            "call": 0.5
+          },
+          "AKo": {
+            "call": 0.5
+          },
+          "AQo": {
+            "call": 1.0
+          },
+          "AJo": {
+            "call": 1.0
+          },
+          "ATo": {
+            "call": 1.0
+          },
+          "A9o": {
+            "call": 1.0
+          },
+          "A8o": {
+            "call": 0.5
+          },
+          "KQo": {
+            "call": 1.0
+          },
+          "KJo": {
+            "call": 1.0
+          },
+          "KTo": {
+            "call": 1.0
+          },
+          "K9o": {
+            "call": 0.5
+          },
+          "QJo": {
+            "call": 1.0
+          },
+          "QTo": {
+            "call": 1.0
+          },
+          "Q9o": {
+            "call": 0.5
+          },
+          "JTo": {
+            "call": 1.0
+          },
+          "J9o": {
+            "call": 0.5
+          },
+          "T9o": {
+            "call": 1.0
+          },
+          "T8o": {
+            "call": 0.5
+          },
+          "98o": {
+            "call": 0.5
+          },
+          "87o": {
+            "call": 0.5
+          }
+        },
+        "vs_4bet": {
+          "AA": {
+            "call": 0.5
+          },
+          "KK": {
+            "call": 0.5
+          },
+          "QQ": {
+            "call": 0.7
+          },
+          "JJ": {
+            "call": 0.8
+          },
+          "TT": {
+            "call": 1.0
+          },
+          "99": {
+            "call": 1.0
+          },
+          "88": {
+            "call": 1.0
+          },
+          "77": {
+            "call": 1.0
+          },
+          "66": {
+            "call": 1.0
+          },
+          "55": {
+            "call": 1.0
+          },
+          "44": {
+            "call": 1.0
+          },
+          "33": {
+            "call": 1.0
+          },
+          "22": {
+            "call": 1.0
+          },
+          "AKs": {
+            "call": 0.5
+          },
+          "AQs": {
+            "call": 0.7
+          },
+          "AJs": {
+            "call": 1.0
+          },
+          "ATs": {
+            "call": 1.0
+          },
+          "A9s": {
+            "call": 1.0
+          },
+          "A8s": {
+            "call": 1.0
+          },
+          "A7s": {
+            "call": 1.0
+          },
+          "A6s": {
+            "call": 1.0
+          },
+          "A5s": {
+            "call": 0.7
+          },
+          "A4s": {
+            "call": 0.7
+          },
+          "A3s": {
+            "call": 1.0
+          },
+          "A2s": {
+            "call": 1.0
+          },
+          "KQs": {
+            "call": 0.8
+          },
+          "KJs": {
+            "call": 1.0
+          },
+          "KTs": {
+            "call": 1.0
+          },
+          "K9s": {
+            "call": 1.0
+          },
+          "K8s": {
+            "call": 1.0
+          },
+          "K7s": {
+            "call": 1.0
+          },
+          "K6s": {
+            "call": 1.0
+          },
+          "K5s": {
+            "call": 1.0
+          },
+          "K4s": {
+            "call": 1.0
+          },
+          "K3s": {
+            "call": 0.5
+          },
+          "K2s": {
+            "call": 0.5
+          },
+          "QJs": {
+            "call": 1.0
+          },
+          "QTs": {
+            "call": 1.0
+          },
+          "Q9s": {
+            "call": 1.0
+          },
+          "Q8s": {
+            "call": 1.0
+          },
+          "Q7s": {
+            "call": 0.5
+          },
+          "Q6s": {
+            "call": 0.5
+          },
+          "JTs": {
+            "call": 1.0
+          },
+          "J9s": {
+            "call": 1.0
+          },
+          "J8s": {
+            "call": 1.0
+          },
+          "J7s": {
+            "call": 0.5
+          },
+          "T9s": {
+            "call": 1.0
+          },
+          "T8s": {
+            "call": 1.0
+          },
+          "T7s": {
+            "call": 0.5
+          },
+          "98s": {
+            "call": 1.0
+          },
+          "97s": {
+            "call": 1.0
+          },
+          "96s": {
+            "call": 0.5
+          },
+          "87s": {
+            "call": 1.0
+          },
+          "86s": {
+            "call": 1.0
+          },
+          "76s": {
+            "call": 1.0
+          },
+          "75s": {
+            "call": 0.5
+          },
+          "65s": {
+            "call": 1.0
+          },
+          "64s": {
+            "call": 0.5
+          },
+          "54s": {
+            "call": 1.0
+          },
+          "53s": {
+            "call": 0.5
+          },
+          "43s": {
+            "call": 0.5
+          },
+          "AKo": {
+            "call": 0.5
+          },
+          "AQo": {
+            "call": 1.0
+          },
+          "AJo": {
+            "call": 1.0
+          },
+          "ATo": {
+            "call": 1.0
+          },
+          "A9o": {
+            "call": 1.0
+          },
+          "A8o": {
+            "call": 0.5
+          },
+          "KQo": {
+            "call": 1.0
+          },
+          "KJo": {
+            "call": 1.0
+          },
+          "KTo": {
+            "call": 1.0
+          },
+          "K9o": {
+            "call": 0.5
+          },
+          "QJo": {
+            "call": 1.0
+          },
+          "QTo": {
+            "call": 1.0
+          },
+          "Q9o": {
+            "call": 0.5
+          },
+          "JTo": {
+            "call": 1.0
+          },
+          "J9o": {
+            "call": 0.5
+          },
+          "T9o": {
+            "call": 1.0
+          },
+          "T8o": {
+            "call": 0.5
+          },
+          "98o": {
+            "call": 0.5
+          },
+          "87o": {
+            "call": 0.5
           }
         }
       },
       {
-        "strategies": {
+        "rfi": {
           "AA": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KK": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QQ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "JJ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "TT": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "99": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "88": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "77": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "66": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "55": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "44": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "33": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "22": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AKs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A6s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A5s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A4s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A3s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A2s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K6s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K5s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K4s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K3s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K2s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q6s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q5s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q4s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "Q3s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "Q2s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "JTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J6s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "J5s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "T9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T6s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "98s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "97s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "96s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "95s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "87s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "86s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "85s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "76s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "75s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "74s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "65s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "64s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "63s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "54s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "53s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "52s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "43s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "42s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "32s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "AKo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A8o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A7o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A6o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A5o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A4o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A3o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A2o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KQo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K8o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K7o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K6o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K5o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K4o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K3o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K2o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "QJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q8o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q7o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "Q6o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "JTo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J8o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J7o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "T9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T8o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T7o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "98o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "97o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "87o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "86o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "76o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "65o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "54o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           }
         }
       },
       {
-        "strategies": {
+        "rfi": {
           "AA": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KK": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QQ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "JJ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "TT": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "99": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "88": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "77": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "66": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "55": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "44": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "33": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "22": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AKs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A6s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A5s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A4s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A3s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A2s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K6s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K5s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K4s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K3s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K2s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "QJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q7s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "Q6s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "JTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J7s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "T9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T7s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "98s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "97s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "96s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "87s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "86s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "76s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "75s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "65s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "64s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "54s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "53s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "43s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "AKo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A8o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A7o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A6o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A5o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A4o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A3o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A2o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "KQo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K8o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K7o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "QJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q8o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "JTo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J8o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "T9o": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T8o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "98o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "87o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           }
         }
       },
       {
-        "strategies": {
+        "rfi": {
           "AA": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KK": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QQ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "JJ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "TT": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "99": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "88": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "77": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "66": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "55": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "44": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "33": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "22": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "AKs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A8s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A7s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A6s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A5s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A4s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A3s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A2s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K8s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K7s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K6s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "K5s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "QJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "Q8s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "JTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "J8s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "T9s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T8s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "98s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "87s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "76s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "65s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "54s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "AKo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A9o": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "KQo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTo": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "QJo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTo": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "JTo": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           }
         }
       },
       {
-        "strategies": {
+        "rfi": {
           "AA": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KK": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QQ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "JJ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "TT": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "99": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "88": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "77": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "66": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "55": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "AKs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A9s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A5s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A4s": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A3s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A2s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "KQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "K9s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "QJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "JTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "T9s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "98s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "AKo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJo": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "KQo": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           }
         }
       },
       {
-        "strategies": {
+        "rfi": {
           "AA": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KK": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QQ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "JJ": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "TT": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "99": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "88": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "77": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "66": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "AKs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "ATs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "A5s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A4s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A3s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "A2s": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           },
           "KQs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "KTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QJs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "QTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "JTs": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AKo": {
-            "frequencies": [
-              [
-                "Raise",
-                1.0
-              ]
-            ]
+            "raise": 1.0
           },
           "AQo": {
-            "frequencies": [
-              [
-                "Raise",
-                0.5
-              ],
-              [
-                "Fold",
-                0.5
-              ]
-            ]
+            "raise": 0.5
           }
         }
       }
@@ -3703,8 +1743,13 @@
   "postflop_config": {
     "default": {
       "call_enabled": true,
-      "raise_mult": [3.0],
-      "pot_mult": [0.5, 1.0],
+      "raise_mult": [
+        3.0
+      ],
+      "pot_mult": [
+        0.5,
+        1.0
+      ],
       "setup_shove": false,
       "all_in": true
     }

--- a/src/arena/agent/config.rs
+++ b/src/arena/agent/config.rs
@@ -274,7 +274,7 @@ pub enum AgentConfig {
 ///
 /// Can be either a preset name (e.g., "6max_gto", "tight", "loose")
 /// or an inline chart configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PreflopChartConfigOption {
@@ -282,6 +282,26 @@ pub enum PreflopChartConfigOption {
     Preset(String),
     /// Inline chart configuration
     Inline(PreflopChartConfig),
+}
+
+// Custom Deserialize so failures on the inline path surface the *specific*
+// PreflopChartConfig parse error (e.g. "missing field `charts`", "unknown
+// field `position`") instead of serde's generic "data did not match any
+// variant of untagged enum" message, which is useless when debugging a
+// malformed config.
+impl<'de> Deserialize<'de> for PreflopChartConfigOption {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if let serde_json::Value::String(s) = &value {
+            return Ok(PreflopChartConfigOption::Preset(s.clone()));
+        }
+        serde_json::from_value::<PreflopChartConfig>(value)
+            .map(PreflopChartConfigOption::Inline)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 impl Default for PreflopChartConfigOption {

--- a/src/arena/cfr/action_generator/mod.rs
+++ b/src/arena/cfr/action_generator/mod.rs
@@ -15,7 +15,7 @@ pub use configurable::{
     RoundActionConfig,
 };
 pub use preflop_chart::{
-    PreflopChartActionConfig, PreflopChartActionGenerator, PreflopChartConfig,
+    PositionCharts, PreflopChartActionConfig, PreflopChartActionGenerator, PreflopChartConfig,
     PreflopChartConfigError,
 };
 pub use simple::SimpleActionGenerator;

--- a/src/arena/cfr/action_generator/preflop_chart.rs
+++ b/src/arena/cfr/action_generator/preflop_chart.rs
@@ -2,8 +2,8 @@
 //!
 //! This action generator uses pre-configured preflop charts to limit
 //! exploration during preflop, generating only actions that have non-zero
-//! probability in the chart for the current hand/position. For post-flop,
-//! it delegates to configurable action generation.
+//! probability in the chart for the current (hand, position, scenario).
+//! For post-flop, it delegates to configurable action generation.
 
 use std::sync::Arc;
 
@@ -15,15 +15,15 @@ use crate::arena::GameState;
 use crate::arena::action::AgentAction;
 use crate::arena::cfr::{CFRState, TraversalState};
 use crate::arena::game_state::Round;
-use crate::holdem::{PreflopActionType, PreflopChart, PreflopHand};
+use crate::holdem::{PreflopChart, PreflopHand, PreflopScenario};
 
 use super::{ActionGenerator, ConfigurableActionConfig, ConfigurableActionGenerator};
 
 /// Errors produced when validating a [`PreflopChartConfig`].
 #[derive(Debug, Error, PartialEq)]
 pub enum PreflopChartConfigError {
-    /// At least one preflop chart must be supplied.
-    #[error("at least one preflop chart is required")]
+    /// At least one position chart must be supplied.
+    #[error("at least one position chart is required")]
     NoCharts,
 
     /// `raise_size_bb` must be strictly positive.
@@ -33,6 +33,32 @@ pub enum PreflopChartConfigError {
     /// `three_bet_multiplier` must be strictly positive.
     #[error("three_bet_multiplier must be positive, got {0}")]
     NonPositiveThreeBetMultiplier(f32),
+
+    /// `four_bet_plus_multiplier` must be strictly positive.
+    #[error("four_bet_plus_multiplier must be positive, got {0}")]
+    NonPositiveFourBetPlusMultiplier(f32),
+
+    /// The RFI chart at `position` contains a hand with `call > 0`. Limping
+    /// is not representable — the pot is unopened in RFI.
+    #[error(
+        "position {position}: RFI strategy for {hand} has call={call:.3}; limping not supported"
+    )]
+    RfiCallNotAllowed {
+        position: usize,
+        hand: String,
+        call: f32,
+    },
+
+    /// The Vs4Bet chart at `position` contains a hand with `raise > 0`. The
+    /// raise cap blocks 5-bets, so the action isn't representable.
+    #[error(
+        "position {position}: Vs4Bet strategy for {hand} has raise={raise:.3}; 5-betting is capped"
+    )]
+    Vs4BetRaiseNotAllowed {
+        position: usize,
+        hand: String,
+        raise: f32,
+    },
 }
 
 fn default_raise_size_bb() -> f32 {
@@ -43,10 +69,60 @@ fn default_three_bet_multiplier() -> f32 {
     3.0
 }
 
+fn default_four_bet_plus_multiplier() -> f32 {
+    2.5
+}
+
+/// Charts for each preflop scenario at a single position.
+///
+/// All four scenarios are optional; an empty chart is equivalent to
+/// "everyone folds for this scenario". In JSON, unknown/omitted fields
+/// default to an empty chart.
+///
+/// # Examples
+///
+/// ```json
+/// {
+///   "rfi":     { "AA": {"raise": 1.0}, "KK": {"raise": 1.0} },
+///   "vs_open": { "AA": {"raise": 0.5, "call": 0.5} }
+/// }
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct PositionCharts {
+    /// Unopened pot — raise (open) or fold. Limping (call > 0) is rejected.
+    #[serde(default, skip_serializing_if = "PreflopChart::is_empty")]
+    pub rfi: PreflopChart,
+    /// Facing one raise — raise (3-bet), call, or fold.
+    #[serde(default, skip_serializing_if = "PreflopChart::is_empty")]
+    pub vs_open: PreflopChart,
+    /// Facing two raises — raise (4-bet), call, or fold.
+    #[serde(default, skip_serializing_if = "PreflopChart::is_empty")]
+    pub vs_3bet: PreflopChart,
+    /// Facing 3+ raises — call or fold only (raise cap blocks further raises).
+    #[serde(default, skip_serializing_if = "PreflopChart::is_empty")]
+    pub vs_4bet: PreflopChart,
+}
+
+impl PositionCharts {
+    /// Borrow the chart for a specific scenario.
+    pub fn chart_for(&self, scenario: PreflopScenario) -> &PreflopChart {
+        match scenario {
+            PreflopScenario::Rfi => &self.rfi,
+            PreflopScenario::VsOpen => &self.vs_open,
+            PreflopScenario::Vs3Bet => &self.vs_3bet,
+            PreflopScenario::Vs4Bet => &self.vs_4bet,
+        }
+    }
+}
+
 /// Configuration for preflop chart-based play.
 ///
-/// This configuration specifies which hands to play from each position
-/// and how to size bets during preflop.
+/// `positions` is indexed by BB-relative distance: 0 = Big Blind, 1 = Small
+/// Blind, 2 = Button, 3 = Cutoff, 4 = Hijack, 5 = UTG, 6+ = earlier
+/// positions. If a position index exceeds the available charts, the last
+/// chart is used — this fallback makes the tightest early-position range
+/// the default for unspecified seats at bigger tables.
 ///
 /// # Example JSON
 ///
@@ -54,102 +130,103 @@ fn default_three_bet_multiplier() -> f32 {
 /// {
 ///   "raise_size_bb": 2.5,
 ///   "three_bet_multiplier": 3.0,
-///   "charts": [
-///     { "AA": {"Raise": 1.0}, "KK": {"Raise": 1.0} },
-///     { "AA": {"Raise": 1.0} }
+///   "four_bet_plus_multiplier": 2.5,
+///   "positions": [
+///     {},  // BB: all-fold everywhere
+///     { "vs_open": { "AA": {"raise": 1.0} } },
+///     {
+///       "rfi":     { "AA": {"raise": 1.0}, "KK": {"raise": 1.0} },
+///       "vs_open": { "AA": {"raise": 0.5, "call": 0.5} }
+///     }
 ///   ]
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PreflopChartConfig {
-    /// Charts indexed by position (distance from button).
-    /// Index 0 = Button, 1 = Small Blind, 2 = Big Blind, 3+ = early positions.
-    ///
-    /// If a position index exceeds the available charts, the last chart is used.
-    /// This allows specifying fewer charts (e.g., just one "tight" chart for all positions)
-    /// while still having position-specific play when desired.
-    pub charts: Vec<PreflopChart>,
+    /// Charts indexed by BB-relative position (0 = BB, 1 = SB, 2 = BTN, ...).
+    pub positions: Vec<PositionCharts>,
 
-    /// Default raise size as multiple of big blind for open raises.
-    /// Standard is 2.5bb from most positions.
+    /// Open-raise size as a multiple of the big blind (used in RFI).
     #[serde(default = "default_raise_size_bb")]
     pub raise_size_bb: f32,
 
-    /// Multiplier for 3-bet sizing (3-bet = this * opponent's raise).
-    /// Standard is 3x the opponent's raise from in position.
+    /// 3-bet sizing = this * current_bet (used in VsOpen).
     #[serde(default = "default_three_bet_multiplier")]
     pub three_bet_multiplier: f32,
+
+    /// 4-bet and subsequent raise sizing = this * current_bet (used in
+    /// Vs3Bet).
+    #[serde(default = "default_four_bet_plus_multiplier")]
+    pub four_bet_plus_multiplier: f32,
 }
 
 impl Default for PreflopChartConfig {
     fn default() -> Self {
         Self {
-            charts: vec![PreflopChart::new()],
+            positions: vec![PositionCharts::default()],
             raise_size_bb: default_raise_size_bb(),
             three_bet_multiplier: default_three_bet_multiplier(),
+            four_bet_plus_multiplier: default_four_bet_plus_multiplier(),
         }
     }
 }
 
 impl PreflopChartConfig {
-    /// Create a new config with the given charts.
-    pub fn new(charts: Vec<PreflopChart>) -> Self {
+    /// Create a new config with the given position charts.
+    pub fn new(positions: Vec<PositionCharts>) -> Self {
         Self {
-            charts,
+            positions,
             ..Default::default()
         }
     }
 
-    /// Create a config with a single chart used for all positions.
-    pub fn with_single_chart(chart: PreflopChart) -> Self {
+    /// Create a config with a single position chart used for all positions
+    /// (via the fallback).
+    pub fn with_single_position(charts: PositionCharts) -> Self {
         Self {
-            charts: vec![chart],
+            positions: vec![charts],
             ..Default::default()
         }
     }
 
-    /// Get the chart for a given position relative to button.
+    /// Get the [`PositionCharts`] for a given BB-relative position.
     ///
-    /// Position 0 = Button, 1 = Small Blind, 2 = Big Blind, etc.
-    /// If position exceeds available charts, returns the last chart.
-    pub fn chart_for_position(&self, position: usize) -> &PreflopChart {
-        if self.charts.is_empty() {
-            // This shouldn't happen with Default, but handle gracefully
-            panic!("PreflopChartConfig has no charts");
+    /// If `position` exceeds `positions.len()`, returns the last entry
+    /// (tightest-seat fallback).
+    pub fn charts_for_position(&self, position: usize) -> &PositionCharts {
+        if self.positions.is_empty() {
+            panic!("PreflopChartConfig has no positions");
         }
-        let idx = position.min(self.charts.len() - 1);
-        &self.charts[idx]
+        let idx = position.min(self.positions.len() - 1);
+        &self.positions[idx]
     }
 
-    /// Calculate the position relative to the big blind.
+    /// Get the chart for a specific (position, scenario). Missing entries
+    /// return an empty (all-fold) chart.
+    pub fn chart_for(&self, position: usize, scenario: PreflopScenario) -> &PreflopChart {
+        self.charts_for_position(position).chart_for(scenario)
+    }
+
+    /// Calculate the BB-relative position from player/dealer indexes.
     ///
-    /// Returns the distance from the big blind position (counter-clockwise):
     /// - 0 = Big Blind
-    /// - 1 = Small Blind (or Button in heads-up)
+    /// - 1 = Small Blind (or Button in heads-up, which posts SB)
     /// - 2 = Button (for 3+ players)
     /// - 3 = Cutoff
     /// - 4 = Hijack
-    /// - 5+ = Earlier positions (UTG, etc.)
-    ///
-    /// This ordering is designed so that if fewer charts are provided than
-    /// positions, the "fallback" (last chart) represents the tightest/earliest
-    /// position range, which is appropriate for unspecified early positions.
-    ///
-    /// Note: In heads-up (2 players), the button posts the small blind and
-    /// acts first preflop. The BB is 1 position after the dealer, not 2.
+    /// - 5+ = Earlier positions (UTG, UTG+1, ...)
     pub fn calculate_position(player_idx: usize, dealer_idx: usize, num_players: usize) -> usize {
         // In heads-up, BB is 1 seat after dealer (BTN posts SB)
         // In 3+ players, BB is 2 seats after dealer
         let bb_offset = if num_players == 2 { 1 } else { 2 };
         let bb_idx = (dealer_idx + bb_offset) % num_players;
-        // Distance from BB (counter-clockwise = positions acting before BB)
         (bb_idx + num_players - player_idx) % num_players
     }
 
     /// Validate the configuration.
     pub fn validate(&self) -> Result<(), PreflopChartConfigError> {
-        if self.charts.is_empty() {
+        if self.positions.is_empty() {
             return Err(PreflopChartConfigError::NoCharts);
         }
         if self.raise_size_bb <= 0.0 {
@@ -162,13 +239,39 @@ impl PreflopChartConfig {
                 self.three_bet_multiplier,
             ));
         }
+        if self.four_bet_plus_multiplier <= 0.0 {
+            return Err(PreflopChartConfigError::NonPositiveFourBetPlusMultiplier(
+                self.four_bet_plus_multiplier,
+            ));
+        }
+        for (position, charts) in self.positions.iter().enumerate() {
+            for (hand, strategy) in charts.rfi.iter() {
+                if strategy.call() > 0.0 {
+                    return Err(PreflopChartConfigError::RfiCallNotAllowed {
+                        position,
+                        hand: hand.to_notation(),
+                        call: strategy.call(),
+                    });
+                }
+            }
+            for (hand, strategy) in charts.vs_4bet.iter() {
+                if strategy.raise() > 0.0 {
+                    return Err(PreflopChartConfigError::Vs4BetRaiseNotAllowed {
+                        position,
+                        hand: hand.to_notation(),
+                        raise: strategy.raise(),
+                    });
+                }
+            }
+        }
         Ok(())
     }
 }
 
 /// Configuration for the preflop chart action generator.
 ///
-/// Combines preflop chart configuration with configurable post-flop action generation.
+/// Combines preflop chart configuration with configurable post-flop action
+/// generation.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Default)]
@@ -180,17 +283,14 @@ pub struct PreflopChartActionConfig {
     pub postflop_config: ConfigurableActionConfig,
 }
 
-/// Action generator that uses preflop charts for preflop and configurable
-/// actions for post-flop.
+/// Action generator that uses preflop charts for preflop decisions and a
+/// configurable generator for post-flop streets.
 ///
-/// During preflop, this generator:
-/// 1. Gets the player's hand and position
-/// 2. Looks up the chart for that position
-/// 3. Gets the strategy for the hand (or fold if not in chart)
-/// 4. Returns all actions with non-zero frequency as possible actions
-///
-/// During post-flop, this generator delegates to `ConfigurableActionGenerator`
-/// logic for action generation.
+/// During preflop, the generator:
+/// 1. Derives the player's scenario from `round_data.total_raise_count`.
+/// 2. Looks up the chart for `(bb_relative_position, scenario)`.
+/// 3. Reads the strategy for the player's hand (defaulting to pure-fold).
+/// 4. Emits `AgentAction`s for every non-zero frequency (raise/call/fold).
 ///
 /// # Example
 ///
@@ -257,23 +357,20 @@ impl ActionGenerator for PreflopChartActionGenerator {
     }
 
     fn gen_possible_actions(&self, game_state: &GameState) -> Vec<AgentAction> {
-        // For preflop, use chart-based action generation
         if matches!(game_state.round, Round::Preflop | Round::DealPreflop) {
             self.gen_preflop_actions(game_state)
         } else {
-            // For post-flop, delegate to configurable action generator logic
             self.gen_postflop_actions(game_state)
         }
     }
 }
 
 impl PreflopChartActionGenerator {
-    /// Generate preflop actions based on the configured charts.
+    /// Generate preflop actions from the (position, scenario) chart.
     fn gen_preflop_actions(&self, game_state: &GameState) -> Vec<AgentAction> {
         let player_idx = game_state.to_act_idx();
         let player_hand = &game_state.hands[player_idx];
 
-        // Convert player's hole cards to PreflopHand
         let preflop_hand = match PreflopHand::try_from(player_hand) {
             Ok(h) => h,
             Err(e) => {
@@ -282,50 +379,57 @@ impl PreflopChartActionGenerator {
                     ?e,
                     "Failed to convert hand to PreflopHand, returning fold only"
                 );
-                // If we can't identify the hand, just return fold
                 return vec![AgentAction::Fold];
             }
         };
 
-        // Calculate position relative to button
         let position = PreflopChartConfig::calculate_position(
             player_idx,
             game_state.dealer_idx,
             game_state.num_players,
         );
-
-        // Get chart for this position
-        let chart = self.config.preflop_config.chart_for_position(position);
-
-        // Look up strategy for this hand
+        let scenario = PreflopScenario::from_raise_count(game_state.round_data.total_raise_count);
+        let chart = self.config.preflop_config.chart_for(position, scenario);
         let strategy = chart.get_or_fold(&preflop_hand);
 
         event!(
             tracing::Level::DEBUG,
             hand = %preflop_hand,
             position,
+            scenario = scenario.label(),
             "Generating preflop actions from chart"
         );
 
-        // Extract all actions with non-zero frequency
-        let mut actions = Vec::new();
         let current_bet = game_state.current_round_bet();
         let player_bet = game_state.current_round_current_player_bet();
         let to_call = current_bet - player_bet;
 
-        for (action_type, freq) in strategy.frequencies() {
-            if *freq > 0.0
-                && let Some(action) = self.convert_preflop_action(*action_type, game_state)
-            {
-                // Avoid duplicates
-                if !actions.contains(&action) {
-                    actions.push(action);
-                }
+        let mut actions = Vec::new();
+        if strategy.raise() > 0.0
+            && let Some(action) = self.raise_action(scenario, game_state)
+            && !actions.contains(&action)
+        {
+            actions.push(action);
+        }
+        if strategy.call() > 0.0 {
+            let action = AgentAction::Call;
+            if !actions.contains(&action) {
+                actions.push(action);
+            }
+        }
+        if strategy.fold_freq() > 0.0 {
+            let action = if to_call > 0.0 {
+                AgentAction::Fold
+            } else {
+                AgentAction::Call // Check when no bet to face.
+            };
+            if !actions.contains(&action) {
+                actions.push(action);
             }
         }
 
-        // If we end up with no actions (shouldn't happen with fold strategy),
-        // ensure we at least have fold or call
+        // Never leave the picker with an empty action set (it panics on
+        // empty-range sampling). Fall back to Check or Fold.
         if actions.is_empty() {
             if to_call > 0.0 {
                 actions.push(AgentAction::Fold);
@@ -337,10 +441,14 @@ impl PreflopChartActionGenerator {
         actions
     }
 
-    /// Convert a PreflopActionType to an AgentAction with proper sizing.
-    fn convert_preflop_action(
+    /// Build an `AgentAction::Bet` (or `AllIn`) sized for `scenario`.
+    ///
+    /// Returns `None` for `Vs4Bet` (no 5-bet sizing; the raise cap blocks it
+    /// anyway). If the raise cap is already reached at earlier scenarios,
+    /// falls back to a Call so the agent can still see the flop.
+    fn raise_action(
         &self,
-        action: PreflopActionType,
+        scenario: PreflopScenario,
         game_state: &GameState,
     ) -> Option<AgentAction> {
         let player_idx = game_state.to_act_idx();
@@ -348,77 +456,27 @@ impl PreflopChartActionGenerator {
         let current_bet = game_state.current_round_bet();
         let player_bet = game_state.current_round_current_player_bet();
         let player_stack = game_state.stacks[player_idx];
-        let to_call = current_bet - player_bet;
-
-        // When the raise cap has been reached, any Raise/3-bet/4-bet the
-        // chart prescribes is illegal. Fall back to Call so the agent still
-        // plays the hand the chart flagged as playable rather than folding
-        // it — and, more importantly, so the validated action set is never
-        // empty (which would panic the picker with "cannot sample empty
-        // range").
         let raise_capped = game_state.is_raise_capped();
 
-        match action {
-            PreflopActionType::Fold => {
-                // If there's nothing to call, fold becomes check
-                if to_call <= 0.0 {
-                    Some(AgentAction::Call) // Check
-                } else {
-                    Some(AgentAction::Fold)
-                }
-            }
-            PreflopActionType::Call => Some(AgentAction::Call),
-            PreflopActionType::Raise => {
-                if raise_capped {
-                    return Some(AgentAction::Call);
-                }
-                // Standard open raise: raise_size_bb * big_blind
-                let raise_amount = self.config.preflop_config.raise_size_bb * big_blind;
-
-                // If there's already a raise, this becomes a re-raise (3-bet)
-                if current_bet > big_blind {
-                    // Someone already raised, so we 3-bet
-                    let three_bet_amount =
-                        current_bet * self.config.preflop_config.three_bet_multiplier;
-                    Some(self.bet_or_all_in(three_bet_amount, player_stack, player_bet))
-                } else {
-                    // Standard open raise
-                    Some(self.bet_or_all_in(raise_amount, player_stack, player_bet))
-                }
-            }
-            PreflopActionType::ThreeBet => {
-                if raise_capped {
-                    return Some(AgentAction::Call);
-                }
-                // 3-bet: multiply current bet by three_bet_multiplier
-                let three_bet_amount =
-                    current_bet * self.config.preflop_config.three_bet_multiplier;
-                Some(self.bet_or_all_in(three_bet_amount, player_stack, player_bet))
-            }
-            PreflopActionType::FourBet => {
-                if raise_capped {
-                    return Some(AgentAction::Call);
-                }
-                // 4-bet: typically 2.5x the 3-bet
-                let four_bet_amount = current_bet * 2.5;
-                Some(self.bet_or_all_in(four_bet_amount, player_stack, player_bet))
-            }
+        if raise_capped {
+            return Some(AgentAction::Call);
         }
-    }
 
-    /// Return a Bet action or AllIn if the bet amount exceeds the stack.
-    fn bet_or_all_in(&self, amount: f32, stack: f32, player_bet: f32) -> AgentAction {
-        let all_in_amount = stack + player_bet;
-        if amount >= all_in_amount {
-            AgentAction::AllIn
-        } else {
-            AgentAction::Bet(amount)
-        }
+        let amount = match scenario {
+            PreflopScenario::Rfi => self.config.preflop_config.raise_size_bb * big_blind,
+            PreflopScenario::VsOpen => {
+                current_bet * self.config.preflop_config.three_bet_multiplier
+            }
+            PreflopScenario::Vs3Bet => {
+                current_bet * self.config.preflop_config.four_bet_plus_multiplier
+            }
+            PreflopScenario::Vs4Bet => return None,
+        };
+        Some(bet_or_all_in(amount, player_stack, player_bet))
     }
 
     /// Generate post-flop actions using configurable action generator logic.
     fn gen_postflop_actions(&self, game_state: &GameState) -> Vec<AgentAction> {
-        // Create a temporary ConfigurableActionGenerator to reuse its logic
         let configurable = ConfigurableActionGenerator::new_with_config(
             self.cfr_state.clone(),
             self.traversal_state.clone(),
@@ -428,20 +486,31 @@ impl PreflopChartActionGenerator {
     }
 }
 
+/// Return a Bet action, or AllIn if the bet amount would consume the stack.
+fn bet_or_all_in(amount: f32, stack: f32, player_bet: f32) -> AgentAction {
+    let all_in_amount = stack + player_bet;
+    if amount >= all_in_amount {
+        AgentAction::AllIn
+    } else {
+        AgentAction::Bet(amount)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::arena::GameStateBuilder;
     use crate::arena::cfr::{CFRState, TraversalState};
     use crate::core::Value;
-    use crate::holdem::{PreflopChart, PreflopStrategy};
+    use crate::holdem::PreflopStrategy;
 
     #[test]
-    fn test_validate_no_charts() {
+    fn test_validate_no_positions() {
         let cfg = PreflopChartConfig {
-            charts: vec![],
+            positions: vec![],
             raise_size_bb: 2.5,
             three_bet_multiplier: 3.0,
+            four_bet_plus_multiplier: 2.5,
         };
         assert_eq!(
             cfg.validate().unwrap_err(),
@@ -452,9 +521,10 @@ mod tests {
     #[test]
     fn test_validate_non_positive_raise_size() {
         let cfg = PreflopChartConfig {
-            charts: vec![PreflopChart::new()],
+            positions: vec![PositionCharts::default()],
             raise_size_bb: 0.0,
             three_bet_multiplier: 3.0,
+            four_bet_plus_multiplier: 2.5,
         };
         assert_eq!(
             cfg.validate().unwrap_err(),
@@ -465,13 +535,54 @@ mod tests {
     #[test]
     fn test_validate_non_positive_three_bet_multiplier() {
         let cfg = PreflopChartConfig {
-            charts: vec![PreflopChart::new()],
+            positions: vec![PositionCharts::default()],
             raise_size_bb: 2.5,
             three_bet_multiplier: -1.0,
+            four_bet_plus_multiplier: 2.5,
         };
         assert_eq!(
             cfg.validate().unwrap_err(),
             PreflopChartConfigError::NonPositiveThreeBetMultiplier(-1.0)
+        );
+    }
+
+    #[test]
+    fn test_validate_non_positive_four_bet_plus_multiplier() {
+        let cfg = PreflopChartConfig {
+            positions: vec![PositionCharts::default()],
+            raise_size_bb: 2.5,
+            three_bet_multiplier: 3.0,
+            four_bet_plus_multiplier: 0.0,
+        };
+        assert_eq!(
+            cfg.validate().unwrap_err(),
+            PreflopChartConfigError::NonPositiveFourBetPlusMultiplier(0.0)
+        );
+    }
+
+    #[test]
+    fn test_validate_rfi_rejects_call() {
+        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
+        let mut charts = PositionCharts::default();
+        charts.rfi.set(aa, PreflopStrategy::new(0.5, 0.5).unwrap());
+        let cfg = PreflopChartConfig::new(vec![charts]);
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            matches!(err, PreflopChartConfigError::RfiCallNotAllowed { .. }),
+            "expected RfiCallNotAllowed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_vs4bet_rejects_raise() {
+        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
+        let mut charts = PositionCharts::default();
+        charts.vs_4bet.set(aa, PreflopStrategy::pure_raise());
+        let cfg = PreflopChartConfig::new(vec![charts]);
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            matches!(err, PreflopChartConfigError::Vs4BetRaiseNotAllowed { .. }),
+            "expected Vs4BetRaiseNotAllowed, got {err:?}"
         );
     }
 
@@ -484,15 +595,14 @@ mod tests {
     }
 
     fn create_simple_config() -> PreflopChartActionConfig {
-        let mut chart = PreflopChart::new();
-        // Only AA and KK raise
+        let mut charts = PositionCharts::default();
         let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
         let kk = PreflopHand::new(Value::King, Value::King, false);
-        chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
-        chart.set(kk, PreflopStrategy::pure(PreflopActionType::Raise));
+        charts.rfi.set(aa, PreflopStrategy::pure_raise());
+        charts.rfi.set(kk, PreflopStrategy::pure_raise());
 
         PreflopChartActionConfig {
-            preflop_config: PreflopChartConfig::with_single_chart(chart),
+            preflop_config: PreflopChartConfig::with_single_position(charts),
             postflop_config: ConfigurableActionConfig::default(),
         }
     }
@@ -509,11 +619,8 @@ mod tests {
     }
 
     /// Regression: when the raise cap is reached preflop and the chart says
-    /// Raise, the generator used to output a `Bet(three_bet_amount)` that
-    /// `validate_actions` would then strip as a capped raise, leaving an
-    /// empty action set and panicking the picker with "cannot sample empty
-    /// range". A preflop chart agent must fall back to a non-raise action
-    /// (Call or Fold) so the validated set is never empty.
+    /// Raise, the generator must fall back to a non-raise action so the
+    /// validated action set is never empty.
     #[test]
     fn test_chart_raise_when_raise_capped_falls_back_to_call() {
         use crate::arena::cfr::{ValidatorMode, validate_actions};
@@ -521,26 +628,20 @@ mod tests {
         use crate::core::{Hand, PlayerBitSet};
 
         // 6-handed preflop, three raises already in the pot.
-        // Player 0 is to act; they hold AA so the chart entry says Raise.
         let num_players = 6;
         let big_blind = 5.0;
         let small_blind = 2.5;
 
-        // Round bets: P1 opens to 12.5, P3 3-bets to 37.5, P5 4-bets to 112.5.
-        // Everyone else has 0 in this round (P0 is about to act).
         let round_player_bet = vec![0.0, 12.5, 0.0, 37.5, 0.0, 112.5];
-        // Starting stacks uniform.
         let stacks: Vec<f32> = vec![500.0; num_players];
-        // Carry round bets into total player_bet for accurate state.
         let player_bet = round_player_bet.clone();
 
         let mut round_data = RoundData::new_with_bets(
-            big_blind, // min raise
+            big_blind,
             PlayerBitSet::new(num_players),
-            0, // P0 to act
+            0,
             round_player_bet,
         );
-        // Force raise-capped state (default cap is 3).
         round_data.total_raise_count = 3;
 
         let mut hands = vec![Hand::default(); num_players];
@@ -562,12 +663,13 @@ mod tests {
             "test setup: expected raise cap reached"
         );
 
-        // Pure-Raise chart for AA, matching the experiment config shape.
-        let mut chart = PreflopChart::new();
+        // Player faces 3 raises → Vs4Bet. Pure-call chart entry so we exercise
+        // the call path; raise is rejected in Vs4Bet anyway.
+        let mut charts = PositionCharts::default();
         let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-        chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
+        charts.vs_4bet.set(aa, PreflopStrategy::pure_call());
         let config = PreflopChartActionConfig {
-            preflop_config: PreflopChartConfig::with_single_chart(chart),
+            preflop_config: PreflopChartConfig::with_single_position(charts),
             postflop_config: ConfigurableActionConfig::default(),
         };
 
@@ -584,13 +686,11 @@ mod tests {
             "validated action set must not be empty (raw was {raw:?})"
         );
 
-        // Intelligent fallback: calling should always be possible when
-        // facing a raise-capped bet, so the agent can still see the flop.
         assert!(
             validated
                 .iter()
                 .any(|a| matches!(a, AgentAction::Call | AgentAction::Fold)),
-            "expected Call or Fold in fallback action set, got {validated:?}"
+            "expected Call or Fold in validated action set, got {validated:?}"
         );
     }
 
@@ -599,24 +699,7 @@ mod tests {
         let game_state = create_test_game_state();
         let config = create_simple_config();
         let generator = create_generator(&game_state, config);
-
-        // The generator should return actions based on the chart
         let actions = generator.gen_possible_actions(&game_state);
-
-        // Should have at least one action
-        assert!(!actions.is_empty());
-    }
-
-    #[test]
-    fn test_preflop_actions_for_non_chart_hand() {
-        let game_state = create_test_game_state();
-        let config = create_simple_config();
-        let generator = create_generator(&game_state, config);
-
-        // For hands not in the chart, should get fold action
-        let actions = generator.gen_possible_actions(&game_state);
-
-        // Should have at least fold/call
         assert!(!actions.is_empty());
     }
 
@@ -628,25 +711,18 @@ mod tests {
             .blinds(10.0, 5.0)
             .build()
             .unwrap();
-        // Move to flop
         game_state.advance_round();
 
         let config = create_simple_config();
         let generator = create_generator(&game_state, config);
 
         let actions = generator.gen_possible_actions(&game_state);
-
-        // Should have configurable actions (call, raises, all-in, etc.)
         assert!(!actions.is_empty());
-        // Should include all-in since that's default for ConfigurableActionConfig
         assert!(actions.contains(&AgentAction::AllIn));
     }
 
     #[test]
     fn test_position_calculation() {
-        // Test the static position calculation
-        // Position is relative to BB (position 0)
-        //
         // 2-player heads up: dealer=0
         // Player 0 = BTN, Player 1 = BB
         assert_eq!(PreflopChartConfig::calculate_position(1, 0, 2), 0); // BB
@@ -664,67 +740,37 @@ mod tests {
 
     #[test]
     fn test_bet_or_all_in() {
-        let game_state = create_test_game_state();
-        let config = create_simple_config();
-        let generator = create_generator(&game_state, config);
-
-        // Normal bet (player has 100 stack, 0 already bet)
-        let action = generator.bet_or_all_in(50.0, 100.0, 0.0);
-        assert!(matches!(action, AgentAction::Bet(50.0)));
-
-        // Bet equals total possible (stack + current bet)
-        let action = generator.bet_or_all_in(100.0, 100.0, 0.0);
-        assert!(matches!(action, AgentAction::AllIn));
-
-        // Bet exceeds stack
-        let action = generator.bet_or_all_in(150.0, 100.0, 0.0);
-        assert!(matches!(action, AgentAction::AllIn));
-
-        // With some already bet
-        let action = generator.bet_or_all_in(110.0, 90.0, 10.0);
-        assert!(matches!(action, AgentAction::AllIn));
-    }
-
-    #[test]
-    fn test_fold_becomes_check_when_no_bet() {
-        let mut game_state = create_test_game_state();
-        // Move past blinds
-        game_state.advance_round();
-
-        let config = create_simple_config();
-        let generator = create_generator(&game_state, config);
-
-        // When there's no bet to call, Fold should become Call (check)
-        let action = generator.convert_preflop_action(PreflopActionType::Fold, &game_state);
-        // If current_bet == player_bet (no bet to call), fold becomes check
-        // In preflop after blinds, there is a bet to call for most positions
-        assert!(action.is_some());
+        assert!(matches!(
+            bet_or_all_in(50.0, 100.0, 0.0),
+            AgentAction::Bet(_)
+        ));
+        assert!(matches!(
+            bet_or_all_in(100.0, 100.0, 0.0),
+            AgentAction::AllIn
+        ));
+        assert!(matches!(
+            bet_or_all_in(150.0, 100.0, 0.0),
+            AgentAction::AllIn
+        ));
+        assert!(matches!(
+            bet_or_all_in(110.0, 90.0, 10.0),
+            AgentAction::AllIn
+        ));
     }
 
     #[test]
     fn test_mixed_strategy_generates_multiple_actions() {
-        let mut chart = PreflopChart::new();
+        let mut charts = PositionCharts::default();
         let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-        // Mixed strategy: 70% raise, 30% call
-        chart.set(
-            aa,
-            PreflopStrategy::new(vec![
-                (PreflopActionType::Raise, 0.7),
-                (PreflopActionType::Call, 0.3),
-            ])
-            .unwrap(),
-        );
+        charts.rfi.set(aa, PreflopStrategy::new(0.7, 0.0).unwrap());
 
         let config = PreflopChartActionConfig {
-            preflop_config: PreflopChartConfig::with_single_chart(chart),
+            preflop_config: PreflopChartConfig::with_single_position(charts),
             postflop_config: ConfigurableActionConfig::default(),
         };
 
         let game_state = create_test_game_state();
         let generator = create_generator(&game_state, config);
-
-        // For AA with mixed strategy, should generate both raise and call actions
-        // (Note: the actual hand dealt may not be AA, but this tests the mechanism)
         let actions = generator.gen_possible_actions(&game_state);
         assert!(!actions.is_empty());
     }
@@ -737,7 +783,6 @@ mod tests {
         use crate::arena::{Agent, HoldemSimulationBuilder, test_util};
         use rand::{SeedableRng, rngs::StdRng};
 
-        // Create a starting game state
         let game_state = GameStateBuilder::new()
             .num_players_with_stack(2, 100.0)
             .blinds(10.0, 5.0)
@@ -747,7 +792,6 @@ mod tests {
         let config = create_simple_config();
         let depth_config = CfrDepthConfig::new(vec![1]);
 
-        // Create CFR agents with PreflopChartActionGenerator sharing a single CFR state
         let cfr_state = CFRState::new(game_state.clone());
         let traversal_set = TraversalSet::new(game_state.num_players);
         let agents: Vec<Box<dyn Agent>> = (0..2)
@@ -780,181 +824,38 @@ mod tests {
         test_util::assert_valid_game_state(&sim.game_state);
     }
 
-    /// Test multiple games with PreflopChartActionGenerator.
     #[test]
-    fn test_multiple_games_preflop_chart_action_gen() {
-        use crate::arena::cfr::{CFRAgentBuilder, CFRState, CfrDepthConfig, TraversalSet};
-        use crate::arena::game_state::Round;
-        use crate::arena::{Agent, HoldemSimulationBuilder, test_util};
-        use rand::{SeedableRng, rngs::StdRng};
-
-        let config = create_simple_config();
-        let depth_config = CfrDepthConfig::new(vec![1]);
-
-        for game_idx in 0..5 {
-            let game_state = GameStateBuilder::new()
-                .num_players_with_stack(2, 100.0)
-                .blinds(10.0, 5.0)
-                .build()
-                .unwrap();
-
-            let cfr_state = CFRState::new(game_state.clone());
-            let traversal_set = TraversalSet::new(game_state.num_players);
-            let agents: Vec<Box<dyn Agent>> = (0..2)
-                .map(|idx| {
-                    Box::new(
-                        CFRAgentBuilder::<PreflopChartActionGenerator>::new()
-                            .name(format!("PreflopChartAgent-game{game_idx}-p{idx}"))
-                            .player_idx(idx)
-                            .cfr_state(cfr_state.clone())
-                            .traversal_set(traversal_set.clone())
-                            .depth_config(depth_config.clone())
-                            .action_gen_config(config.clone())
-                            .build(),
-                    ) as Box<dyn Agent>
-                })
-                .collect();
-
-            let mut rng = StdRng::seed_from_u64(42 + game_idx as u64);
-
-            let mut sim = HoldemSimulationBuilder::default()
-                .game_state(game_state)
-                .agents(agents)
-                .cfr_context(cfr_state, traversal_set, true)
-                .build()
-                .unwrap();
-
-            sim.run(&mut rng);
-
-            assert_eq!(
-                Round::Complete,
-                sim.game_state.round,
-                "Game {game_idx} should complete"
-            );
-            test_util::assert_valid_game_state(&sim.game_state);
-        }
-    }
-
-    // Tests for PreflopChartConfig
-
-    #[test]
-    fn test_default_config() {
-        let config = PreflopChartConfig::default();
-        assert_eq!(config.charts.len(), 1);
-        assert_eq!(config.raise_size_bb, 2.5);
-        assert_eq!(config.three_bet_multiplier, 3.0);
-    }
-
-    #[test]
-    fn test_position_calculation_6_player() {
-        // 6-player table, dealer at position 3
-        // Positions relative to BB (position 0):
-        // Player 5 = BB (0)
-        // Player 4 = SB (1)
-        // Player 3 = BTN (2)
-        // Player 2 = CO (3)
-        // Player 1 = HJ (4)
-        // Player 0 = UTG (5)
-
-        let num_players = 6;
-        let dealer_idx = 3;
-
-        assert_eq!(
-            PreflopChartConfig::calculate_position(5, dealer_idx, num_players),
-            0
-        ); // BB
-        assert_eq!(
-            PreflopChartConfig::calculate_position(4, dealer_idx, num_players),
-            1
-        ); // SB
-        assert_eq!(
-            PreflopChartConfig::calculate_position(3, dealer_idx, num_players),
-            2
-        ); // BTN
-        assert_eq!(
-            PreflopChartConfig::calculate_position(2, dealer_idx, num_players),
-            3
-        ); // CO
-        assert_eq!(
-            PreflopChartConfig::calculate_position(1, dealer_idx, num_players),
-            4
-        ); // HJ
-        assert_eq!(
-            PreflopChartConfig::calculate_position(0, dealer_idx, num_players),
-            5
-        ); // UTG
-    }
-
-    #[test]
-    fn test_chart_for_position_single_chart() {
-        let mut chart = PreflopChart::new();
+    fn test_charts_for_position_fallback() {
         let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-        chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
+        let mut loose = PositionCharts::default();
+        loose.rfi.set(aa, PreflopStrategy::pure_raise());
 
-        let config = PreflopChartConfig::with_single_chart(chart);
-
-        // All positions should use the same chart
-        for pos in 0..10 {
-            let c = config.chart_for_position(pos);
-            assert!(c.get(&aa).is_some());
-        }
-    }
-
-    #[test]
-    fn test_chart_for_position_multiple_charts() {
-        let mut btn_chart = PreflopChart::new();
-        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-        btn_chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
-
-        let mut utg_chart = PreflopChart::new();
-        // UTG chart only has AA, nothing else
-        utg_chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
+        let mut tight = PositionCharts::default();
         let kk = PreflopHand::new(Value::King, Value::King, false);
-        utg_chart.set(kk, PreflopStrategy::pure(PreflopActionType::Raise));
+        tight.rfi.set(kk, PreflopStrategy::pure_raise());
 
-        let config = PreflopChartConfig::new(vec![btn_chart, utg_chart.clone()]);
+        let config = PreflopChartConfig::new(vec![loose, tight.clone()]);
 
-        // Position 0 (BTN) uses first chart
-        let btn = config.chart_for_position(0);
-        assert!(btn.get(&aa).is_some());
-        assert!(btn.get(&kk).is_none()); // BTN chart doesn't have KK
-
-        // Position 1+ uses second chart (which has KK)
-        let other = config.chart_for_position(1);
-        assert!(other.get(&kk).is_some());
-    }
-
-    #[test]
-    fn test_validate_empty_charts() {
-        let config = PreflopChartConfig {
-            charts: vec![],
-            raise_size_bb: 2.5,
-            three_bet_multiplier: 3.0,
-        };
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn test_validate_invalid_raise_size() {
-        let config = PreflopChartConfig {
-            charts: vec![PreflopChart::new()],
-            raise_size_bb: 0.0,
-            three_bet_multiplier: 3.0,
-        };
-        assert!(config.validate().is_err());
+        // Position 0 uses first charts.
+        assert!(config.chart_for(0, PreflopScenario::Rfi).get(&aa).is_some());
+        // Position 1 uses second charts.
+        assert!(config.chart_for(1, PreflopScenario::Rfi).get(&kk).is_some());
+        // Position 5 (past end) falls back to the last (tightest).
+        assert!(config.chart_for(5, PreflopScenario::Rfi).get(&kk).is_some());
     }
 
     #[cfg(feature = "serde")]
     #[test]
     fn test_serde_roundtrip() {
-        let mut chart = PreflopChart::new();
         let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-        chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
+        let mut charts = PositionCharts::default();
+        charts.rfi.set(aa, PreflopStrategy::pure_raise());
 
         let config = PreflopChartConfig {
-            charts: vec![chart],
+            positions: vec![charts],
             raise_size_bb: 3.0,
             three_bet_multiplier: 3.5,
+            four_bet_plus_multiplier: 2.2,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -962,6 +863,36 @@ mod tests {
 
         assert_eq!(parsed.raise_size_bb, 3.0);
         assert_eq!(parsed.three_bet_multiplier, 3.5);
-        assert_eq!(parsed.charts.len(), 1);
+        assert_eq!(parsed.four_bet_plus_multiplier, 2.2);
+        assert_eq!(parsed.positions.len(), 1);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_minimal_config() {
+        // Only positions required; multipliers all default.
+        let json = r#"{"positions": [{}]}"#;
+        let cfg: PreflopChartConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.raise_size_bb, 2.5);
+        assert_eq!(cfg.three_bet_multiplier, 3.0);
+        assert_eq!(cfg.four_bet_plus_multiplier, 2.5);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_strategy_minimal_in_chart() {
+        // Per-hand strategy with only "raise" set; call defaults to 0.
+        let json = r#"{
+            "positions": [
+                {
+                    "rfi": {"AA": {"raise": 1.0}}
+                }
+            ]
+        }"#;
+        let cfg: PreflopChartConfig = serde_json::from_str(json).unwrap();
+        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
+        let strategy = cfg.chart_for(0, PreflopScenario::Rfi).get(&aa).unwrap();
+        assert_eq!(strategy.raise(), 1.0);
+        assert_eq!(strategy.call(), 0.0);
     }
 }

--- a/src/arena/cfr/mod.rs
+++ b/src/arena/cfr/mod.rs
@@ -91,9 +91,9 @@ mod traversal_state;
 
 pub use action_generator::{
     ActionGenerator, BasicCFRActionGenerator, ConfigurableActionConfig,
-    ConfigurableActionConfigError, ConfigurableActionGenerator, PreflopChartActionConfig,
-    PreflopChartActionGenerator, PreflopChartConfig, PreflopChartConfigError, RoundActionConfig,
-    SimpleActionGenerator,
+    ConfigurableActionConfigError, ConfigurableActionGenerator, PositionCharts,
+    PreflopChartActionConfig, PreflopChartActionGenerator, PreflopChartConfig,
+    PreflopChartConfigError, RoundActionConfig, SimpleActionGenerator,
 };
 pub use action_index_mapper::{
     ACTION_IDX_ALL_IN, ACTION_IDX_CALL, ACTION_IDX_FOLD, ACTION_IDX_RAISE_MAX,

--- a/src/bin/rsp/arena/charts.rs
+++ b/src/bin/rsp/arena/charts.rs
@@ -1,0 +1,276 @@
+//! `rsp arena charts` — view preflop charts from agent configs.
+//!
+//! Loads an agent config file, extracts or synthesizes a
+//! [`PreflopChartConfig`], and launches an interactive TUI that shows the
+//! 13×13 hand grid for each seat along with range-weighted action
+//! breakdowns.
+
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use clap::Args;
+
+use rs_poker::arena::agent::{AgentConfig, ConfigAgentBuilder};
+use rs_poker::arena::cfr::{PositionCharts, PreflopChartConfig};
+use rs_poker::holdem::{PreflopChart, PreflopHand, PreflopStrategy};
+
+#[cfg(test)]
+use rs_poker::holdem::PreflopScenario;
+
+use crate::tui::chart_app::{ChartApp, run_chart_app};
+use crate::tui::screens::chart_viewer::ChartViewerState;
+
+/// Arguments for `rsp arena charts`.
+#[derive(Args, Debug, Clone)]
+pub struct ChartsArgs {
+    /// Path to an agent config file.
+    path: PathBuf,
+    /// Seat to start on (0 = BB, 1 = SB, 2 = BTN, ...).
+    #[arg(long, default_value_t = 2)]
+    seat: usize,
+    /// Override the number of seat tabs (default: 6).
+    #[arg(long)]
+    num_seats: Option<usize>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChartsError {
+    #[error("failed to load agent config: {0}")]
+    LoadConfig(#[from] rs_poker::arena::agent::AgentConfigError),
+    #[error("chart viewer requires a TTY; run in a terminal (or unset RSP_NO_TUI)")]
+    NotATty,
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub fn run(args: ChartsArgs) -> Result<(), ChartsError> {
+    if !std::io::stdout().is_terminal() {
+        return Err(ChartsError::NotATty);
+    }
+
+    let builder = ConfigAgentBuilder::from_file(&args.path)?;
+    let config = builder.config();
+    let config_name = config_label(config, &args.path);
+    let num_seats = args.num_seats.unwrap_or(6).max(1);
+
+    let (preflop_config, synthesized, banner) = resolve_preflop_config(config);
+    let mut state = ChartViewerState::new(preflop_config, config_name, num_seats, synthesized);
+    if let Some(msg) = banner {
+        state = state.with_banner(msg);
+    }
+    state.set_seat(args.seat);
+
+    let mut app = ChartApp::new(state);
+    run_chart_app(&mut app)?;
+    Ok(())
+}
+
+/// Best-effort human-readable label for the config: use the agent's `name`
+/// field if present, else the file stem.
+fn config_label(config: &AgentConfig, path: &std::path::Path) -> String {
+    let name = match config {
+        AgentConfig::AllIn { name, .. }
+        | AgentConfig::Calling { name, .. }
+        | AgentConfig::Folding { name, .. }
+        | AgentConfig::Random { name, .. }
+        | AgentConfig::RandomPotControl { name, .. }
+        | AgentConfig::CfrBasic { name, .. }
+        | AgentConfig::CfrSimple { name, .. }
+        | AgentConfig::CfrConfigurable { name, .. }
+        | AgentConfig::CfrPreflopChart { name, .. } => name.clone(),
+    };
+    name.unwrap_or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("config")
+            .to_string()
+    })
+}
+
+/// Extract or synthesize a `PreflopChartConfig` for any agent config.
+///
+/// Returns `(config, synthesized, optional banner)`. `synthesized=true`
+/// means the chart is a reasonable approximation of the agent's behavior
+/// rather than an authoritative preflop range.
+fn resolve_preflop_config(config: &AgentConfig) -> (PreflopChartConfig, bool, Option<String>) {
+    match config {
+        AgentConfig::CfrPreflopChart { preflop_config, .. } => match preflop_config.resolve() {
+            Ok(cfg) => (cfg, false, None),
+            Err(e) => (
+                PreflopChartConfig::with_single_position(PositionCharts::default()),
+                true,
+                Some(format!("failed to resolve preflop config: {}", e)),
+            ),
+        },
+        AgentConfig::AllIn { .. } => (
+            PreflopChartConfig::with_single_position(uniform_position_charts(
+                PreflopStrategy::pure_raise(),
+            )),
+            true,
+            None,
+        ),
+        AgentConfig::Calling { .. } => (
+            PreflopChartConfig::with_single_position(uniform_position_charts(
+                PreflopStrategy::pure_call(),
+            )),
+            true,
+            None,
+        ),
+        AgentConfig::Folding { .. } => (
+            PreflopChartConfig::with_single_position(PositionCharts::default()),
+            true,
+            None,
+        ),
+        AgentConfig::Random {
+            percent_fold,
+            percent_call,
+            ..
+        } => (
+            PreflopChartConfig::with_single_position(random_position_charts(
+                percent_fold,
+                percent_call,
+            )),
+            true,
+            Some(
+                "Synthesized from first element of percent_fold/percent_call \
+                 (preflop, no raises yet)"
+                    .to_string(),
+            ),
+        ),
+        AgentConfig::RandomPotControl { percent_call, .. } => (
+            PreflopChartConfig::with_single_position(random_position_charts(&[], percent_call)),
+            true,
+            Some(
+                "Synthesized from first element of percent_call \
+                 (RandomPotControl only defines call frequency)"
+                    .to_string(),
+            ),
+        ),
+        AgentConfig::CfrBasic { .. }
+        | AgentConfig::CfrSimple { .. }
+        | AgentConfig::CfrConfigurable { .. } => (
+            PreflopChartConfig::with_single_position(PositionCharts::default()),
+            true,
+            Some(
+                "CFR agent without preflop chart — preflop action is learned \
+                 at runtime via CFR exploration. Use cfr_preflop_chart to \
+                 constrain preflop."
+                    .to_string(),
+            ),
+        ),
+    }
+}
+
+/// Build a chart containing `strategy` for every hand.
+fn uniform_chart(strategy: PreflopStrategy) -> PreflopChart {
+    let mut chart = PreflopChart::new();
+    for hand in PreflopHand::all() {
+        chart.set(hand, strategy);
+    }
+    chart
+}
+
+/// Build position charts with `strategy` applied across every scenario.
+///
+/// Note: `rfi` does not populate `call` even if the input strategy has it —
+/// call is invalid in RFI (no limping). Similarly `vs_4bet` drops raise.
+fn uniform_position_charts(strategy: PreflopStrategy) -> PositionCharts {
+    // Strip disallowed components per scenario.
+    let rfi_strategy = PreflopStrategy::new(strategy.raise(), 0.0).unwrap_or_default();
+    let vs_4bet_strategy = PreflopStrategy::new(0.0, strategy.call()).unwrap_or_default();
+    PositionCharts {
+        rfi: uniform_chart(rfi_strategy),
+        vs_open: uniform_chart(strategy),
+        vs_3bet: uniform_chart(strategy),
+        vs_4bet: uniform_chart(vs_4bet_strategy),
+    }
+}
+
+/// Build `PositionCharts` from a random agent's fold/call probability
+/// vectors. The preflop (no raises yet) entry is index 0.
+fn random_position_charts(percent_fold: &[f64], percent_call: &[f64]) -> PositionCharts {
+    let fold = percent_fold.first().copied().unwrap_or(0.0).clamp(0.0, 1.0);
+    let call = percent_call.first().copied().unwrap_or(0.0).clamp(0.0, 1.0);
+    let call = call.min(1.0 - fold);
+    let raise = (1.0 - fold - call).max(0.0);
+    let strategy =
+        PreflopStrategy::new(raise as f32, call as f32).unwrap_or_else(|_| PreflopStrategy::fold());
+    uniform_position_charts(strategy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn config_from_json(json: &str) -> AgentConfig {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn label_falls_back_to_file_stem() {
+        let cfg = config_from_json(r#"{"type":"all_in"}"#);
+        let label = config_label(&cfg, Path::new("/foo/my_agent.json"));
+        assert_eq!(label, "my_agent");
+    }
+
+    #[test]
+    fn label_uses_name_field_when_present() {
+        let cfg = config_from_json(r#"{"type":"all_in","name":"YOLO"}"#);
+        let label = config_label(&cfg, Path::new("/foo/other.json"));
+        assert_eq!(label, "YOLO");
+    }
+
+    #[test]
+    fn all_in_synthesizes_pure_raise() {
+        let cfg = config_from_json(r#"{"type":"all_in"}"#);
+        let (chart_cfg, synth, _) = resolve_preflop_config(&cfg);
+        assert!(synth);
+        let aa = PreflopHand::from_notation("AA").unwrap();
+        let strategy = chart_cfg
+            .chart_for(0, PreflopScenario::Rfi)
+            .get(&aa)
+            .unwrap();
+        assert!((strategy.raise() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn folding_synthesizes_empty_chart() {
+        let cfg = config_from_json(r#"{"type":"folding"}"#);
+        let (chart_cfg, synth, _) = resolve_preflop_config(&cfg);
+        assert!(synth);
+        assert!(chart_cfg.chart_for(0, PreflopScenario::Rfi).is_empty());
+    }
+
+    #[test]
+    fn random_synthesizes_mixed_strategy() {
+        let cfg =
+            config_from_json(r#"{"type":"random","percent_fold":[0.2],"percent_call":[0.5]}"#);
+        let (chart_cfg, synth, _) = resolve_preflop_config(&cfg);
+        assert!(synth);
+        let aa = PreflopHand::from_notation("AA").unwrap();
+        // fold=0.2, call=0.5, raise=0.3 — but RFI strips call.
+        let rfi = chart_cfg
+            .chart_for(0, PreflopScenario::Rfi)
+            .get(&aa)
+            .unwrap();
+        assert!((rfi.raise() - 0.3).abs() < 1e-5);
+        assert_eq!(rfi.call(), 0.0);
+        // VsOpen keeps both raise and call.
+        let vso = chart_cfg
+            .chart_for(0, PreflopScenario::VsOpen)
+            .get(&aa)
+            .unwrap();
+        assert!((vso.raise() - 0.3).abs() < 1e-5);
+        assert!((vso.call() - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn cfr_basic_has_banner_but_empty_chart() {
+        let cfg = config_from_json(r#"{"type":"cfr_basic"}"#);
+        let (chart_cfg, synth, banner) = resolve_preflop_config(&cfg);
+        assert!(synth);
+        assert!(banner.is_some());
+        assert!(chart_cfg.chart_for(0, PreflopScenario::Rfi).is_empty());
+    }
+}

--- a/src/bin/rsp/arena/mod.rs
+++ b/src/bin/rsp/arena/mod.rs
@@ -2,8 +2,10 @@ use clap::{Args, Subcommand};
 
 use crate::tui::TuiFlags;
 
+pub mod charts;
 pub mod compare;
 pub mod generate;
+pub mod verify;
 
 #[derive(Args)]
 pub struct ArenaArgs {
@@ -13,24 +15,34 @@ pub struct ArenaArgs {
 
 #[derive(Subcommand)]
 enum ArenaCommand {
+    /// View preflop charts for an agent config in an interactive TUI
+    Charts(charts::ChartsArgs),
     /// Compare poker agents across all possible matchups
     Compare(compare::CompareArgs),
     /// Generate Open Hand History files from poker simulations
     Generate(generate::GenerateArgs),
+    /// Verify agent config files load correctly
+    Verify(verify::VerifyArgs),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum ArenaError {
     #[error(transparent)]
+    Charts(#[from] charts::ChartsError),
+    #[error(transparent)]
     Compare(#[from] compare::CompareError),
     #[error(transparent)]
     Generate(#[from] generate::GenerateError),
+    #[error(transparent)]
+    Verify(#[from] verify::VerifyError),
 }
 
 pub fn run(args: ArenaArgs, tui_flags: &TuiFlags) -> Result<(), ArenaError> {
     match args.command {
+        ArenaCommand::Charts(a) => charts::run(a)?,
         ArenaCommand::Compare(a) => compare::run(a, tui_flags)?,
         ArenaCommand::Generate(a) => generate::run(a, tui_flags)?,
+        ArenaCommand::Verify(a) => verify::run(a)?,
     }
     Ok(())
 }

--- a/src/bin/rsp/arena/verify.rs
+++ b/src/bin/rsp/arena/verify.rs
@@ -1,0 +1,366 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::Args;
+use tracing::{info, warn};
+
+use rs_poker::arena::agent::{AgentConfig, ConfigAgentBuilder};
+use rs_poker::arena::cfr::{PositionCharts, PreflopChartConfig};
+use rs_poker::holdem::{PreflopChart, PreflopHand, PreflopScenario};
+
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError {
+    #[error("failed to read path '{path}': {source}")]
+    ReadPath {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("{failed} of {total} config(s) failed verification")]
+    VerificationFailed { failed: usize, total: usize },
+}
+
+/// Verify agent config files load correctly and, when they carry preflop
+/// charts, that the charts are well-formed with reasonable range coverage.
+///
+/// Accepts either a single config file or a directory of `.json` configs.
+/// Matches `arena generate`'s loading behavior: non-recursive, top-level
+/// `.json` files only. Exits non-zero if any configs fail to load.
+#[derive(Args, Debug, Clone)]
+pub struct VerifyArgs {
+    /// Path to an agent config file or a directory of config files.
+    path: PathBuf,
+    /// Print combo-weighted range summaries for each (position, scenario).
+    #[arg(long, default_value_t = false)]
+    summary: bool,
+}
+
+pub fn run(args: VerifyArgs) -> Result<(), VerifyError> {
+    let paths = collect_config_paths(&args.path)?;
+    if paths.is_empty() {
+        info!("No .json files found at '{}'", args.path.display());
+        return Ok(());
+    }
+
+    let mut ok = 0usize;
+    let mut failed = 0usize;
+    for path in &paths {
+        match ConfigAgentBuilder::from_file(path) {
+            Ok(builder) => {
+                info!("OK   {}", path.display());
+                ok += 1;
+                if args.summary
+                    && let AgentConfig::CfrPreflopChart { preflop_config, .. } = builder.config()
+                {
+                    match preflop_config.resolve() {
+                        Ok(cfg) => print_chart_summary(&cfg),
+                        Err(e) => warn!("  could not resolve preflop config: {}", e),
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("FAIL {}: {}", path.display(), e);
+                failed += 1;
+            }
+        }
+    }
+
+    let total = paths.len();
+    info!("{} OK, {} failed ({} total)", ok, failed, total);
+
+    if failed > 0 {
+        return Err(VerifyError::VerificationFailed { failed, total });
+    }
+    Ok(())
+}
+
+fn collect_config_paths(path: &Path) -> Result<Vec<PathBuf>, VerifyError> {
+    let meta = fs::metadata(path).map_err(|e| VerifyError::ReadPath {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+
+    if meta.is_file() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+
+    let entries = fs::read_dir(path).map_err(|e| VerifyError::ReadPath {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    Ok(paths)
+}
+
+fn print_chart_summary(cfg: &PreflopChartConfig) {
+    info!(
+        "  raise {:.2}bb · 3bet×{:.1} · 4bet+×{:.1} · positions {}",
+        cfg.raise_size_bb,
+        cfg.three_bet_multiplier,
+        cfg.four_bet_plus_multiplier,
+        cfg.positions.len()
+    );
+    for (idx, position) in cfg.positions.iter().enumerate() {
+        let label = position_label(idx, cfg.positions.len());
+        info!("  position {} ({}):", idx, label);
+        for scenario in PreflopScenario::all() {
+            print_scenario_summary(position, scenario);
+        }
+        if let Some(warning) = sanity_warning(idx, position) {
+            warn!("    ⚠ {}", warning);
+        }
+    }
+}
+
+fn print_scenario_summary(position: &PositionCharts, scenario: PreflopScenario) {
+    let chart = position.chart_for(scenario);
+    let stats = range_stats(chart);
+    info!(
+        "    {:<8}  raise {:>5.1}%  call {:>5.1}%  fold {:>5.1}%  ({} hands)",
+        scenario.label(),
+        stats.raise_pct * 100.0,
+        stats.call_pct * 100.0,
+        stats.fold_pct * 100.0,
+        chart.len()
+    );
+}
+
+struct RangeStats {
+    raise_pct: f32,
+    call_pct: f32,
+    fold_pct: f32,
+}
+
+/// Combo-weighted summary of a single chart. Pairs count as 6, suited as 4,
+/// offsuit as 12.
+fn range_stats(chart: &PreflopChart) -> RangeStats {
+    let mut raise = 0.0f32;
+    let mut call = 0.0f32;
+    let mut fold = 0.0f32;
+    let mut total = 0.0f32;
+
+    for hand in PreflopHand::all() {
+        let weight = combo_weight(&hand);
+        total += weight;
+        match chart.get(&hand) {
+            Some(strategy) => {
+                raise += strategy.raise() * weight;
+                call += strategy.call() * weight;
+                fold += strategy.fold_freq() * weight;
+            }
+            None => fold += weight,
+        }
+    }
+
+    if total <= 0.0 {
+        return RangeStats {
+            raise_pct: 0.0,
+            call_pct: 0.0,
+            fold_pct: 0.0,
+        };
+    }
+    RangeStats {
+        raise_pct: raise / total,
+        call_pct: call / total,
+        fold_pct: fold / total,
+    }
+}
+
+fn combo_weight(hand: &PreflopHand) -> f32 {
+    if hand.is_pair() {
+        6.0
+    } else if hand.suited() {
+        4.0
+    } else {
+        12.0
+    }
+}
+
+fn position_label(idx: usize, num_positions: usize) -> String {
+    match (idx, num_positions) {
+        (0, _) => "BB".to_string(),
+        (1, 2) => "BTN".to_string(),
+        (1, _) => "SB".to_string(),
+        (2, _) => "BTN".to_string(),
+        (3, _) => "CO".to_string(),
+        (4, _) => "HJ".to_string(),
+        (5, _) => "UTG".to_string(),
+        (n, _) => format!("UTG+{}", n - 5),
+    }
+}
+
+/// Flag structurally odd charts. These aren't errors — just hints that the
+/// config may be incomplete.
+///
+/// BB having RFI entries is legitimate: when the SB completes the blind, BB
+/// faces a 0-raise decision (check or raise the option), so the RFI chart
+/// applies.
+fn sanity_warning(position: usize, charts: &PositionCharts) -> Option<String> {
+    // BTN (idx 2) and CO (idx 3) should have open ranges. Empty RFI there
+    // almost always indicates an incomplete chart rather than a strategic
+    // choice.
+    if (position == 2 || position == 3) && charts.rfi.is_empty() {
+        return Some(format!(
+            "position {} has no RFI chart — likely incomplete",
+            position
+        ));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_json(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn valid_config_dir_passes() {
+        let tmp = TempDir::new().unwrap();
+        write_json(tmp.path(), "a.json", r#"{"type":"all_in"}"#);
+        write_json(tmp.path(), "b.json", r#"{"type":"calling"}"#);
+        run(VerifyArgs {
+            path: tmp.path().to_path_buf(),
+            summary: false,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn invalid_config_dir_fails() {
+        let tmp = TempDir::new().unwrap();
+        write_json(tmp.path(), "ok.json", r#"{"type":"all_in"}"#);
+        write_json(tmp.path(), "bad.json", r#"{"name":"nope"}"#);
+        let err = run(VerifyArgs {
+            path: tmp.path().to_path_buf(),
+            summary: false,
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            VerifyError::VerificationFailed {
+                failed: 1,
+                total: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn single_file_verifies() {
+        let tmp = TempDir::new().unwrap();
+        let file = write_json(tmp.path(), "single.json", r#"{"type":"folding"}"#);
+        run(VerifyArgs {
+            path: file,
+            summary: false,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn missing_path_errors() {
+        let err = run(VerifyArgs {
+            path: PathBuf::from("/does/not/exist/configs"),
+            summary: false,
+        })
+        .unwrap_err();
+        assert!(matches!(err, VerifyError::ReadPath { .. }));
+    }
+
+    #[test]
+    fn non_json_files_ignored() {
+        let tmp = TempDir::new().unwrap();
+        write_json(tmp.path(), "a.json", r#"{"type":"all_in"}"#);
+        write_json(tmp.path(), "notes.txt", "not json at all");
+        run(VerifyArgs {
+            path: tmp.path().to_path_buf(),
+            summary: false,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn empty_dir_passes() {
+        let tmp = TempDir::new().unwrap();
+        run(VerifyArgs {
+            path: tmp.path().to_path_buf(),
+            summary: false,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn subdirectory_not_recursed() {
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        write_json(&sub, "bad.json", r#"{"name":"no type field"}"#);
+        run(VerifyArgs {
+            path: tmp.path().to_path_buf(),
+            summary: false,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn range_stats_empty_chart_is_all_fold() {
+        let chart = PreflopChart::new();
+        let stats = range_stats(&chart);
+        assert!((stats.fold_pct - 1.0).abs() < 1e-5);
+        assert!(stats.raise_pct.abs() < 1e-5);
+        assert!(stats.call_pct.abs() < 1e-5);
+    }
+
+    #[test]
+    fn range_stats_pure_raise_hand_contributes_combo_weight() {
+        use rs_poker::core::Value;
+        use rs_poker::holdem::PreflopStrategy;
+
+        let mut chart = PreflopChart::new();
+        // AA pure raise → 6 combos out of 1326 = ~0.452%.
+        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
+        chart.set(aa, PreflopStrategy::pure_raise());
+
+        let stats = range_stats(&chart);
+        let expected = 6.0 / 1326.0;
+        assert!((stats.raise_pct - expected).abs() < 1e-5);
+    }
+
+    #[test]
+    fn sanity_warning_silent_for_bb_rfi() {
+        // BB can legitimately have RFI entries (SB-completes scenario).
+        use rs_poker::core::Value;
+        use rs_poker::holdem::PreflopStrategy;
+
+        let mut charts = PositionCharts::default();
+        charts.rfi.set(
+            PreflopHand::new(Value::Ace, Value::Ace, false),
+            PreflopStrategy::pure_raise(),
+        );
+        assert!(sanity_warning(0, &charts).is_none());
+    }
+
+    #[test]
+    fn sanity_warning_flags_btn_missing_rfi() {
+        let charts = PositionCharts::default();
+        assert!(sanity_warning(2, &charts).is_some());
+    }
+
+    #[test]
+    fn sanity_warning_silent_for_utg_empty_rfi() {
+        // UTG may legitimately have a tight/empty chart in some studies.
+        let charts = PositionCharts::default();
+        assert!(sanity_warning(5, &charts).is_none());
+    }
+}

--- a/src/bin/rsp/tui/chart_app.rs
+++ b/src/bin/rsp/tui/chart_app.rs
@@ -1,0 +1,268 @@
+//! Standalone TUI app for viewing preflop charts.
+//!
+//! Unlike [`crate::tui::app::App`], which drives a live simulation and merges
+//! a bounded sync_channel of `SimMessage`s with crossterm events, this app
+//! only reacts to keyboard/mouse input. There is no background thread and
+//! no tick-based refresh beyond a short polling interval.
+
+use std::time::Duration;
+
+use crossterm::event::{
+    self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
+
+use rs_poker::holdem::PreflopScenario;
+
+use crate::tui::{
+    screens::chart_viewer::{ChartViewerRects, ChartViewerState, render_chart_viewer},
+    terminal::{self, Tui},
+    widgets::hand_grid::cell_size,
+};
+
+/// App owning a `ChartViewerState` plus input-handling flags.
+pub struct ChartApp {
+    pub state: ChartViewerState,
+    pub should_quit: bool,
+    rects: Option<ChartViewerRects>,
+}
+
+impl ChartApp {
+    pub fn new(state: ChartViewerState) -> Self {
+        Self {
+            state,
+            should_quit: false,
+            rects: None,
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) {
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.should_quit = true;
+            return;
+        }
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
+            KeyCode::Char('j') | KeyCode::Down => self.state.move_hover(1, 0),
+            KeyCode::Char('k') | KeyCode::Up => self.state.move_hover(-1, 0),
+            KeyCode::Char('h') | KeyCode::Left => self.state.move_hover(0, -1),
+            KeyCode::Char('l') | KeyCode::Right => self.state.move_hover(0, 1),
+            KeyCode::Tab => self.state.next_seat(),
+            KeyCode::BackTab => self.state.prev_seat(),
+            KeyCode::Char(']') => self.state.next_seat(),
+            KeyCode::Char('[') => self.state.prev_seat(),
+            // Scenario jumps. Digit keys conflict with seat jumps, so we use
+            // letters: `r`=RFI, `o`=vs Open, `t`=vs 3-Bet, `f`=vs 4-Bet.
+            // `s`/`S` also cycle scenarios forward/backward.
+            KeyCode::Char('r') => self.state.set_scenario(PreflopScenario::Rfi),
+            KeyCode::Char('o') => self.state.set_scenario(PreflopScenario::VsOpen),
+            KeyCode::Char('t') => self.state.set_scenario(PreflopScenario::Vs3Bet),
+            KeyCode::Char('f') => self.state.set_scenario(PreflopScenario::Vs4Bet),
+            KeyCode::Char('s') => self.state.next_scenario(),
+            KeyCode::Char('S') => self.state.prev_scenario(),
+            KeyCode::Char(c) if c.is_ascii_digit() && c != '0' => {
+                let seat = (c as u8 - b'1') as usize;
+                if seat < self.state.num_seats {
+                    self.state.set_seat(seat);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_mouse(&mut self, mouse: MouseEvent) {
+        let Some(rects) = &self.rects else {
+            return;
+        };
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                for (seat, rect) in rects.seat_tabs.iter().enumerate() {
+                    if rect.contains((mouse.column, mouse.row).into()) {
+                        self.state.set_seat(seat);
+                        return;
+                    }
+                }
+                for (scenario, rect) in &rects.scenario_tabs {
+                    if rect.contains((mouse.column, mouse.row).into()) {
+                        self.state.set_scenario(*scenario);
+                        return;
+                    }
+                }
+                if let Some((row, col)) = grid_hit(&rects.grid, mouse.column, mouse.row) {
+                    self.state.hover = (row, col);
+                }
+            }
+            // Drag: keep moving the hover as the user drags across the grid.
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if let Some((row, col)) = grid_hit(&rects.grid, mouse.column, mouse.row) {
+                    self.state.hover = (row, col);
+                }
+            }
+            // Scroll wheel over the seat tab row cycles seats — a fast way to
+            // compare positions without reaching for the keyboard.
+            MouseEventKind::ScrollUp
+                if rects
+                    .seat_tabs
+                    .iter()
+                    .any(|r| r.contains((mouse.column, mouse.row).into())) =>
+            {
+                self.state.prev_seat();
+            }
+            MouseEventKind::ScrollDown
+                if rects
+                    .seat_tabs
+                    .iter()
+                    .any(|r| r.contains((mouse.column, mouse.row).into())) =>
+            {
+                self.state.next_seat();
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Convert a mouse (column, row) position inside the grid area to a
+/// `(row, col)` cell index. Returns `None` if the position landed outside
+/// the 13x13 cell region (axis labels, gutters, or padding beyond the grid).
+///
+/// Uses [`cell_size`] so responsive cell dimensions stay consistent with
+/// what [`render_hand_grid`](super::widgets::hand_grid::render_hand_grid)
+/// drew.
+fn grid_hit(grid: &ratatui::layout::Rect, col: u16, row: u16) -> Option<(usize, usize)> {
+    let (cell_w, cell_h) = cell_size(*grid);
+    if col < grid.x + 2 || row < grid.y + 1 {
+        return None;
+    }
+    let c = ((col - grid.x - 2) / cell_w) as usize;
+    let r = ((row - grid.y - 1) / cell_h) as usize;
+    if r < 13 && c < 13 { Some((r, c)) } else { None }
+}
+
+/// Drive the chart viewer event loop until the user quits.
+pub fn run_chart_app(app: &mut ChartApp) -> std::io::Result<()> {
+    let mut terminal = terminal::setup_terminal()?;
+    let result = event_loop(&mut terminal, app);
+    terminal::restore_terminal(&mut terminal)?;
+    result
+}
+
+fn event_loop(terminal: &mut Tui, app: &mut ChartApp) -> std::io::Result<()> {
+    loop {
+        let mut new_rects = None;
+        terminal.draw(|frame| {
+            new_rects = Some(render_chart_viewer(frame, &app.state));
+        })?;
+        app.rects = new_rects;
+
+        if app.should_quit {
+            break;
+        }
+
+        if event::poll(Duration::from_millis(100))? {
+            match event::read()? {
+                CrosstermEvent::Key(key) => app.handle_key(key),
+                CrosstermEvent::Mouse(mouse) => app.handle_mouse(mouse),
+                CrosstermEvent::Resize(_, _) => {}
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+    use rs_poker::arena::cfr::{PositionCharts, PreflopChartConfig};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn app() -> ChartApp {
+        let config = PreflopChartConfig::with_single_position(PositionCharts::default());
+        ChartApp::new(ChartViewerState::new(config, "test".into(), 6, false))
+    }
+
+    #[test]
+    fn q_quits() {
+        let mut a = app();
+        a.handle_key(key(KeyCode::Char('q')));
+        assert!(a.should_quit);
+    }
+
+    #[test]
+    fn ctrl_c_quits() {
+        let mut a = app();
+        a.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(a.should_quit);
+    }
+
+    #[test]
+    fn hjkl_moves_hover() {
+        let mut a = app();
+        a.state.hover = (5, 5);
+        a.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(a.state.hover, (6, 5));
+        a.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(a.state.hover, (5, 5));
+        a.handle_key(key(KeyCode::Char('l')));
+        assert_eq!(a.state.hover, (5, 6));
+        a.handle_key(key(KeyCode::Char('h')));
+        assert_eq!(a.state.hover, (5, 5));
+    }
+
+    #[test]
+    fn digit_keys_jump_to_seat() {
+        let mut a = app();
+        a.handle_key(key(KeyCode::Char('3')));
+        assert_eq!(a.state.current_seat, 2);
+        a.handle_key(key(KeyCode::Char('1')));
+        assert_eq!(a.state.current_seat, 0);
+    }
+
+    #[test]
+    fn tab_cycles_seats() {
+        let mut a = app();
+        a.state.set_seat(5);
+        a.handle_key(key(KeyCode::Tab));
+        assert_eq!(a.state.current_seat, 0);
+    }
+
+    #[test]
+    fn digit_outside_range_is_ignored() {
+        let mut a = app();
+        a.state.set_seat(2);
+        // num_seats = 6, so '9' (seat 8) must not change anything.
+        a.handle_key(key(KeyCode::Char('9')));
+        assert_eq!(a.state.current_seat, 2);
+    }
+
+    #[test]
+    fn grid_hit_inside_cell() {
+        // 50 wide, 16 tall → cell_size returns (3, 1).
+        let grid = ratatui::layout::Rect::new(0, 0, 50, 16);
+        // Cell (0, 0) starts at col=2, row=1
+        assert_eq!(grid_hit(&grid, 2, 1), Some((0, 0)));
+        // Cell (0, 1) starts at col=5, row=1
+        assert_eq!(grid_hit(&grid, 6, 1), Some((0, 1)));
+        // Axis-label area returns None.
+        assert_eq!(grid_hit(&grid, 0, 0), None);
+        assert_eq!(grid_hit(&grid, 1, 1), None);
+    }
+
+    #[test]
+    fn grid_hit_scales_with_responsive_cells() {
+        // 130 wide, 40 tall → cells are wider and taller.
+        // avail_w=128, cell_w=128/13=9 (capped); avail_h=39, cell_h=min(3, 9/2=4)=3.
+        let grid = ratatui::layout::Rect::new(0, 0, 130, 40);
+        let (cw, ch) = super::cell_size(grid);
+        // Click in the middle of cell (2, 5) should resolve to (2, 5).
+        let x = 2 + 5 * cw + cw / 2;
+        let y = 1 + 2 * ch + ch / 2;
+        assert_eq!(grid_hit(&grid, x, y), Some((2, 5)));
+        // Click at the very start of the cells row/col.
+        assert_eq!(grid_hit(&grid, 2, 1), Some((0, 0)));
+    }
+}

--- a/src/bin/rsp/tui/mod.rs
+++ b/src/bin/rsp/tui/mod.rs
@@ -28,6 +28,7 @@
 //!   per agent, agent stats keyed by unique agent name.
 
 pub mod app;
+pub mod chart_app;
 pub mod effects;
 pub mod event;
 pub mod filtered_log;

--- a/src/bin/rsp/tui/screens/chart_viewer.rs
+++ b/src/bin/rsp/tui/screens/chart_viewer.rs
@@ -1,0 +1,642 @@
+//! Preflop chart viewer screen.
+//!
+//! Renders a header of seat tabs, a 13x13 color-only hand grid, range-weighted
+//! action totals for the selected seat/scenario, and hover detail for the cell
+//! under the cursor.
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Gauge, Paragraph},
+};
+
+use rs_poker::arena::cfr::PreflopChartConfig;
+use rs_poker::holdem::{PreflopActionType, PreflopScenario, PreflopStrategy};
+
+use crate::tui::{
+    theme,
+    widgets::hand_grid::{
+        action_color, action_label, blended_color, hand_at, render_hand_grid, seat_totals,
+    },
+};
+
+/// State for the preflop chart viewer.
+pub struct ChartViewerState {
+    pub config: PreflopChartConfig,
+    pub config_name: String,
+    /// Number of seats to display tabs for. Usually 6 for a 6-max config.
+    pub num_seats: usize,
+    /// Currently selected seat index (BB-relative: 0=BB, 1=SB, 2=BTN, ...).
+    pub current_seat: usize,
+    /// Currently selected decision scenario.
+    pub current_scenario: PreflopScenario,
+    /// Grid hover cursor: `(row, col)` where 0 ≤ row,col < 13.
+    pub hover: (usize, usize),
+    /// When true, the config did not ship a preflop chart and the grid is
+    /// synthesized. The header shows a warning.
+    pub synthesized: bool,
+    /// Banner shown in place of the grid (for configs with no preflop info).
+    pub banner: Option<String>,
+}
+
+impl ChartViewerState {
+    pub fn new(
+        config: PreflopChartConfig,
+        config_name: String,
+        num_seats: usize,
+        synthesized: bool,
+    ) -> Self {
+        let mut state = Self {
+            config,
+            config_name,
+            num_seats: num_seats.max(1),
+            current_seat: 0,
+            current_scenario: PreflopScenario::Rfi,
+            hover: (0, 0),
+            synthesized,
+            banner: None,
+        };
+        state.ensure_non_empty_scenario();
+        state
+    }
+
+    pub fn set_scenario(&mut self, scenario: PreflopScenario) {
+        self.current_scenario = scenario;
+    }
+
+    pub fn next_scenario(&mut self) {
+        let all = PreflopScenario::all();
+        let idx = all
+            .iter()
+            .position(|s| *s == self.current_scenario)
+            .unwrap_or(0);
+        self.current_scenario = all[(idx + 1) % all.len()];
+    }
+
+    pub fn prev_scenario(&mut self) {
+        let all = PreflopScenario::all();
+        let idx = all
+            .iter()
+            .position(|s| *s == self.current_scenario)
+            .unwrap_or(0);
+        self.current_scenario = all[(idx + all.len() - 1) % all.len()];
+    }
+
+    pub fn with_banner(mut self, banner: impl Into<String>) -> Self {
+        self.banner = Some(banner.into());
+        self
+    }
+
+    pub fn move_hover(&mut self, d_row: isize, d_col: isize) {
+        let (r, c) = self.hover;
+        let r = (r as isize + d_row).clamp(0, 12) as usize;
+        let c = (c as isize + d_col).clamp(0, 12) as usize;
+        self.hover = (r, c);
+    }
+
+    pub fn set_seat(&mut self, seat: usize) {
+        if self.num_seats == 0 {
+            self.current_seat = 0;
+        } else {
+            self.current_seat = seat % self.num_seats;
+        }
+        self.ensure_non_empty_scenario();
+    }
+
+    /// Returns true if the chart at the current (seat, scenario) has any
+    /// entries.
+    fn current_scenario_has_data(&self) -> bool {
+        !self
+            .config
+            .chart_for(self.current_seat, self.current_scenario)
+            .is_empty()
+    }
+
+    /// If the current scenario has no data for the current seat, advance to
+    /// the first scenario that does. No-op if every scenario is empty (truly
+    /// blank position) or if the current one already has data.
+    ///
+    /// This makes seat switching "do the sensible thing" — e.g., picking BB
+    /// lands on `vs Open` (the only scenario with data for BB) instead of
+    /// RFI (structurally empty, since BB doesn't open).
+    fn ensure_non_empty_scenario(&mut self) {
+        if self.current_scenario_has_data() {
+            return;
+        }
+        for scenario in PreflopScenario::all() {
+            if !self
+                .config
+                .chart_for(self.current_seat, scenario)
+                .is_empty()
+            {
+                self.current_scenario = scenario;
+                return;
+            }
+        }
+    }
+
+    pub fn next_seat(&mut self) {
+        self.set_seat(self.current_seat + 1);
+    }
+
+    pub fn prev_seat(&mut self) {
+        if self.current_seat == 0 {
+            self.set_seat(self.num_seats.saturating_sub(1));
+        } else {
+            self.set_seat(self.current_seat - 1);
+        }
+    }
+}
+
+/// Canonical label for a BB-relative seat index, matching
+/// `PreflopChartConfig::calculate_position` semantics.
+///
+/// 0=BB, 1=SB, 2=BTN, 3=CO, 4=HJ, 5=UTG, then UTG+1 / UTG+2 / ... for larger
+/// tables.
+pub fn seat_label(seat: usize, num_seats: usize) -> String {
+    match (seat, num_seats) {
+        (0, _) => "BB".to_string(),
+        (1, 2) => "BTN".to_string(),
+        (1, _) => "SB".to_string(),
+        (2, _) => "BTN".to_string(),
+        (3, _) => "CO".to_string(),
+        (4, _) => "HJ".to_string(),
+        (5, _) => "UTG".to_string(),
+        (n, _) => format!("UTG+{}", n - 5),
+    }
+}
+
+/// Layout rects produced by `render_chart_viewer`, exposed for mouse
+/// hit-testing by the event loop.
+pub struct ChartViewerRects {
+    pub seat_tabs: Vec<Rect>,
+    pub scenario_tabs: Vec<(PreflopScenario, Rect)>,
+    pub grid: Rect,
+}
+
+pub fn render_chart_viewer(frame: &mut Frame, state: &ChartViewerState) -> ChartViewerRects {
+    let area = frame.area();
+    let outer = theme::chart_block(&format!(
+        "Preflop Charts: {}{}",
+        state.config_name,
+        if state.synthesized {
+            " (synthesized)"
+        } else {
+            ""
+        }
+    ));
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1), // Seat tab row
+        Constraint::Length(1), // Scenario tab row
+        Constraint::Length(1), // Config params row
+        Constraint::Min(14),   // Grid + right panel
+        Constraint::Length(1), // Legend
+        Constraint::Length(1), // Keybindings
+    ])
+    .split(inner);
+
+    let seat_tabs = render_seat_tabs(frame, chunks[0], state);
+    let scenario_tabs = render_scenario_tabs(frame, chunks[1], state);
+    render_config_params(frame, chunks[2], state);
+
+    let body = Layout::horizontal([Constraint::Min(41), Constraint::Length(44)]).split(chunks[3]);
+
+    let grid_rect = body[0];
+    if let Some(msg) = &state.banner {
+        let banner = Paragraph::new(msg.as_str()).style(Style::default().fg(theme::YELLOW));
+        frame.render_widget(banner, grid_rect);
+    } else {
+        let chart = state
+            .config
+            .chart_for(state.current_seat, state.current_scenario);
+        render_hand_grid(frame, grid_rect, chart, Some(state.hover));
+    }
+
+    render_right_panel(frame, body[1], state);
+    render_legend(frame, chunks[4]);
+    render_keybindings(frame, chunks[5]);
+
+    ChartViewerRects {
+        seat_tabs,
+        scenario_tabs,
+        grid: grid_rect,
+    }
+}
+
+fn render_scenario_tabs(
+    frame: &mut Frame,
+    area: Rect,
+    state: &ChartViewerState,
+) -> Vec<(PreflopScenario, Rect)> {
+    let mut rects: Vec<(PreflopScenario, Rect)> = Vec::with_capacity(4);
+    let mut spans = vec![Span::styled(
+        "Scenario: ",
+        Style::default().fg(theme::SUBTEXT1),
+    )];
+    let mut x = area.x + "Scenario: ".len() as u16;
+    for scenario in PreflopScenario::all() {
+        let is_current = scenario == state.current_scenario;
+        let is_empty = state
+            .config
+            .chart_for(state.current_seat, scenario)
+            .is_empty();
+        let tab_text = if is_current {
+            format!("▶{}◀ ", scenario.label())
+        } else {
+            format!(" {}  ", scenario.label())
+        };
+        let style = if is_current {
+            Style::default()
+                .fg(theme::FOCUS_COLOR)
+                .add_modifier(Modifier::BOLD)
+        } else if is_empty {
+            // Empty chart for this (seat, scenario) — dim so users know there's
+            // nothing to see without having to click through.
+            Style::default().fg(theme::OVERLAY0)
+        } else {
+            Style::default().fg(theme::SUBTEXT0)
+        };
+        let width = tab_text.chars().count() as u16;
+        let rect = Rect::new(
+            x,
+            area.y,
+            width.min(area.width.saturating_sub(x - area.x)),
+            1,
+        );
+        spans.push(Span::styled(tab_text, style));
+        rects.push((scenario, rect));
+        x += width;
+        if x >= area.x + area.width {
+            break;
+        }
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    rects
+}
+
+fn render_seat_tabs(frame: &mut Frame, area: Rect, state: &ChartViewerState) -> Vec<Rect> {
+    let mut rects = Vec::with_capacity(state.num_seats);
+    let mut spans = vec![Span::styled(
+        "Seats: ",
+        Style::default().fg(theme::SUBTEXT1),
+    )];
+    let mut x = area.x + "Seats: ".len() as u16;
+    for seat in 0..state.num_seats {
+        let label = seat_label(seat, state.num_seats);
+        let is_current = seat == state.current_seat;
+        let tab_text = if is_current {
+            format!("▶{}◀ ", label)
+        } else {
+            format!(" {}  ", label)
+        };
+        let style = if is_current {
+            Style::default()
+                .fg(theme::FOCUS_COLOR)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme::SUBTEXT0)
+        };
+        let width = tab_text.chars().count() as u16;
+        let rect = Rect::new(
+            x,
+            area.y,
+            width.min(area.width.saturating_sub(x - area.x)),
+            1,
+        );
+        spans.push(Span::styled(tab_text, style));
+        rects.push(rect);
+        x += width;
+        if x >= area.x + area.width {
+            break;
+        }
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    rects
+}
+
+fn render_config_params(frame: &mut Frame, area: Rect, state: &ChartViewerState) {
+    let text = if state.synthesized {
+        format!(
+            "  (no preflop_config — synthesized from {})",
+            state.config_name
+        )
+    } else {
+        format!(
+            "  raise {:.2}bb   3bet×{:.1}   4bet+×{:.1}   positions: {}",
+            state.config.raise_size_bb,
+            state.config.three_bet_multiplier,
+            state.config.four_bet_plus_multiplier,
+            state.config.positions.len(),
+        )
+    };
+    let para = Paragraph::new(text).style(Style::default().fg(theme::SUBTEXT0));
+    frame.render_widget(para, area);
+}
+
+fn render_right_panel(frame: &mut Frame, area: Rect, state: &ChartViewerState) {
+    let sub = Layout::vertical([Constraint::Length(5), Constraint::Min(5)]).split(area);
+
+    if state.banner.is_none() {
+        let chart = state
+            .config
+            .chart_for(state.current_seat, state.current_scenario);
+        let totals = seat_totals(chart);
+        render_totals_block(
+            frame,
+            sub[0],
+            &format!(
+                "{} · {} — range totals",
+                seat_label(state.current_seat, state.num_seats),
+                state.current_scenario.label(),
+            ),
+            &totals,
+        );
+
+        let hover_hand = hand_at(state.hover.0, state.hover.1);
+        let hover_strategy = chart.get_or_fold(&hover_hand);
+        let hover_rows = strategy_rows(&hover_strategy);
+        render_totals_block(
+            frame,
+            sub[1],
+            &format!("Hover: {} · {}", hover_hand, state.current_scenario.label()),
+            &hover_rows,
+        );
+    } else {
+        let para = Paragraph::new("No seat data").style(Style::default().fg(theme::SUBTEXT0));
+        frame.render_widget(para, area);
+    }
+}
+
+fn strategy_rows(strategy: &PreflopStrategy) -> [(PreflopActionType, f32); 3] {
+    [
+        (PreflopActionType::Fold, strategy.fold_freq()),
+        (PreflopActionType::Call, strategy.call()),
+        (PreflopActionType::Raise, strategy.raise()),
+    ]
+}
+
+fn render_totals_block(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    rows: &[(PreflopActionType, f32)],
+) {
+    let block = theme::chart_block(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    render_action_bars(frame, inner, rows);
+}
+
+fn render_action_bars(frame: &mut Frame, area: Rect, rows: &[(PreflopActionType, f32)]) {
+    if area.height == 0 {
+        return;
+    }
+    // Canonical display order so the panel doesn't jitter as the hover moves.
+    let canonical = [
+        PreflopActionType::Raise,
+        PreflopActionType::Call,
+        PreflopActionType::Fold,
+    ];
+
+    let lookup = |action: PreflopActionType| {
+        rows.iter()
+            .find(|(a, _)| *a == action)
+            .map(|(_, f)| *f)
+            .unwrap_or(0.0)
+    };
+
+    let line_count = canonical.len().min(area.height as usize);
+    let constraints: Vec<Constraint> = (0..line_count).map(|_| Constraint::Length(1)).collect();
+    let chunks = Layout::vertical(constraints).split(Rect::new(
+        area.x,
+        area.y,
+        area.width,
+        line_count as u16,
+    ));
+
+    for (i, action) in canonical.iter().take(line_count).enumerate() {
+        let freq = lookup(*action);
+        let label = format!("{:<5}", action_label(*action));
+        let pct = format!("{:>4}%", (freq * 100.0).round() as i32);
+
+        let row = chunks[i];
+        if row.width < 14 {
+            let text = format!("{} {}", label, pct);
+            frame.render_widget(
+                Paragraph::new(text).style(Style::default().fg(action_color(*action))),
+                row,
+            );
+            continue;
+        }
+        let parts = Layout::horizontal([
+            Constraint::Length(6),
+            Constraint::Length(6),
+            Constraint::Min(4),
+        ])
+        .split(row);
+        frame.render_widget(
+            Paragraph::new(label).style(Style::default().fg(action_color(*action))),
+            parts[0],
+        );
+        frame.render_widget(
+            Paragraph::new(pct).style(Style::default().fg(theme::SUBTEXT1)),
+            parts[1],
+        );
+        let gauge = Gauge::default()
+            .ratio(freq.clamp(0.0, 1.0) as f64)
+            .label("")
+            .gauge_style(
+                Style::default()
+                    .fg(action_color(*action))
+                    .bg(theme::SURFACE1),
+            );
+        frame.render_widget(gauge, parts[2]);
+    }
+}
+
+fn render_legend(frame: &mut Frame, area: Rect) {
+    let swatches = [
+        PreflopActionType::Raise,
+        PreflopActionType::Call,
+        PreflopActionType::Fold,
+    ];
+    let pure = |action: PreflopActionType| -> PreflopStrategy {
+        match action {
+            PreflopActionType::Raise => PreflopStrategy::pure_raise(),
+            PreflopActionType::Call => PreflopStrategy::pure_call(),
+            PreflopActionType::Fold => PreflopStrategy::fold(),
+        }
+    };
+    let mut spans: Vec<Span> = Vec::with_capacity(swatches.len() * 2 + 1);
+    for action in swatches {
+        let strategy = pure(action);
+        let bg = blended_color(Some(&strategy));
+        spans.push(Span::styled("   ", Style::default().bg(bg).fg(theme::TEXT)));
+        spans.push(Span::styled(
+            format!(" {}  ", action_label(action)),
+            Style::default().fg(theme::SUBTEXT1),
+        ));
+    }
+    spans.push(Span::styled(
+        "(blended = mixed strategy)",
+        Style::default().fg(theme::OVERLAY0),
+    ));
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn render_keybindings(frame: &mut Frame, area: Rect) {
+    let spans = vec![
+        Span::styled("[1-9]", theme::keybinding_key_style()),
+        Span::styled(" seat  ", Style::default().fg(theme::OVERLAY0)),
+        Span::styled("[r/o/t/f]", theme::keybinding_key_style()),
+        Span::styled(" scenario  ", Style::default().fg(theme::OVERLAY0)),
+        Span::styled("[s]", theme::keybinding_key_style()),
+        Span::styled(" cycle  ", Style::default().fg(theme::OVERLAY0)),
+        Span::styled("[hjkl]", theme::keybinding_key_style()),
+        Span::styled(" move  ", Style::default().fg(theme::OVERLAY0)),
+        Span::styled("[Tab]", theme::keybinding_key_style()),
+        Span::styled(" next seat  ", Style::default().fg(theme::OVERLAY0)),
+        Span::styled("[q]", theme::keybinding_key_style()),
+        Span::styled(" quit", Style::default().fg(theme::OVERLAY0)),
+    ];
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+    use rs_poker::arena::cfr::PositionCharts;
+    use rs_poker::core::Value;
+    use rs_poker::holdem::PreflopHand;
+
+    fn simple_position_charts() -> PositionCharts {
+        let mut charts = PositionCharts::default();
+        charts.rfi.set(
+            PreflopHand::new(Value::Ace, Value::Ace, false),
+            PreflopStrategy::pure_raise(),
+        );
+        charts
+    }
+
+    fn simple_state(num_seats: usize) -> ChartViewerState {
+        let config = PreflopChartConfig::with_single_position(simple_position_charts());
+        ChartViewerState::new(config, "test".to_string(), num_seats, false)
+    }
+
+    #[test]
+    fn seat_labels_6max() {
+        assert_eq!(seat_label(0, 6), "BB");
+        assert_eq!(seat_label(1, 6), "SB");
+        assert_eq!(seat_label(2, 6), "BTN");
+        assert_eq!(seat_label(3, 6), "CO");
+        assert_eq!(seat_label(4, 6), "HJ");
+        assert_eq!(seat_label(5, 6), "UTG");
+    }
+
+    #[test]
+    fn seat_labels_heads_up_uses_btn_for_one() {
+        assert_eq!(seat_label(0, 2), "BB");
+        assert_eq!(seat_label(1, 2), "BTN");
+    }
+
+    #[test]
+    fn seat_labels_large_table_appends_plus() {
+        assert_eq!(seat_label(6, 9), "UTG+1");
+        assert_eq!(seat_label(8, 9), "UTG+3");
+    }
+
+    #[test]
+    fn move_hover_clamps() {
+        let mut state = simple_state(6);
+        state.hover = (0, 0);
+        state.move_hover(-1, -1);
+        assert_eq!(state.hover, (0, 0));
+        state.move_hover(100, 100);
+        assert_eq!(state.hover, (12, 12));
+    }
+
+    #[test]
+    fn seat_navigation_wraps() {
+        let mut state = simple_state(6);
+        state.set_seat(5);
+        state.next_seat();
+        assert_eq!(state.current_seat, 0);
+        state.prev_seat();
+        assert_eq!(state.current_seat, 5);
+    }
+
+    #[test]
+    fn render_does_not_panic() {
+        let state = simple_state(6);
+        let backend = TestBackend::new(100, 25);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let _ = render_chart_viewer(frame, &state);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn render_with_banner_does_not_panic() {
+        let state = simple_state(6).with_banner("no chart");
+        let backend = TestBackend::new(100, 25);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let _ = render_chart_viewer(frame, &state);
+            })
+            .unwrap();
+    }
+
+    /// Regression: switching to a seat whose current scenario has no data
+    /// should auto-advance to the first scenario that does. The motivating
+    /// case is BB, whose RFI chart is structurally empty in most configs —
+    /// previously the user saw an all-fold grid with no hint that vs_open
+    /// had data.
+    #[test]
+    fn set_seat_auto_switches_to_non_empty_scenario() {
+        use rs_poker::arena::cfr::PositionCharts;
+
+        // Position 0 (BB) has only vs_open data; position 1 has only rfi.
+        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
+        let mut bb = PositionCharts::default();
+        bb.vs_open.set(aa, PreflopStrategy::pure_call());
+        let mut sb = PositionCharts::default();
+        sb.rfi.set(aa, PreflopStrategy::pure_raise());
+
+        let config = PreflopChartConfig::new(vec![bb, sb]);
+        let mut state = ChartViewerState::new(config, "test".into(), 6, false);
+
+        // Start on seat 1 (SB); RFI has data, no switch.
+        state.set_seat(1);
+        assert_eq!(state.current_scenario, PreflopScenario::Rfi);
+
+        // Switch to seat 0 (BB); RFI is empty, should land on vs_open.
+        state.set_seat(0);
+        assert_eq!(state.current_scenario, PreflopScenario::VsOpen);
+    }
+
+    #[test]
+    fn set_seat_keeps_current_scenario_when_it_has_data() {
+        use rs_poker::arena::cfr::PositionCharts;
+
+        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
+        let mut position = PositionCharts::default();
+        position.vs_open.set(aa, PreflopStrategy::pure_call());
+        let config = PreflopChartConfig::with_single_position(position);
+        let mut state = ChartViewerState::new(config, "test".into(), 6, false);
+
+        // State starts on VsOpen (auto-picked since RFI is empty).
+        assert_eq!(state.current_scenario, PreflopScenario::VsOpen);
+        // Cycling seats keeps VsOpen — no reason to switch away.
+        state.set_seat(3);
+        assert_eq!(state.current_scenario, PreflopScenario::VsOpen);
+    }
+}

--- a/src/bin/rsp/tui/screens/mod.rs
+++ b/src/bin/rsp/tui/screens/mod.rs
@@ -1,2 +1,3 @@
+pub mod chart_viewer;
 pub mod game_detail;
 pub mod overview;

--- a/src/bin/rsp/tui/widgets/hand_grid.rs
+++ b/src/bin/rsp/tui/widgets/hand_grid.rs
@@ -1,0 +1,445 @@
+//! 13x13 preflop hand grid widget.
+//!
+//! Renders a colored grid where each cell's background color encodes the
+//! blended action mix for a `PreflopHand` in the chart passed in. Rows and
+//! columns are labeled by rank (A → 2). The upper-right triangle (col > row)
+//! is suited, the lower-left is offsuit, and the diagonal is pairs.
+//!
+//! A `PreflopChart` is scoped to a single (position, scenario) decision
+//! point, so rendering is scenario-free — the caller picks which chart to
+//! pass in.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::Paragraph,
+};
+
+use rs_poker::core::Value;
+use rs_poker::holdem::{PreflopActionType, PreflopChart, PreflopHand, PreflopStrategy};
+
+use crate::tui::theme;
+
+/// Number of combos for each cell type. Used when combo-weighting seat totals
+/// so the bars read "X% of your dealt hands are a raise" rather than
+/// "X% of the 169 grid cells".
+const PAIR_COMBOS: f32 = 6.0;
+const SUITED_COMBOS: f32 = 4.0;
+const OFFSUIT_COMBOS: f32 = 12.0;
+
+/// Ranks in display order, highest first (A at row 0 / col 0).
+pub fn display_ranks() -> [Value; 13] {
+    let mut ranks = Value::values();
+    ranks.reverse();
+    ranks
+}
+
+/// The `PreflopHand` shown at grid cell `(row, col)`.
+pub fn hand_at(row: usize, col: usize) -> PreflopHand {
+    let ranks = display_ranks();
+    let high;
+    let low;
+    let suited;
+    if row == col {
+        high = ranks[row];
+        low = ranks[row];
+        suited = false;
+    } else if col > row {
+        // Upper-right: suited. Row rank is higher (smaller index = higher rank).
+        high = ranks[row];
+        low = ranks[col];
+        suited = true;
+    } else {
+        // Lower-left: offsuit.
+        high = ranks[col];
+        low = ranks[row];
+        suited = false;
+    }
+    PreflopHand::new(high, low, suited)
+}
+
+/// Combo count for a cell, used for range-weighted seat totals.
+pub fn combo_count(row: usize, col: usize) -> f32 {
+    if row == col {
+        PAIR_COMBOS
+    } else if col > row {
+        SUITED_COMBOS
+    } else {
+        OFFSUIT_COMBOS
+    }
+}
+
+/// Base color for each action type.
+pub fn action_color(action: PreflopActionType) -> Color {
+    match action {
+        PreflopActionType::Fold => theme::SURFACE1,
+        PreflopActionType::Call => theme::GREEN,
+        PreflopActionType::Raise => theme::RED,
+    }
+}
+
+/// Human-readable label for an action, used in legends and hover detail.
+pub fn action_label(action: PreflopActionType) -> &'static str {
+    match action {
+        PreflopActionType::Fold => "Fold",
+        PreflopActionType::Call => "Call",
+        PreflopActionType::Raise => "Raise",
+    }
+}
+
+/// Blend the raise/call/fold frequencies in `strategy` into a single
+/// background color. `None` means the hand isn't in the chart — pure fold.
+pub fn blended_color(strategy: Option<&PreflopStrategy>) -> Color {
+    let (raise, call, fold) = match strategy {
+        Some(s) => (s.raise(), s.call(), s.fold_freq()),
+        None => return action_color(PreflopActionType::Fold),
+    };
+    let total = raise + call + fold;
+    if total <= 0.0 {
+        return action_color(PreflopActionType::Fold);
+    }
+    let (rr, rg, rb) = rgb_components(action_color(PreflopActionType::Raise));
+    let (cr, cg, cb) = rgb_components(action_color(PreflopActionType::Call));
+    let (fr, fg, fb) = rgb_components(action_color(PreflopActionType::Fold));
+    let r = (rr * raise + cr * call + fr * fold) / total;
+    let g = (rg * raise + cg * call + fg * fold) / total;
+    let b = (rb * raise + cb * call + fb * fold) / total;
+    Color::Rgb(
+        r.round().clamp(0.0, 255.0) as u8,
+        g.round().clamp(0.0, 255.0) as u8,
+        b.round().clamp(0.0, 255.0) as u8,
+    )
+}
+
+/// Pick a readable foreground color for text drawn on top of `bg`.
+fn foreground_on(bg: Color) -> Color {
+    let (r, g, b) = rgb_components(bg);
+    // Rec. 709 luma. Below mid-gray → light text, else dark text.
+    let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    if luma < 140.0 {
+        theme::TEXT
+    } else {
+        theme::SURFACE1
+    }
+}
+
+fn rgb_components(color: Color) -> (f32, f32, f32) {
+    match color {
+        Color::Rgb(r, g, b) => (r as f32, g as f32, b as f32),
+        _ => (128.0, 128.0, 128.0),
+    }
+}
+
+/// Range-weighted action totals for a chart.
+///
+/// Returns, for each of `[Fold, Call, Raise]`, the fraction of all dealt
+/// starting hands that take that action at this seat/scenario. Pairs are
+/// weighted by 6, suited by 4, and offsuit by 12, matching combo counts in a
+/// 52-card deck (1326 total).
+pub fn seat_totals(chart: &PreflopChart) -> [(PreflopActionType, f32); 3] {
+    let mut raise = 0.0f32;
+    let mut call = 0.0f32;
+    let mut fold = 0.0f32;
+    let mut total_weight = 0.0f32;
+
+    for row in 0..13 {
+        for col in 0..13 {
+            let hand = hand_at(row, col);
+            let weight = combo_count(row, col);
+            total_weight += weight;
+            match chart.get(&hand) {
+                Some(strategy) => {
+                    raise += strategy.raise() * weight;
+                    call += strategy.call() * weight;
+                    fold += strategy.fold_freq() * weight;
+                }
+                None => {
+                    // Implicit fold for unlisted hands.
+                    fold += weight;
+                }
+            }
+        }
+    }
+
+    let norm = |v: f32| {
+        if total_weight > 0.0 {
+            v / total_weight
+        } else {
+            0.0
+        }
+    };
+    [
+        (PreflopActionType::Fold, norm(fold)),
+        (PreflopActionType::Call, norm(call)),
+        (PreflopActionType::Raise, norm(raise)),
+    ]
+}
+
+/// Compute cell size that fills `area` while keeping cells visually square.
+///
+/// Terminal character cells are roughly 2:1 tall:wide in screen pixels, so
+/// `cell_w = 2 * cell_h` renders as a visual square. Widths floor at 3 and
+/// heights at 1 (the minimum 80-col layout). Widths cap at 9 so super-wide
+/// terminals don't produce absurdly chunky cells.
+///
+/// Exposed so the event loop can use the same sizing when hit-testing
+/// mouse clicks against the rendered grid.
+pub fn cell_size(area: Rect) -> (u16, u16) {
+    let avail_w = area.width.saturating_sub(2);
+    let avail_h = area.height.saturating_sub(1);
+    let cell_w = (avail_w / 13).clamp(3, 9);
+    let cell_h = (avail_h / 13).max(1);
+    let cell_h = cell_h.min((cell_w / 2).max(1));
+    (cell_w, cell_h)
+}
+
+/// Render the 13x13 hand grid into `area` for `chart`.
+///
+/// The leftmost 2 columns hold the row axis labels (rank A–2) and the top
+/// row holds the column axis labels.
+pub fn render_hand_grid(
+    frame: &mut Frame,
+    area: Rect,
+    chart: &PreflopChart,
+    hover: Option<(usize, usize)>,
+) {
+    let (cell_w, cell_h) = cell_size(area);
+    let ranks = display_ranks();
+
+    // Column axis labels across the top (single-char rank, centered in cell).
+    for (col, rank) in ranks.iter().enumerate() {
+        let x = area.x + 2 + col as u16 * cell_w + cell_w / 2;
+        let y = area.y;
+        if x >= area.x + area.width || y >= area.y + area.height {
+            continue;
+        }
+        let label = Paragraph::new(rank.to_char().to_string()).style(
+            Style::default()
+                .fg(theme::HEADER_COLOR)
+                .add_modifier(Modifier::BOLD),
+        );
+        frame.render_widget(label, Rect::new(x, y, 1, 1));
+    }
+
+    // Row axis labels down the left, vertically centered in cell.
+    for (row, rank) in ranks.iter().enumerate() {
+        let x = area.x;
+        let y = area.y + 1 + row as u16 * cell_h + cell_h / 2;
+        if y >= area.y + area.height {
+            continue;
+        }
+        let label = Paragraph::new(rank.to_char().to_string()).style(
+            Style::default()
+                .fg(theme::HEADER_COLOR)
+                .add_modifier(Modifier::BOLD),
+        );
+        frame.render_widget(label, Rect::new(x, y, 1, 1));
+    }
+
+    for row in 0..13 {
+        for col in 0..13 {
+            let x = area.x + 2 + col as u16 * cell_w;
+            let y = area.y + 1 + row as u16 * cell_h;
+            if x + cell_w > area.x + area.width || y + cell_h > area.y + area.height {
+                continue;
+            }
+            let hand = hand_at(row, col);
+            let strategy = chart.get(&hand);
+            let bg = blended_color(strategy);
+            let is_hover = hover == Some((row, col));
+            let fg = if is_hover {
+                theme::LAVENDER
+            } else {
+                foreground_on(bg)
+            };
+            let mut style = Style::default().bg(bg).fg(fg);
+            if is_hover {
+                style = style.add_modifier(Modifier::BOLD);
+            }
+
+            // Fill cell_w x cell_h with background color. The hover dot (if
+            // any) is centered in the middle row of the cell.
+            let middle_row = cell_h / 2;
+            for dy in 0..cell_h {
+                let text = if is_hover && dy == middle_row {
+                    let w = cell_w as usize;
+                    let dot_idx = w / 2;
+                    let mut s = String::with_capacity(w + 2);
+                    s.extend(std::iter::repeat_n(' ', dot_idx));
+                    s.push('●');
+                    s.extend(std::iter::repeat_n(' ', w.saturating_sub(dot_idx + 1)));
+                    s
+                } else {
+                    " ".repeat(cell_w as usize)
+                };
+                let cell = Paragraph::new(text).style(style);
+                frame.render_widget(cell, Rect::new(x, y + dy, cell_w, 1));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hand_at_corners() {
+        let aa = hand_at(0, 0);
+        assert!(aa.is_pair());
+        assert_eq!(aa.high(), Value::Ace);
+
+        let a2s = hand_at(0, 12);
+        assert!(a2s.suited());
+        assert_eq!(a2s.high(), Value::Ace);
+        assert_eq!(a2s.low(), Value::Two);
+
+        let a2o = hand_at(12, 0);
+        assert!(!a2o.is_pair());
+        assert!(!a2o.suited());
+        assert_eq!(a2o.high(), Value::Ace);
+        assert_eq!(a2o.low(), Value::Two);
+
+        let deuces = hand_at(12, 12);
+        assert!(deuces.is_pair());
+        assert_eq!(deuces.high(), Value::Two);
+    }
+
+    #[test]
+    fn hand_at_standard_positions() {
+        let aks = hand_at(0, 1);
+        assert!(aks.suited());
+        assert_eq!(aks.high(), Value::Ace);
+        assert_eq!(aks.low(), Value::King);
+
+        let ako = hand_at(1, 0);
+        assert!(!ako.is_pair());
+        assert!(!ako.suited());
+        assert_eq!(ako.high(), Value::Ace);
+        assert_eq!(ako.low(), Value::King);
+    }
+
+    #[test]
+    fn combo_counts_match_convention() {
+        assert_eq!(combo_count(0, 0), PAIR_COMBOS);
+        assert_eq!(combo_count(0, 1), SUITED_COMBOS);
+        assert_eq!(combo_count(1, 0), OFFSUIT_COMBOS);
+
+        let mut total = 0.0;
+        for r in 0..13 {
+            for c in 0..13 {
+                total += combo_count(r, c);
+            }
+        }
+        assert_eq!(total as u32, 1326);
+    }
+
+    #[test]
+    fn blended_color_pure_fold_for_missing_hand() {
+        let color = blended_color(None);
+        assert_eq!(color, theme::SURFACE1);
+    }
+
+    #[test]
+    fn blended_color_pure_raise_matches_raise_color() {
+        let strategy = PreflopStrategy::pure_raise();
+        let color = blended_color(Some(&strategy));
+        assert_eq!(color, theme::RED);
+    }
+
+    #[test]
+    fn blended_color_mixes_equal_call_raise_to_midpoint() {
+        let strategy = PreflopStrategy::new(0.5, 0.5).unwrap();
+        let color = blended_color(Some(&strategy));
+        let (rr, rg, rb) = rgb_components(theme::RED);
+        let (gr, gg, gb) = rgb_components(theme::GREEN);
+        let expected = Color::Rgb(
+            ((rr + gr) / 2.0).round() as u8,
+            ((rg + gg) / 2.0).round() as u8,
+            ((rb + gb) / 2.0).round() as u8,
+        );
+        assert_eq!(color, expected);
+    }
+
+    #[test]
+    fn seat_totals_all_fold_for_empty_chart() {
+        let chart = PreflopChart::new();
+        let totals = seat_totals(&chart);
+        assert_eq!(totals[0].0, PreflopActionType::Fold);
+        assert!((totals[0].1 - 1.0).abs() < 1e-5);
+        assert!(totals[1].1.abs() < 1e-5);
+        assert!(totals[2].1.abs() < 1e-5);
+    }
+
+    #[test]
+    fn seat_totals_all_raise_for_every_hand() {
+        let mut chart = PreflopChart::new();
+        for hand in PreflopHand::all() {
+            chart.set(hand, PreflopStrategy::pure_raise());
+        }
+        let totals = seat_totals(&chart);
+        let raise = totals
+            .iter()
+            .find(|(a, _)| *a == PreflopActionType::Raise)
+            .unwrap();
+        assert!((raise.1 - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn render_grid_does_not_panic() {
+        use ratatui::{Terminal, backend::TestBackend};
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut chart = PreflopChart::new();
+        chart.set(
+            PreflopHand::new(Value::Ace, Value::Ace, false),
+            PreflopStrategy::pure_raise(),
+        );
+        terminal
+            .draw(|frame| {
+                render_hand_grid(frame, Rect::new(0, 0, 50, 16), &chart, Some((0, 0)));
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn cell_size_minimum_80col_layout() {
+        let (w, h) = cell_size(Rect::new(0, 0, 41, 14));
+        assert_eq!(w, 3);
+        assert_eq!(h, 1);
+    }
+
+    #[test]
+    fn cell_size_grows_width_on_wider_area() {
+        let (w, _) = cell_size(Rect::new(0, 0, 80, 20));
+        assert!(w > 3, "expected wider cells when area grows, got {}", w);
+    }
+
+    #[test]
+    fn cell_size_grows_height_proportionally() {
+        let (w, h) = cell_size(Rect::new(0, 0, 130, 40));
+        assert!(w >= 5);
+        assert!(h >= 2);
+        assert!(h <= w / 2);
+    }
+
+    #[test]
+    fn cell_size_caps_width() {
+        let (w, _) = cell_size(Rect::new(0, 0, 400, 400));
+        assert!(w <= 9, "cell width should cap, got {}", w);
+    }
+
+    #[test]
+    fn render_grid_at_large_size_does_not_panic() {
+        use ratatui::{Terminal, backend::TestBackend};
+        let backend = TestBackend::new(200, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let chart = PreflopChart::new();
+        terminal
+            .draw(|frame| {
+                render_hand_grid(frame, Rect::new(0, 0, 180, 55), &chart, Some((5, 7)));
+            })
+            .unwrap();
+    }
+}

--- a/src/bin/rsp/tui/widgets/mod.rs
+++ b/src/bin/rsp/tui/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod filter_panel;
 pub mod game_log;
+pub mod hand_grid;
 pub mod profit_chart;
 pub mod progress_bar;
 pub mod stats_table;

--- a/src/holdem/mod.rs
+++ b/src/holdem/mod.rs
@@ -23,4 +23,6 @@ pub use self::outs_calculator::{OutsCalculator, OutsCalculatorError, PlayerOutco
 /// Module for pre-flop charts representing action frequencies.
 mod preflop_chart;
 /// Export pre-flop chart types
-pub use self::preflop_chart::{PreflopActionType, PreflopChart, PreflopHand, PreflopStrategy};
+pub use self::preflop_chart::{
+    PreflopActionType, PreflopChart, PreflopHand, PreflopScenario, PreflopStrategy,
+};

--- a/src/holdem/preflop_chart.rs
+++ b/src/holdem/preflop_chart.rs
@@ -2,6 +2,11 @@
 //!
 //! This module provides types for representing GTO-style action frequencies
 //! for the 169 unique starting hands in Texas Hold'em.
+//!
+//! The chart format is scoped by *scenario* — the decision point is derived
+//! from `total_raise_count` at act-time, and a separate [`PreflopChart`] holds
+//! the hand→strategy map for each (position, scenario). A strategy is just a
+//! `(raise, call)` frequency pair; fold is implicit as `1 - raise - call`.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -47,22 +52,6 @@ impl PreflopHand {
     ///
     /// Values are automatically ordered so that `high >= low`.
     /// Pairs always have `suited = false` regardless of the input.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::PreflopHand;
-    /// use rs_poker::core::Value;
-    ///
-    /// // Values are auto-ordered
-    /// let hand1 = PreflopHand::new(Value::King, Value::Ace, true);
-    /// let hand2 = PreflopHand::new(Value::Ace, Value::King, true);
-    /// assert_eq!(hand1, hand2);
-    ///
-    /// // Pairs can't be suited
-    /// let pair = PreflopHand::new(Value::Ace, Value::Ace, true);
-    /// assert!(!pair.suited());
-    /// ```
     pub fn new(v1: Value, v2: Value, suited: bool) -> Self {
         let (high, low) = if v1 >= v2 { (v1, v2) } else { (v2, v1) };
         // Pairs can't be suited
@@ -71,26 +60,11 @@ impl PreflopHand {
     }
 
     /// Returns true if this is a pocket pair.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::PreflopHand;
-    /// use rs_poker::core::Value;
-    ///
-    /// let pair = PreflopHand::new(Value::Ace, Value::Ace, false);
-    /// assert!(pair.is_pair());
-    ///
-    /// let non_pair = PreflopHand::new(Value::Ace, Value::King, true);
-    /// assert!(!non_pair.is_pair());
-    /// ```
     pub fn is_pair(&self) -> bool {
         self.high == self.low
     }
 
-    /// Returns true if this hand is suited.
-    ///
-    /// Pairs always return false.
+    /// Returns true if this hand is suited. Pairs always return false.
     pub fn suited(&self) -> bool {
         self.suited
     }
@@ -105,28 +79,7 @@ impl PreflopHand {
         self.low
     }
 
-    /// Convert to standard notation string.
-    ///
-    /// Format:
-    /// - Pairs: "AA", "KK", "22"
-    /// - Suited: "AKs", "T9s"
-    /// - Offsuit: "AKo", "72o"
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::PreflopHand;
-    /// use rs_poker::core::Value;
-    ///
-    /// let aces = PreflopHand::new(Value::Ace, Value::Ace, false);
-    /// assert_eq!(aces.to_notation(), "AA");
-    ///
-    /// let aks = PreflopHand::new(Value::Ace, Value::King, true);
-    /// assert_eq!(aks.to_notation(), "AKs");
-    ///
-    /// let ako = PreflopHand::new(Value::Ace, Value::King, false);
-    /// assert_eq!(ako.to_notation(), "AKo");
-    /// ```
+    /// Convert to standard notation string ("AA", "AKs", "AKo").
     pub fn to_notation(&self) -> String {
         let high_char = self.high.to_char();
         let low_char = self.low.to_char();
@@ -142,31 +95,10 @@ impl PreflopHand {
 
     /// Parse from notation string.
     ///
-    /// Accepts formats:
-    /// - Pairs: "AA", "KK", "22"
-    /// - Suited: "AKs", "T9s"
-    /// - Offsuit: "AKo", "72o"
-    ///
     /// # Errors
     ///
-    /// Returns `RSPokerError::InvalidPreflopNotation` if the notation is invalid.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::PreflopHand;
-    /// use rs_poker::core::Value;
-    ///
-    /// let aces = PreflopHand::from_notation("AA").unwrap();
-    /// assert!(aces.is_pair());
-    /// assert_eq!(aces.high(), Value::Ace);
-    ///
-    /// let aks = PreflopHand::from_notation("AKs").unwrap();
-    /// assert!(aks.suited());
-    ///
-    /// let ako = PreflopHand::from_notation("AKo").unwrap();
-    /// assert!(!ako.suited());
-    /// ```
+    /// Returns `RSPokerError::InvalidPreflopNotation` if the notation is
+    /// invalid.
     pub fn from_notation(s: &str) -> Result<Self, RSPokerError> {
         let chars: Vec<char> = s.chars().collect();
 
@@ -180,7 +112,6 @@ impl PreflopHand {
             .ok_or_else(|| RSPokerError::InvalidPreflopNotation(s.to_string()))?;
 
         let suited = if chars.len() == 2 {
-            // Must be a pair for 2-char notation
             if v1 != v2 {
                 return Err(RSPokerError::InvalidPreflopNotation(s.to_string()));
             }
@@ -188,7 +119,6 @@ impl PreflopHand {
         } else {
             match chars[2].to_ascii_lowercase() {
                 's' => {
-                    // Can't have suited pair
                     if v1 == v2 {
                         return Err(RSPokerError::InvalidPreflopNotation(s.to_string()));
                     }
@@ -202,31 +132,15 @@ impl PreflopHand {
         Ok(Self::new(v1, v2, suited))
     }
 
-    /// Generate all 169 unique pre-flop hands.
-    ///
-    /// Returns a vector containing:
-    /// - 13 pocket pairs
-    /// - 78 suited hands
-    /// - 78 offsuit hands
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::PreflopHand;
-    ///
-    /// let all_hands = PreflopHand::all();
-    /// assert_eq!(all_hands.len(), 169);
-    /// ```
+    /// Generate all 169 unique pre-flop hands: 13 pairs + 78 suited + 78
+    /// offsuit.
     pub fn all() -> Vec<Self> {
         let mut hands = Vec::with_capacity(169);
         let values = Value::values();
 
         for (i, &high) in values.iter().enumerate() {
             for &low in &values[..=i] {
-                // Always add offsuit (or pair for same values)
                 hands.push(Self::new(high, low, false));
-
-                // Add suited for non-pairs
                 if high != low {
                     hands.push(Self::new(high, low, true));
                 }
@@ -263,22 +177,8 @@ impl From<PreflopHand> for String {
 ///
 /// # Errors
 ///
-/// Returns `RSPokerError::InvalidPreflopHandSize` if the hand doesn't have exactly 2 cards.
-///
-/// # Examples
-///
-/// ```
-/// use rs_poker::holdem::PreflopHand;
-/// use rs_poker::core::{Card, Hand, Value, Suit};
-/// use std::convert::TryFrom;
-///
-/// let mut hand = Hand::new();
-/// hand.insert(Card::new(Value::Ace, Suit::Spade));
-/// hand.insert(Card::new(Value::King, Suit::Spade));
-///
-/// let preflop = PreflopHand::try_from(&hand).unwrap();
-/// assert_eq!(preflop.to_notation(), "AKs");
-/// ```
+/// Returns `RSPokerError::InvalidPreflopHandSize` if the hand doesn't have
+/// exactly 2 cards.
 impl TryFrom<&Hand> for PreflopHand {
     type Error = RSPokerError;
 
@@ -301,189 +201,202 @@ impl TryFrom<&Hand> for PreflopHand {
     }
 }
 
-/// Pre-flop action types.
+/// Pre-flop action types. Bet sizing is supplied by the action generator,
+/// not stored on the action.
 ///
-/// These represent the common pre-flop decisions. Bet sizing is not included
-/// as it's determined by context or separate configuration.
+/// Scenario is external — a single [`PreflopChart`] holds the strategy for
+/// one (position, scenario) pair, and the caller knows which scenario
+/// applies from `total_raise_count`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PreflopActionType {
-    /// Fold the hand (or check when no bet to call)
+    /// Fold the hand (or check when no bet to call).
     Fold,
-    /// Call/limp (match the current bet)
+    /// Flat-call the current bet.
     Call,
-    /// Open raise or standard raise
+    /// Raise (sizing is scenario-specific: open for RFI, 3-bet for VsOpen,
+    /// 4-bet for Vs3Bet).
     Raise,
-    /// Re-raise (raise over a raise)
-    ThreeBet,
-    /// Re-raise over a 3-bet
-    FourBet,
 }
 
-/// Stores action frequencies for a pre-flop hand.
+/// Which preflop decision point a strategy entry applies to.
 ///
-/// Frequencies must sum to 1.0 (within floating point tolerance).
-/// Only non-zero actions are stored.
+/// Derived at action-generation time from `round_data.total_raise_count`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum PreflopScenario {
+    /// Unopened pot (0 prior raises this street). Valid: `Raise`, `Fold`.
+    Rfi,
+    /// Facing exactly 1 raise. Valid: `Raise` (3-bet), `Call`, `Fold`.
+    VsOpen,
+    /// Facing exactly 2 raises. Valid: `Raise` (4-bet), `Call`, `Fold`.
+    Vs3Bet,
+    /// Facing 3+ raises. Valid: `Call`, `Fold` (raise is capped).
+    Vs4Bet,
+}
+
+impl PreflopScenario {
+    /// Derive the scenario from `total_raise_count` (non-forced raises this
+    /// street).
+    pub fn from_raise_count(raises: u8) -> Self {
+        match raises {
+            0 => Self::Rfi,
+            1 => Self::VsOpen,
+            2 => Self::Vs3Bet,
+            _ => Self::Vs4Bet,
+        }
+    }
+
+    /// All scenarios in a stable order.
+    pub const fn all() -> [Self; 4] {
+        [Self::Rfi, Self::VsOpen, Self::Vs3Bet, Self::Vs4Bet]
+    }
+
+    /// Short human-readable label ("RFI", "vs Open", ...).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Rfi => "RFI",
+            Self::VsOpen => "vs Open",
+            Self::Vs3Bet => "vs 3-Bet",
+            Self::Vs4Bet => "vs 4-Bet",
+        }
+    }
+}
+
+/// Action frequencies for a single hand in a single scenario.
+///
+/// `raise` and `call` are both in `[0, 1]`, with `raise + call ≤ 1`. Fold is
+/// implicit as `1 - raise - call`. Both fields default to 0 when absent from
+/// JSON, so `{}` is all-fold, `{"raise": 1.0}` is pure-raise, etc.
+///
+/// The interpretation of "raise" depends on the scenario in which this
+/// strategy is looked up: an open in RFI, a 3-bet in VsOpen, a 4-bet in
+/// Vs3Bet. Sizing is supplied by the action generator's config.
 ///
 /// # Examples
 ///
 /// ```
-/// use rs_poker::holdem::{PreflopStrategy, PreflopActionType};
+/// use rs_poker::holdem::{PreflopActionType, PreflopStrategy};
 ///
-/// // Pure strategy (100% one action)
-/// let always_raise = PreflopStrategy::pure(PreflopActionType::Raise);
-/// assert_eq!(always_raise.frequency(PreflopActionType::Raise), 1.0);
+/// let pure_raise = PreflopStrategy::pure_raise();
+/// assert_eq!(pure_raise.raise(), 1.0);
+/// assert_eq!(pure_raise.fold_freq(), 0.0);
 ///
-/// // Mixed strategy
-/// let mixed = PreflopStrategy::new(vec![
-///     (PreflopActionType::Raise, 0.7),
-///     (PreflopActionType::Call, 0.3),
-/// ]).unwrap();
-/// assert_eq!(mixed.frequency(PreflopActionType::Raise), 0.7);
+/// let mixed = PreflopStrategy::new(0.5, 0.3).unwrap();
+/// assert_eq!(mixed.raise(), 0.5);
+/// assert_eq!(mixed.call(), 0.3);
+/// assert!((mixed.fold_freq() - 0.2).abs() < 1e-5);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PreflopStrategy {
-    frequencies: Vec<(PreflopActionType, f32)>,
+    /// Raise frequency (open / 3-bet / 4-bet depending on scenario).
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "is_zero"))]
+    raise: f32,
+    /// Call frequency. Ignored in RFI.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "is_zero"))]
+    call: f32,
+}
+
+#[cfg(feature = "serde")]
+fn is_zero(f: &f32) -> bool {
+    *f == 0.0
 }
 
 impl PreflopStrategy {
-    /// Create a new strategy with validated frequencies.
-    ///
-    /// Frequencies must sum to 1.0 (within 0.001 tolerance).
+    /// Create a new strategy.
     ///
     /// # Errors
     ///
-    /// Returns `RSPokerError::InvalidStrategyFrequencies` if frequencies don't sum to 1.0.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::{PreflopStrategy, PreflopActionType};
-    ///
-    /// let strategy = PreflopStrategy::new(vec![
-    ///     (PreflopActionType::Raise, 0.6),
-    ///     (PreflopActionType::Call, 0.3),
-    ///     (PreflopActionType::Fold, 0.1),
-    /// ]).unwrap();
-    /// ```
-    pub fn new(frequencies: Vec<(PreflopActionType, f32)>) -> Result<Self, RSPokerError> {
-        let sum: f32 = frequencies.iter().map(|(_, f)| f).sum();
-
-        // Allow small floating point tolerance
-        if (sum - 1.0).abs() > 0.001 {
-            return Err(RSPokerError::InvalidStrategyFrequencies(sum.to_string()));
+    /// Returns `RSPokerError::InvalidStrategyFrequencies` if either value is
+    /// outside `[0.0, 1.0]` or if `raise + call > 1.001`.
+    pub fn new(raise: f32, call: f32) -> Result<Self, RSPokerError> {
+        if !(0.0..=1.0 + 0.001).contains(&raise) {
+            return Err(RSPokerError::InvalidStrategyFrequencies(format!(
+                "raise = {raise}"
+            )));
         }
-
-        // Filter out zero frequencies
-        let frequencies: Vec<_> = frequencies.into_iter().filter(|(_, f)| *f > 0.0).collect();
-
-        Ok(Self { frequencies })
+        if !(0.0..=1.0 + 0.001).contains(&call) {
+            return Err(RSPokerError::InvalidStrategyFrequencies(format!(
+                "call = {call}"
+            )));
+        }
+        if raise + call > 1.0 + 0.001 {
+            return Err(RSPokerError::InvalidStrategyFrequencies(format!(
+                "raise + call = {:.3}",
+                raise + call
+            )));
+        }
+        Ok(Self { raise, call })
     }
 
-    /// Create a pure strategy (100% one action).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::{PreflopStrategy, PreflopActionType};
-    ///
-    /// let always_fold = PreflopStrategy::pure(PreflopActionType::Fold);
-    /// assert_eq!(always_fold.frequency(PreflopActionType::Fold), 1.0);
-    /// ```
-    pub fn pure(action: PreflopActionType) -> Self {
+    /// Pure-fold strategy (raise=0, call=0).
+    pub const fn fold() -> Self {
         Self {
-            frequencies: vec![(action, 1.0)],
+            raise: 0.0,
+            call: 0.0,
         }
     }
 
-    /// Create a fold-only strategy.
-    ///
-    /// Convenience method equivalent to `pure(PreflopActionType::Fold)`.
-    pub fn fold() -> Self {
-        Self::pure(PreflopActionType::Fold)
+    /// Pure-raise strategy (raise=1, call=0).
+    pub const fn pure_raise() -> Self {
+        Self {
+            raise: 1.0,
+            call: 0.0,
+        }
     }
 
-    /// Get the frequency for a specific action.
-    ///
-    /// Returns 0.0 if the action is not in the strategy.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::{PreflopStrategy, PreflopActionType};
-    ///
-    /// let strategy = PreflopStrategy::new(vec![
-    ///     (PreflopActionType::Raise, 0.8),
-    ///     (PreflopActionType::Fold, 0.2),
-    /// ]).unwrap();
-    ///
-    /// assert_eq!(strategy.frequency(PreflopActionType::Raise), 0.8);
-    /// assert_eq!(strategy.frequency(PreflopActionType::Call), 0.0);
-    /// ```
+    /// Pure-call strategy (raise=0, call=1).
+    pub const fn pure_call() -> Self {
+        Self {
+            raise: 0.0,
+            call: 1.0,
+        }
+    }
+
+    /// Raise frequency.
+    pub fn raise(&self) -> f32 {
+        self.raise
+    }
+
+    /// Call frequency.
+    pub fn call(&self) -> f32 {
+        self.call
+    }
+
+    /// Implicit fold frequency (`1 - raise - call`, clamped at 0).
+    pub fn fold_freq(&self) -> f32 {
+        (1.0 - self.raise - self.call).max(0.0)
+    }
+
+    /// True when this is the fold-everywhere strategy.
+    pub fn is_pure_fold(&self) -> bool {
+        self.raise == 0.0 && self.call == 0.0
+    }
+
+    /// Look up the frequency for a specific action type.
     pub fn frequency(&self, action: PreflopActionType) -> f32 {
-        self.frequencies
-            .iter()
-            .find(|(a, _)| *a == action)
-            .map(|(_, f)| *f)
-            .unwrap_or(0.0)
-    }
-
-    /// Get all non-zero action frequencies.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::{PreflopStrategy, PreflopActionType};
-    ///
-    /// let strategy = PreflopStrategy::pure(PreflopActionType::Raise);
-    /// let freqs = strategy.frequencies();
-    /// assert_eq!(freqs.len(), 1);
-    /// assert_eq!(freqs[0], (PreflopActionType::Raise, 1.0));
-    /// ```
-    pub fn frequencies(&self) -> &[(PreflopActionType, f32)] {
-        &self.frequencies
-    }
-
-    /// Sample an action based on frequencies using the provided random value.
-    ///
-    /// The `random_value` should be in the range [0.0, 1.0).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::{PreflopStrategy, PreflopActionType};
-    ///
-    /// let strategy = PreflopStrategy::new(vec![
-    ///     (PreflopActionType::Raise, 0.7),
-    ///     (PreflopActionType::Call, 0.3),
-    /// ]).unwrap();
-    ///
-    /// // Values 0.0..0.7 will return Raise
-    /// assert_eq!(strategy.sample(0.0), PreflopActionType::Raise);
-    /// assert_eq!(strategy.sample(0.69), PreflopActionType::Raise);
-    ///
-    /// // Values 0.7..1.0 will return Call
-    /// assert_eq!(strategy.sample(0.7), PreflopActionType::Call);
-    /// assert_eq!(strategy.sample(0.99), PreflopActionType::Call);
-    /// ```
-    pub fn sample(&self, random_value: f32) -> PreflopActionType {
-        let mut cumulative = 0.0;
-
-        for (action, freq) in &self.frequencies {
-            cumulative += freq;
-            if random_value < cumulative {
-                return *action;
-            }
+        match action {
+            PreflopActionType::Raise => self.raise,
+            PreflopActionType::Call => self.call,
+            PreflopActionType::Fold => self.fold_freq(),
         }
+    }
 
-        // Return last action if we somehow reach here (floating point edge case)
-        self.frequencies
-            .last()
-            .map(|(a, _)| *a)
-            .unwrap_or(PreflopActionType::Fold)
+    /// Sample an action using `random_value` in `[0, 1)`.
+    ///
+    /// Order is Raise → Call → Fold.
+    pub fn sample(&self, random_value: f32) -> PreflopActionType {
+        if random_value < self.raise {
+            PreflopActionType::Raise
+        } else if random_value < self.raise + self.call {
+            PreflopActionType::Call
+        } else {
+            PreflopActionType::Fold
+        }
     }
 }
 
@@ -493,28 +406,27 @@ impl Default for PreflopStrategy {
     }
 }
 
-/// A pre-flop chart mapping hands to strategies.
+/// A pre-flop chart mapping hands to strategies, scoped to one (position,
+/// scenario) pair.
 ///
-/// Hands not in the chart are implicitly 100% fold.
+/// Hands not in the chart are implicitly pure-fold.
 ///
 /// # Examples
 ///
 /// ```
-/// use rs_poker::holdem::{PreflopChart, PreflopHand, PreflopStrategy, PreflopActionType};
+/// use rs_poker::holdem::{PreflopActionType, PreflopChart, PreflopHand, PreflopStrategy};
 /// use rs_poker::core::Value;
 ///
 /// let mut chart = PreflopChart::new();
-///
-/// // Set strategy for AA
 /// let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-/// chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
+/// chart.set(aa, PreflopStrategy::pure_raise());
 ///
-/// // Get strategy
-/// assert!(chart.get(&aa).is_some());
-/// assert_eq!(chart.get(&aa).unwrap().frequency(PreflopActionType::Raise), 1.0);
+/// assert_eq!(chart.get(&aa).unwrap().raise(), 1.0);
+/// assert_eq!(chart.get_or_fold(&PreflopHand::from_notation("72o").unwrap()).fold_freq(), 1.0);
 /// ```
 #[derive(Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PreflopChart {
     strategies: HashMap<PreflopHand, PreflopStrategy>,
@@ -526,35 +438,14 @@ impl PreflopChart {
         Self::default()
     }
 
-    /// Get the strategy for a hand.
-    ///
-    /// Returns `None` if no strategy is set for this hand.
+    /// Get the strategy for a hand, or `None` if not set.
     pub fn get(&self, hand: &PreflopHand) -> Option<&PreflopStrategy> {
         self.strategies.get(hand)
     }
 
-    /// Get the strategy for a hand, returning fold strategy if not found.
-    ///
-    /// This is useful when you always want a valid strategy back.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rs_poker::holdem::{PreflopChart, PreflopHand, PreflopActionType};
-    /// use rs_poker::core::Value;
-    ///
-    /// let chart = PreflopChart::new();
-    /// let unknown = PreflopHand::new(Value::Seven, Value::Two, false);
-    ///
-    /// // Returns fold strategy for unknown hands
-    /// let strategy = chart.get_or_fold(&unknown);
-    /// assert_eq!(strategy.frequency(PreflopActionType::Fold), 1.0);
-    /// ```
+    /// Get the strategy for a hand, falling back to pure-fold when absent.
     pub fn get_or_fold(&self, hand: &PreflopHand) -> PreflopStrategy {
-        self.strategies
-            .get(hand)
-            .cloned()
-            .unwrap_or_else(PreflopStrategy::fold)
+        self.strategies.get(hand).copied().unwrap_or_default()
     }
 
     /// Set the strategy for a hand.
@@ -563,8 +454,6 @@ impl PreflopChart {
     }
 
     /// Remove the strategy for a hand.
-    ///
-    /// Returns the removed strategy if it existed.
     pub fn remove(&mut self, hand: &PreflopHand) -> Option<PreflopStrategy> {
         self.strategies.remove(hand)
     }
@@ -579,7 +468,7 @@ impl PreflopChart {
         self.strategies.len()
     }
 
-    /// Returns true if no hands have explicit strategies.
+    /// Returns true if no hands have explicit strategies (every hand folds).
     pub fn is_empty(&self) -> bool {
         self.strategies.is_empty()
     }
@@ -594,7 +483,6 @@ mod tests {
 
     #[test]
     fn test_preflop_hand_ordering() {
-        // Values should be auto-sorted so high >= low
         let hand1 = PreflopHand::new(Value::King, Value::Ace, true);
         let hand2 = PreflopHand::new(Value::Ace, Value::King, true);
         assert_eq!(hand1, hand2);
@@ -604,7 +492,6 @@ mod tests {
 
     #[test]
     fn test_preflop_hand_try_from_hand() {
-        // Suited hand
         let mut cards = Hand::new();
         cards.insert(Card::new(Value::Ace, Suit::Spade));
         cards.insert(Card::new(Value::King, Suit::Spade));
@@ -613,34 +500,29 @@ mod tests {
         assert_eq!(preflop.high(), Value::Ace);
         assert_eq!(preflop.low(), Value::King);
 
-        // Offsuit hand
         let mut cards = Hand::new();
         cards.insert(Card::new(Value::Ace, Suit::Spade));
         cards.insert(Card::new(Value::King, Suit::Heart));
         let preflop = PreflopHand::try_from(&cards).expect("valid 2-card hand");
         assert!(!preflop.suited());
 
-        // Pair (both same value)
         let mut cards = Hand::new();
         cards.insert(Card::new(Value::Queen, Suit::Spade));
         cards.insert(Card::new(Value::Queen, Suit::Heart));
         let preflop = PreflopHand::try_from(&cards).expect("valid 2-card hand");
         assert!(preflop.is_pair());
-        assert!(!preflop.suited()); // Pairs can't be suited
+        assert!(!preflop.suited());
     }
 
     #[test]
     fn test_preflop_hand_try_from_invalid_size() {
-        // Too few cards
         let cards = Hand::new();
         assert!(PreflopHand::try_from(&cards).is_err());
 
-        // One card
         let mut cards = Hand::new();
         cards.insert(Card::new(Value::Ace, Suit::Spade));
         assert!(PreflopHand::try_from(&cards).is_err());
 
-        // Three cards
         let mut cards = Hand::new();
         cards.insert(Card::new(Value::Ace, Suit::Spade));
         cards.insert(Card::new(Value::King, Suit::Spade));
@@ -649,31 +531,12 @@ mod tests {
     }
 
     #[test]
-    fn test_preflop_hand_is_pair() {
-        let pair = PreflopHand::new(Value::Ace, Value::Ace, false);
-        assert!(pair.is_pair());
-
-        let non_pair = PreflopHand::new(Value::Ace, Value::King, true);
-        assert!(!non_pair.is_pair());
-    }
-
-    #[test]
-    fn test_preflop_hand_pair_not_suited() {
-        // Even if you pass suited=true for a pair, it should be false
-        let pair = PreflopHand::new(Value::King, Value::King, true);
-        assert!(!pair.suited());
-    }
-
-    #[test]
     fn test_preflop_hand_all_count() {
         let all = PreflopHand::all();
         assert_eq!(all.len(), 169);
-
-        // Count pairs, suited, and offsuit
         let pairs = all.iter().filter(|h| h.is_pair()).count();
         let suited = all.iter().filter(|h| h.suited()).count();
         let offsuit = all.iter().filter(|h| !h.is_pair() && !h.suited()).count();
-
         assert_eq!(pairs, 13);
         assert_eq!(suited, 78);
         assert_eq!(offsuit, 78);
@@ -682,53 +545,7 @@ mod tests {
     // ========== Notation tests ==========
 
     #[test]
-    fn test_notation_pairs() {
-        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-        assert_eq!(aa.to_notation(), "AA");
-
-        let twos = PreflopHand::new(Value::Two, Value::Two, false);
-        assert_eq!(twos.to_notation(), "22");
-
-        // Roundtrip
-        let parsed = PreflopHand::from_notation("KK").unwrap();
-        assert_eq!(parsed.high(), Value::King);
-        assert_eq!(parsed.low(), Value::King);
-        assert!(parsed.is_pair());
-    }
-
-    #[test]
-    fn test_notation_suited() {
-        let aks = PreflopHand::new(Value::Ace, Value::King, true);
-        assert_eq!(aks.to_notation(), "AKs");
-
-        let t9s = PreflopHand::new(Value::Ten, Value::Nine, true);
-        assert_eq!(t9s.to_notation(), "T9s");
-
-        // Roundtrip
-        let parsed = PreflopHand::from_notation("QJs").unwrap();
-        assert!(parsed.suited());
-        assert_eq!(parsed.high(), Value::Queen);
-        assert_eq!(parsed.low(), Value::Jack);
-    }
-
-    #[test]
-    fn test_notation_offsuit() {
-        let ako = PreflopHand::new(Value::Ace, Value::King, false);
-        assert_eq!(ako.to_notation(), "AKo");
-
-        let seven_two = PreflopHand::new(Value::Seven, Value::Two, false);
-        assert_eq!(seven_two.to_notation(), "72o");
-
-        // Roundtrip
-        let parsed = PreflopHand::from_notation("A5o").unwrap();
-        assert!(!parsed.suited());
-        assert_eq!(parsed.high(), Value::Ace);
-        assert_eq!(parsed.low(), Value::Five);
-    }
-
-    #[test]
     fn test_notation_roundtrip() {
-        // Test all 169 hands
         for hand in PreflopHand::all() {
             let notation = hand.to_notation();
             let parsed = PreflopHand::from_notation(&notation).unwrap();
@@ -741,131 +558,91 @@ mod tests {
         let parsed_lower = PreflopHand::from_notation("aks").unwrap();
         let parsed_upper = PreflopHand::from_notation("AKS").unwrap();
         let parsed_mixed = PreflopHand::from_notation("AkS").unwrap();
-
         assert_eq!(parsed_lower, parsed_upper);
         assert_eq!(parsed_lower, parsed_mixed);
     }
 
     #[test]
     fn test_notation_invalid() {
-        // Too short
         assert!(PreflopHand::from_notation("A").is_err());
-
-        // Too long
         assert!(PreflopHand::from_notation("AKso").is_err());
-
-        // Invalid value chars
         assert!(PreflopHand::from_notation("XKs").is_err());
-
-        // Non-pair without suitedness indicator
         assert!(PreflopHand::from_notation("AK").is_err());
-
-        // Suited pair (invalid)
         assert!(PreflopHand::from_notation("AAs").is_err());
-
-        // Invalid suitedness char
         assert!(PreflopHand::from_notation("AKx").is_err());
     }
 
     // ========== PreflopStrategy tests ==========
 
     #[test]
-    fn test_strategy_pure() {
-        let strategy = PreflopStrategy::pure(PreflopActionType::Raise);
-        assert_eq!(strategy.frequency(PreflopActionType::Raise), 1.0);
-        assert_eq!(strategy.frequency(PreflopActionType::Fold), 0.0);
-        assert_eq!(strategy.frequencies().len(), 1);
+    fn test_strategy_pure_raise() {
+        let s = PreflopStrategy::pure_raise();
+        assert_eq!(s.raise(), 1.0);
+        assert_eq!(s.call(), 0.0);
+        assert_eq!(s.fold_freq(), 0.0);
+        assert_eq!(s.frequency(PreflopActionType::Raise), 1.0);
+        assert_eq!(s.frequency(PreflopActionType::Fold), 0.0);
+    }
+
+    #[test]
+    fn test_strategy_pure_call() {
+        let s = PreflopStrategy::pure_call();
+        assert_eq!(s.raise(), 0.0);
+        assert_eq!(s.call(), 1.0);
+        assert_eq!(s.fold_freq(), 0.0);
     }
 
     #[test]
     fn test_strategy_fold() {
-        let strategy = PreflopStrategy::fold();
-        assert_eq!(strategy.frequency(PreflopActionType::Fold), 1.0);
+        let s = PreflopStrategy::fold();
+        assert_eq!(s.fold_freq(), 1.0);
+        assert_eq!(s.raise(), 0.0);
+        assert_eq!(s.call(), 0.0);
+        assert!(s.is_pure_fold());
     }
 
     #[test]
     fn test_strategy_mixed() {
-        let strategy = PreflopStrategy::new(vec![
-            (PreflopActionType::Raise, 0.6),
-            (PreflopActionType::Call, 0.3),
-            (PreflopActionType::Fold, 0.1),
-        ])
-        .unwrap();
-
-        assert_eq!(strategy.frequency(PreflopActionType::Raise), 0.6);
-        assert_eq!(strategy.frequency(PreflopActionType::Call), 0.3);
-        assert_eq!(strategy.frequency(PreflopActionType::Fold), 0.1);
-        assert_eq!(strategy.frequencies().len(), 3);
+        let s = PreflopStrategy::new(0.6, 0.3).unwrap();
+        assert_eq!(s.raise(), 0.6);
+        assert_eq!(s.call(), 0.3);
+        assert!((s.fold_freq() - 0.1).abs() < 1e-5);
     }
 
     #[test]
-    fn test_strategy_invalid_sum_too_low() {
-        let result = PreflopStrategy::new(vec![
-            (PreflopActionType::Raise, 0.5),
-            (PreflopActionType::Call, 0.3),
-        ]);
+    fn test_strategy_rejects_out_of_range() {
+        assert!(PreflopStrategy::new(1.5, 0.0).is_err());
+        assert!(PreflopStrategy::new(-0.1, 0.0).is_err());
+        assert!(PreflopStrategy::new(0.0, 1.5).is_err());
+        assert!(PreflopStrategy::new(0.0, -0.1).is_err());
+    }
+
+    #[test]
+    fn test_strategy_rejects_sum_over_one() {
+        let result = PreflopStrategy::new(0.6, 0.5);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_strategy_invalid_sum_too_high() {
-        let result = PreflopStrategy::new(vec![
-            (PreflopActionType::Raise, 0.7),
-            (PreflopActionType::Call, 0.5),
-        ]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_strategy_tolerance() {
-        // Should accept small floating point errors
-        let strategy = PreflopStrategy::new(vec![
-            (PreflopActionType::Raise, 0.333),
-            (PreflopActionType::Call, 0.333),
-            (PreflopActionType::Fold, 0.334),
-        ])
-        .unwrap();
-
-        // Sum is 1.0 within tolerance
-        let total: f32 = strategy.frequencies().iter().map(|(_, f)| f).sum();
-        assert!((total - 1.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_strategy_filters_zero() {
-        let strategy = PreflopStrategy::new(vec![
-            (PreflopActionType::Raise, 1.0),
-            (PreflopActionType::Call, 0.0),
-            (PreflopActionType::Fold, 0.0),
-        ])
-        .unwrap();
-
-        // Zero frequencies should be filtered out
-        assert_eq!(strategy.frequencies().len(), 1);
+    fn test_strategy_allows_partial_sum() {
+        let s = PreflopStrategy::new(0.5, 0.0).unwrap();
+        assert!((s.fold_freq() - 0.5).abs() < 1e-5);
     }
 
     #[test]
     fn test_strategy_sample() {
-        let strategy = PreflopStrategy::new(vec![
-            (PreflopActionType::Raise, 0.5),
-            (PreflopActionType::Call, 0.3),
-            (PreflopActionType::Fold, 0.2),
-        ])
-        .unwrap();
-
-        // Test boundary conditions
-        assert_eq!(strategy.sample(0.0), PreflopActionType::Raise);
-        assert_eq!(strategy.sample(0.49), PreflopActionType::Raise);
-        assert_eq!(strategy.sample(0.5), PreflopActionType::Call);
-        assert_eq!(strategy.sample(0.79), PreflopActionType::Call);
-        assert_eq!(strategy.sample(0.8), PreflopActionType::Fold);
-        assert_eq!(strategy.sample(0.99), PreflopActionType::Fold);
+        let s = PreflopStrategy::new(0.5, 0.3).unwrap();
+        assert_eq!(s.sample(0.0), PreflopActionType::Raise);
+        assert_eq!(s.sample(0.49), PreflopActionType::Raise);
+        assert_eq!(s.sample(0.5), PreflopActionType::Call);
+        assert_eq!(s.sample(0.79), PreflopActionType::Call);
+        assert_eq!(s.sample(0.85), PreflopActionType::Fold);
     }
 
     #[test]
-    fn test_strategy_default() {
-        let strategy = PreflopStrategy::default();
-        assert_eq!(strategy.frequency(PreflopActionType::Fold), 1.0);
+    fn test_strategy_default_is_fold() {
+        let s = PreflopStrategy::default();
+        assert!(s.is_pure_fold());
     }
 
     // ========== PreflopChart tests ==========
@@ -874,72 +651,66 @@ mod tests {
     fn test_chart_get_set() {
         let mut chart = PreflopChart::new();
         let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-
         assert!(chart.get(&aa).is_none());
-
-        chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
-
-        assert!(chart.get(&aa).is_some());
-        assert_eq!(
-            chart.get(&aa).unwrap().frequency(PreflopActionType::Raise),
-            1.0
-        );
+        chart.set(aa, PreflopStrategy::pure_raise());
+        assert_eq!(chart.get(&aa).unwrap().raise(), 1.0);
     }
 
     #[test]
     fn test_chart_get_or_fold() {
         let chart = PreflopChart::new();
         let unknown = PreflopHand::new(Value::Seven, Value::Two, false);
-
         let strategy = chart.get_or_fold(&unknown);
-        assert_eq!(strategy.frequency(PreflopActionType::Fold), 1.0);
+        assert!(strategy.is_pure_fold());
     }
 
     #[test]
     fn test_chart_remove() {
         let mut chart = PreflopChart::new();
         let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-
-        chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
+        chart.set(aa, PreflopStrategy::pure_raise());
         assert_eq!(chart.len(), 1);
-
-        let removed = chart.remove(&aa);
-        assert!(removed.is_some());
+        assert!(chart.remove(&aa).is_some());
         assert_eq!(chart.len(), 0);
-
-        // Remove non-existent
-        let removed = chart.remove(&aa);
-        assert!(removed.is_none());
-    }
-
-    #[test]
-    fn test_chart_iter() {
-        let mut chart = PreflopChart::new();
-        let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-        let kk = PreflopHand::new(Value::King, Value::King, false);
-
-        chart.set(aa, PreflopStrategy::pure(PreflopActionType::Raise));
-        chart.set(kk, PreflopStrategy::pure(PreflopActionType::ThreeBet));
-
-        let count = chart.iter().count();
-        assert_eq!(count, 2);
+        assert!(chart.remove(&aa).is_none());
     }
 
     #[test]
     fn test_chart_len_is_empty() {
         let mut chart = PreflopChart::new();
         assert!(chart.is_empty());
-        assert_eq!(chart.len(), 0);
-
         chart.set(
             PreflopHand::new(Value::Ace, Value::Ace, false),
-            PreflopStrategy::pure(PreflopActionType::Raise),
+            PreflopStrategy::pure_raise(),
         );
         assert!(!chart.is_empty());
         assert_eq!(chart.len(), 1);
     }
 
-    // ========== Serde tests (feature-gated) ==========
+    // ========== PreflopScenario tests ==========
+
+    #[test]
+    fn test_scenario_from_raise_count() {
+        assert_eq!(PreflopScenario::from_raise_count(0), PreflopScenario::Rfi);
+        assert_eq!(
+            PreflopScenario::from_raise_count(1),
+            PreflopScenario::VsOpen
+        );
+        assert_eq!(
+            PreflopScenario::from_raise_count(2),
+            PreflopScenario::Vs3Bet
+        );
+        assert_eq!(
+            PreflopScenario::from_raise_count(3),
+            PreflopScenario::Vs4Bet
+        );
+        assert_eq!(
+            PreflopScenario::from_raise_count(10),
+            PreflopScenario::Vs4Bet
+        );
+    }
+
+    // ========== Serde tests ==========
 
     #[cfg(feature = "serde")]
     mod serde_tests {
@@ -950,40 +721,59 @@ mod tests {
             let hand = PreflopHand::new(Value::Ace, Value::King, true);
             let json = serde_json::to_string(&hand).unwrap();
             assert_eq!(json, "\"AKs\"");
-
             let parsed: PreflopHand = serde_json::from_str(&json).unwrap();
             assert_eq!(hand, parsed);
         }
 
         #[test]
         fn test_serde_action_type() {
-            let action = PreflopActionType::ThreeBet;
+            let action = PreflopActionType::Raise;
             let json = serde_json::to_string(&action).unwrap();
-            assert_eq!(json, "\"ThreeBet\"");
-
+            assert_eq!(json, "\"Raise\"");
             let parsed: PreflopActionType = serde_json::from_str(&json).unwrap();
             assert_eq!(action, parsed);
         }
 
         #[test]
-        fn test_serde_strategy_roundtrip() {
-            let strategy = PreflopStrategy::new(vec![
-                (PreflopActionType::Raise, 0.7),
-                (PreflopActionType::Call, 0.3),
-            ])
-            .unwrap();
+        fn test_serde_strategy_minimal() {
+            // {} should deserialize as pure-fold.
+            let s: PreflopStrategy = serde_json::from_str("{}").unwrap();
+            assert!(s.is_pure_fold());
+        }
 
-            let json = serde_json::to_string(&strategy).unwrap();
-            let parsed: PreflopStrategy = serde_json::from_str(&json).unwrap();
+        #[test]
+        fn test_serde_strategy_raise_only() {
+            // {"raise": 1.0} should deserialize with call=0.
+            let s: PreflopStrategy = serde_json::from_str(r#"{"raise": 1.0}"#).unwrap();
+            assert_eq!(s.raise(), 1.0);
+            assert_eq!(s.call(), 0.0);
+        }
 
-            assert_eq!(
-                strategy.frequency(PreflopActionType::Raise),
-                parsed.frequency(PreflopActionType::Raise)
-            );
-            assert_eq!(
-                strategy.frequency(PreflopActionType::Call),
-                parsed.frequency(PreflopActionType::Call)
-            );
+        #[test]
+        fn test_serde_strategy_call_only() {
+            let s: PreflopStrategy = serde_json::from_str(r#"{"call": 0.5}"#).unwrap();
+            assert_eq!(s.raise(), 0.0);
+            assert_eq!(s.call(), 0.5);
+        }
+
+        #[test]
+        fn test_serde_strategy_both() {
+            let s: PreflopStrategy =
+                serde_json::from_str(r#"{"raise": 0.5, "call": 0.3}"#).unwrap();
+            assert_eq!(s.raise(), 0.5);
+            assert_eq!(s.call(), 0.3);
+        }
+
+        #[test]
+        fn test_serde_strategy_skip_zero() {
+            // Zero fields should not appear in output.
+            let s = PreflopStrategy::pure_raise();
+            let json = serde_json::to_string(&s).unwrap();
+            assert_eq!(json, r#"{"raise":1.0}"#);
+
+            let s = PreflopStrategy::fold();
+            let json = serde_json::to_string(&s).unwrap();
+            assert_eq!(json, "{}");
         }
 
         #[test]
@@ -991,38 +781,24 @@ mod tests {
             let mut chart = PreflopChart::new();
             chart.set(
                 PreflopHand::new(Value::Ace, Value::Ace, false),
-                PreflopStrategy::new(vec![
-                    (PreflopActionType::ThreeBet, 0.85),
-                    (PreflopActionType::Call, 0.15),
-                ])
-                .unwrap(),
+                PreflopStrategy::new(0.85, 0.15).unwrap(),
             );
             chart.set(
                 PreflopHand::new(Value::Ace, Value::King, true),
-                PreflopStrategy::new(vec![
-                    (PreflopActionType::ThreeBet, 0.50),
-                    (PreflopActionType::Call, 0.40),
-                    (PreflopActionType::Fold, 0.10),
-                ])
-                .unwrap(),
+                PreflopStrategy::pure_raise(),
             );
 
-            let json = serde_json::to_string_pretty(&chart).unwrap();
+            let json = serde_json::to_string(&chart).unwrap();
             let parsed: PreflopChart = serde_json::from_str(&json).unwrap();
+            assert_eq!(chart, parsed);
+        }
 
-            assert_eq!(chart.len(), parsed.len());
-
-            let aa = PreflopHand::new(Value::Ace, Value::Ace, false);
-            assert_eq!(
-                chart
-                    .get(&aa)
-                    .unwrap()
-                    .frequency(PreflopActionType::ThreeBet),
-                parsed
-                    .get(&aa)
-                    .unwrap()
-                    .frequency(PreflopActionType::ThreeBet)
-            );
+        #[test]
+        fn test_serde_chart_transparent() {
+            // PreflopChart serializes as the underlying map.
+            let chart = PreflopChart::new();
+            let json = serde_json::to_string(&chart).unwrap();
+            assert_eq!(json, "{}");
         }
     }
 }


### PR DESCRIPTION
Rework the preflop chart system around (position, scenario) — each
`PositionCharts` holds one `PreflopChart` per scenario (rfi/vs_open/
vs_3bet/vs_4bet), replacing the labeled Raise/ThreeBet/FourBet scheme
that tried to pack every scenario into one strategy. `PreflopStrategy`
collapses to `{raise, call}` with fold implicit; both fields are
optional in JSON so the common `{"raise": 1.0}` case is terse. A new
`four_bet_plus_multiplier` (default 2.5) sizes 4-bet raises in Vs3Bet.

Adds `rsp arena charts` (interactive TUI hand-grid viewer with
auto-switching to a non-empty scenario when seats change) and
`rsp arena verify` with `--summary` for combo-weighted range stats per
position/scenario. The in-tree example config is rewritten in the new
format; a one-shot migration script for local configs lives outside
the tree.
