### PR TITLE
feat(tui): normalize game log won/loss/pot to big blinds

### DIFF
--- a/src/bin/rsp/tui/state.rs
+++ b/src/bin/rsp/tui/state.rs
@@ -439,17 +439,18 @@ impl FilterState {
             return false;
         }
 
-        // Win size filter: bucket of winner's profit in BB
-        if !self.win_sizes.is_empty() && entry.big_blind > 0.0 {
-            let bucket = ProfitBucket::from_bb(entry.winner_profit / entry.big_blind);
+        // Win size filter: bucket of winner's profit (already in BB; a zero-bb
+        // entry buckets as Small, so no big-blind guard is needed here).
+        if !self.win_sizes.is_empty() {
+            let bucket = ProfitBucket::from_bb(entry.winner_profit);
             if !self.win_sizes.contains(&bucket) {
                 return false;
             }
         }
 
         // Loss size filter: bucket of loser's loss in BB
-        if !self.loss_sizes.is_empty() && entry.big_blind > 0.0 {
-            let bucket = ProfitBucket::from_bb(entry.loser_loss.abs() / entry.big_blind);
+        if !self.loss_sizes.is_empty() {
+            let bucket = ProfitBucket::from_bb(entry.loser_loss.abs());
             if !self.loss_sizes.contains(&bucket) {
                 return false;
             }
@@ -518,17 +519,22 @@ pub const ALL_PROFIT_BUCKETS: [ProfitBucket; 4] = [
 ];
 
 /// A single entry in the game log.
+///
+/// All chip amounts are normalized to big blinds using the game's big blind,
+/// matching the rest of the arena stats output.
 #[derive(Debug, Clone)]
 pub struct GameLogEntry {
     pub game_number: usize,
     pub agent_names: Vec<String>,
     pub ending_round: RoundLabel,
     pub winner_name: String,
+    /// Winner's profit in big blinds.
     pub winner_profit: f32,
     pub loser_name: String,
+    /// Loser's loss (negative) in big blinds.
     pub loser_loss: f32,
+    /// Pot size in big blinds.
     pub pot_size: f32,
-    pub big_blind: f32,
 }
 
 impl GameLogEntry {
@@ -540,21 +546,32 @@ impl GameLogEntry {
         ending_round: RoundLabel,
         big_blind: f32,
     ) -> Self {
+        // Normalize chip amounts to big blinds. A non-positive big blind never
+        // occurs in a real game; we treat it as 0 bb so the value still buckets
+        // as `ProfitBucket::Small` rather than producing inf/NaN from a divide.
+        let to_bb = |chips: f32| {
+            if big_blind > 0.0 {
+                chips / big_blind
+            } else {
+                0.0
+            }
+        };
+
         let (winner_name, winner_profit) = agent_names
             .iter()
             .zip(profits.iter())
             .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(n, &p)| (n.clone(), p))
+            .map(|(n, &p)| (n.clone(), to_bb(p)))
             .unwrap_or_default();
 
         let (loser_name, loser_loss) = agent_names
             .iter()
             .zip(profits.iter())
             .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(n, &p)| (n.clone(), p))
+            .map(|(n, &p)| (n.clone(), to_bb(p)))
             .unwrap_or_default();
 
-        let pot_size: f32 = profits.iter().filter(|&&p| p > 0.0).sum();
+        let pot_size: f32 = to_bb(profits.iter().filter(|&&p| p > 0.0).sum());
 
         Self {
             game_number,
@@ -565,7 +582,6 @@ impl GameLogEntry {
             loser_name,
             loser_loss,
             pot_size,
-            big_blind,
         }
     }
 
@@ -1085,13 +1101,13 @@ mod tests {
 
     #[test]
     fn test_game_log_entry_new_derived_fields() {
+        // big blind of 10.0 → chip amounts normalized to big blinds.
         let entry = make_entry(1, &["Alice", "Bob"], &[15.0, -15.0], RoundLabel::River);
         assert_eq!(entry.winner_name, "Alice");
-        assert!((entry.winner_profit - 15.0).abs() < 0.01);
+        assert!((entry.winner_profit - 1.5).abs() < 0.01);
         assert_eq!(entry.loser_name, "Bob");
-        assert!((entry.loser_loss - (-15.0)).abs() < 0.01);
-        assert!((entry.pot_size - 15.0).abs() < 0.01);
-        assert!((entry.big_blind - 10.0).abs() < 0.01);
+        assert!((entry.loser_loss - (-1.5)).abs() < 0.01);
+        assert!((entry.pot_size - 1.5).abs() < 0.01);
     }
 
     #[test]
@@ -1103,10 +1119,10 @@ mod tests {
             RoundLabel::Showdown,
         );
         assert_eq!(entry.winner_name, "A");
-        assert!((entry.winner_profit - 20.0).abs() < 0.01);
+        assert!((entry.winner_profit - 2.0).abs() < 0.01);
         assert_eq!(entry.loser_name, "C");
-        assert!((entry.loser_loss - (-15.0)).abs() < 0.01);
-        assert!((entry.pot_size - 20.0).abs() < 0.01);
+        assert!((entry.loser_loss - (-1.5)).abs() < 0.01);
+        assert!((entry.pot_size - 2.0).abs() < 0.01);
     }
 
     #[test]

--- a/src/bin/rsp/tui/widgets/game_log.rs
+++ b/src/bin/rsp/tui/widgets/game_log.rs
@@ -24,10 +24,10 @@ fn entry_to_row(entry: &GameLogEntry, agent_colors: &HashMap<&str, Color>) -> Ro
     let cells = vec![
         Cell::from(format!("{}", entry.game_number)).style(Style::default().fg(OVERLAY0)),
         Cell::from(entry.winner_name.clone()).style(Style::default().fg(winner_color)),
-        Cell::from(format!("{:+.0}", entry.winner_profit)).style(profit_style(entry.winner_profit)),
+        Cell::from(format!("{:+.1}", entry.winner_profit)).style(profit_style(entry.winner_profit)),
         Cell::from(entry.loser_name.clone()).style(Style::default().fg(loser_color)),
-        Cell::from(format!("{:+.0}", entry.loser_loss)).style(profit_style(entry.loser_loss)),
-        Cell::from(format!("{:.0}", entry.pot_size)).style(Style::default().fg(TEXT)),
+        Cell::from(format!("{:+.1}", entry.loser_loss)).style(profit_style(entry.loser_loss)),
+        Cell::from(format!("{:.1}", entry.pot_size)).style(Style::default().fg(TEXT)),
         Cell::from(format!("{}", entry.ending_round)).style(Style::default().fg(OVERLAY0)),
     ];
     Row::new(cells)
@@ -52,10 +52,10 @@ pub fn render_game_log(
     let header_cells = vec![
         Cell::from("#").style(header_style()),
         Cell::from("Winner").style(header_style()),
-        Cell::from("Win").style(header_style()),
+        Cell::from("Win(bb)").style(header_style()),
         Cell::from("Loser").style(header_style()),
-        Cell::from("Loss").style(header_style()),
-        Cell::from("Pot").style(header_style()),
+        Cell::from("Loss(bb)").style(header_style()),
+        Cell::from("Pot(bb)").style(header_style()),
         Cell::from("Street").style(header_style()),
     ];
     let header = Row::new(header_cells).height(1).bottom_margin(1);

--- a/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log.snap
+++ b/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log.snap
@@ -1,12 +1,14 @@
 ---
 source: src/bin/rsp/tui/widgets/game_log.rs
+assertion_line: 149
 expression: terminal.backend()
+snapshot_kind: text
 ---
 "╭ ♥ Recent Games ──────────────────────────────────────────────────────────────╮"
-"│ #       Winner          Win      Loser           Loss     Pot      Street    │"
+"│ #       Winner          Win(bb)  Loser           Loss(bb) Pot(bb)  Street    │"
 "│                                                                              │"
-"│ 1       Alice           +15      Bob             -15      15       river     │"
-"│ 2       Bob             +5       Alice           -5       5        flop      │"
+"│ 1       Alice           +1.5     Bob             -1.5     1.5      river     │"
+"│ 2       Bob             +0.5     Alice           -0.5     0.5      flop      │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log_empty.snap
+++ b/src/bin/rsp/tui/widgets/snapshots/rsp__tui__widgets__game_log__tests__render_game_log_empty.snap
@@ -1,9 +1,11 @@
 ---
 source: src/bin/rsp/tui/widgets/game_log.rs
+assertion_line: 162
 expression: terminal.backend()
+snapshot_kind: text
 ---
 "╭ ♥ Recent Games ──────────────────────────────────────────────────────────────╮"
-"│ #       Winner          Win      Loser           Loss     Pot      Street    │"
+"│ #       Winner          Win(bb)  Loser           Loss(bb) Pot(bb)  Street    │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"


### PR DESCRIPTION
Summary:
The recent-games list rendered won, loss, and pot as raw chip counts
while the rest of the arena stats are reported in big blinds. Normalize
these columns to big blinds at the source.

GameLogEntry::new now divides winner_profit, loser_loss, and pot_size by
the game's big blind (guarding against a zero big blind), so the stored
values are already in BB. The redundant big_blind field is removed; the
win/loss-size filter buckets use the normalized values directly instead
of re-dividing, and the game log widget formats the columns as floats
(Win(bb)/Loss(bb)/Pot(bb)) matching the stats table convention.

Test Plan:
mise check (fmt, clippy, 1228 nextest tests, doctests) all pass;
game_log snapshot tests updated.
