### PR TITLE
feat: hand estimator and game state generation in CFR

### DIFF
--- a/benches/cfr.rs
+++ b/benches/cfr.rs
@@ -1,7 +1,16 @@
+use std::sync::Arc;
+
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rs_poker::arena::agent::ConfigAgentBuilder;
-use rs_poker::arena::cfr::{CFRState, TraversalSet};
-use rs_poker::arena::{Agent, GameStateBuilder, HoldemSimulationBuilder};
+use rs_poker::arena::cfr::{
+    BudgetConfig, BudgetItem, CFRAgentBuilder, CFRState, ConfigurableActionConfig,
+    ConfigurableActionGenerator, TraversalSet,
+};
+use rs_poker::arena::hand_estimator::KnownHandsEstimator;
+use rs_poker::arena::{
+    Agent, GameLog, GameState, GameStateBuilder, HandDistributionEstimator,
+    HoldemSimulationBuilder, OpponentRanges,
+};
 
 const STARTING_STACK: f32 = 100_000.0;
 const ANTE: f32 = 50.0;
@@ -187,5 +196,112 @@ fn bench_cfr_multi_thread(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_cfr_single_thread, bench_cfr_multi_thread);
+/// A `needs_history` stub estimator. Sampling semantics are identical to
+/// `KnownHandsEstimator`, but `needs_history()` returns `true`, which activates
+/// the copy-on-write `HandLog` path (freeze at depth 0, copy-tail descent,
+/// per-sim `HandLogHistorian`). Because sampling is unchanged, this isolates the
+/// logging overhead of the history path versus the no-history default groups.
+#[derive(Default)]
+struct HistoryNeedingKnown;
+
+#[async_trait::async_trait]
+impl HandDistributionEstimator for HistoryNeedingKnown {
+    async fn estimate(
+        &self,
+        game_state: &GameState,
+        _history: Option<&GameLog<'_>>,
+    ) -> OpponentRanges {
+        KnownHandsEstimator.estimate(game_state, None).await
+    }
+
+    fn needs_history(&self) -> bool {
+        true
+    }
+}
+
+/// Build a 2-player CFR simulation whose agents use the `HistoryNeedingKnown`
+/// estimator, exercising the `HandLog` history path.
+///
+/// Agents are built DIRECTLY (not via JSON) so a custom estimator can be
+/// injected. The budget matches `build_sim`'s `per_depth_iterations` workload
+/// (`[num_hands, 5, 1]`) so old-vs-new and history-vs-default comparisons use
+/// the same exploration size.
+fn build_sim_with_history(num_hands: usize) -> rs_poker::arena::HoldemSimulation {
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    let game_state = GameStateBuilder::new()
+        .num_players_with_stack(2, STARTING_STACK)
+        .blinds(BIG_BLIND, SMALL_BLIND)
+        .ante(ANTE)
+        .build()
+        .unwrap();
+
+    let cfr_state = CFRState::new(game_state.clone());
+    let traversal_set = TraversalSet::new(2);
+
+    let budget = BudgetConfig(vec![BudgetItem::PerDepthIterations {
+        counts: vec![num_hands as u64, 5, 1],
+        fallback: 1,
+    }])
+    .build();
+
+    let agents: Vec<Box<dyn Agent>> = (0..2)
+        .map(|idx| {
+            Box::new(
+                CFRAgentBuilder::<ConfigurableActionGenerator>::new()
+                    .name(format!("CFR-History-{idx}"))
+                    .player_idx(idx)
+                    .cfr_state(cfr_state.clone())
+                    .traversal_set(traversal_set.clone())
+                    .budget(budget.clone())
+                    .estimator(Arc::new(HistoryNeedingKnown))
+                    .action_gen_config(ConfigurableActionConfig::default())
+                    .build(),
+            ) as Box<dyn Agent>
+        })
+        .collect();
+
+    HoldemSimulationBuilder::default()
+        .game_state(game_state)
+        .agents(agents)
+        .cfr_context(cfr_state, traversal_set, true)
+        .build_with_rng(StdRng::seed_from_u64(BENCH_SEED))
+        .unwrap()
+}
+
+/// History-path latency. Same single-threaded setup as
+/// `bench_cfr_single_thread`, but every agent's estimator returns
+/// `needs_history() == true`, so the `HandLog` recording path runs. Unlike the
+/// default groups this measures raw per-game wall time (no `Throughput`
+/// normalization), since the point is the absolute logging overhead. Compare
+/// against the default groups (same budget) to read that overhead.
+fn bench_cfr_history(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let mut group = c.benchmark_group("cfr_history");
+
+    for num_hands in [5, 15] {
+        group.bench_with_input(
+            BenchmarkId::new("num_hands", num_hands),
+            &num_hands,
+            |b, &num_hands| {
+                b.iter_batched(
+                    || build_sim_with_history(num_hands),
+                    |sim| rt.block_on(run_sim(sim)),
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_cfr_single_thread,
+    bench_cfr_multi_thread,
+    bench_cfr_history
+);
 criterion_main!(benches);

--- a/examples/configs/cfr_configurable.json
+++ b/examples/configs/cfr_configurable.json
@@ -1,6 +1,7 @@
 {
     "type": "cfr_configurable",
     "name": "CFR-Configurable",
+    "hand_estimator": "known",
     "exploration": {
         "budget": [
             {

--- a/src/arena/agent/config.rs
+++ b/src/arena/agent/config.rs
@@ -358,7 +358,7 @@ pub struct CfrExploration {
 
 /// Which opponent hand-distribution estimator a CFR agent uses.
 // Task 12 will wire this into AgentConfig variants; suppress dead_code until then.
-#[expect(dead_code, reason = "wired into AgentConfig variants in Task 12")]
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EstimatorConfig {
@@ -371,7 +371,7 @@ pub enum EstimatorConfig {
 
 impl EstimatorConfig {
     /// Construct the configured estimator.
-    #[expect(dead_code, reason = "called from AgentConfig variants in Task 12")]
+    #[allow(dead_code)]
     pub fn build(&self) -> Arc<dyn HandDistributionEstimator> {
         match self {
             EstimatorConfig::Known => Arc::new(KnownHandsEstimator),

--- a/src/arena/agent/config.rs
+++ b/src/arena/agent/config.rs
@@ -227,6 +227,10 @@ pub enum AgentConfig {
         /// and the per-action real-time ceiling.
         #[serde(default)]
         exploration: CfrExploration,
+        /// Which hand estimator the agent uses for its opponents. Defaults to
+        /// `known` (today's behavior).
+        #[serde(default)]
+        hand_estimator: EstimatorConfig,
     },
     /// CFR agent with SimpleActionGenerator (more bet sizing options)
     ///
@@ -239,6 +243,10 @@ pub enum AgentConfig {
         /// and the per-action real-time ceiling.
         #[serde(default)]
         exploration: CfrExploration,
+        /// Which hand estimator the agent uses for its opponents. Defaults to
+        /// `known` (today's behavior).
+        #[serde(default)]
+        hand_estimator: EstimatorConfig,
     },
     /// CFR agent with configurable action generator
     ///
@@ -255,6 +263,10 @@ pub enum AgentConfig {
         /// and the per-action real-time ceiling.
         #[serde(default)]
         exploration: CfrExploration,
+        /// Which hand estimator the agent uses for its opponents. Defaults to
+        /// `known` (today's behavior).
+        #[serde(default)]
+        hand_estimator: EstimatorConfig,
         /// Action generator configuration
         action_config: Box<ConfigurableActionConfig>,
     },
@@ -271,6 +283,10 @@ pub enum AgentConfig {
         /// budget, wave width, and the per-action real-time ceiling.
         #[serde(default)]
         exploration: CfrExploration,
+        /// Which hand estimator the agent uses for its opponents. Defaults to
+        /// `known` (today's behavior).
+        #[serde(default)]
+        hand_estimator: EstimatorConfig,
         /// Preflop chart configuration (inline or preset name)
         #[serde(default)]
         preflop_config: PreflopChartConfigOption,
@@ -356,10 +372,9 @@ pub struct CfrExploration {
     pub budget: Option<BudgetConfig>,
 }
 
-/// Which opponent hand-distribution estimator a CFR agent uses.
-// Task 12 will wire this into AgentConfig variants; suppress dead_code until then.
-#[allow(dead_code)]
+/// Which hand-distribution estimator a CFR agent uses for its opponents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "snake_case")]
 pub enum EstimatorConfig {
     /// Use the real opponent hands (today's behavior). Default.
@@ -371,7 +386,6 @@ pub enum EstimatorConfig {
 
 impl EstimatorConfig {
     /// Construct the configured estimator.
-    #[allow(dead_code)]
     pub fn build(&self) -> Arc<dyn HandDistributionEstimator> {
         match self {
             EstimatorConfig::Known => Arc::new(KnownHandsEstimator),
@@ -694,7 +708,11 @@ impl ConfigAgentBuilder {
                     Box::new(RandomPotControlAgent::new(agent_name, percent_call.clone()))
                 }
             }
-            AgentConfig::CfrBasic { name, exploration } => {
+            AgentConfig::CfrBasic {
+                name,
+                exploration,
+                hand_estimator,
+            } => {
                 let (cfr_state, traversal_set) = self.resolve_cfr_context();
                 let budget = exploration.budget.clone().unwrap_or_default().build();
                 let builder = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
@@ -703,10 +721,15 @@ impl ConfigAgentBuilder {
                     .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .budget(budget)
+                    .estimator(hand_estimator.build())
                     .action_gen_config(());
                 Box::new(builder.build())
             }
-            AgentConfig::CfrSimple { name, exploration } => {
+            AgentConfig::CfrSimple {
+                name,
+                exploration,
+                hand_estimator,
+            } => {
                 let (cfr_state, traversal_set) = self.resolve_cfr_context();
                 let budget = exploration.budget.clone().unwrap_or_default().build();
                 let builder = CFRAgentBuilder::<SimpleActionGenerator>::new()
@@ -715,12 +738,14 @@ impl ConfigAgentBuilder {
                     .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .budget(budget)
+                    .estimator(hand_estimator.build())
                     .action_gen_config(());
                 Box::new(builder.build())
             }
             AgentConfig::CfrConfigurable {
                 name,
                 exploration,
+                hand_estimator,
                 action_config,
             } => {
                 let (cfr_state, traversal_set) = self.resolve_cfr_context();
@@ -731,12 +756,14 @@ impl ConfigAgentBuilder {
                     .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .budget(budget)
+                    .estimator(hand_estimator.build())
                     .action_gen_config(action_config.as_ref().clone());
                 Box::new(builder.build())
             }
             AgentConfig::CfrPreflopChart {
                 name,
                 exploration,
+                hand_estimator,
                 preflop_config,
                 postflop_config,
             } => {
@@ -758,6 +785,7 @@ impl ConfigAgentBuilder {
                     .cfr_state(cfr_state)
                     .traversal_set(traversal_set)
                     .budget(budget)
+                    .estimator(hand_estimator.build())
                     .action_gen_config(action_config);
                 Box::new(builder.build())
             }
@@ -1034,7 +1062,9 @@ mod tests {
         }"#;
         let config: AgentConfig = serde_json::from_str(json).unwrap();
         match config {
-            AgentConfig::CfrBasic { name, exploration } => {
+            AgentConfig::CfrBasic {
+                name, exploration, ..
+            } => {
                 assert!(name.is_none());
                 assert_eq!(
                     exploration.budget,
@@ -1053,7 +1083,9 @@ mod tests {
         let json = r#"{"type":"cfr_basic"}"#;
         let config: AgentConfig = serde_json::from_str(json).unwrap();
         match config {
-            AgentConfig::CfrBasic { name, exploration } => {
+            AgentConfig::CfrBasic {
+                name, exploration, ..
+            } => {
                 assert!(name.is_none());
                 assert_eq!(exploration, CfrExploration::default());
                 // Default = budget unset; the build path will substitute
@@ -1106,6 +1138,7 @@ mod tests {
                     fallback: 1,
                 }])),
             },
+            hand_estimator: EstimatorConfig::default(),
         };
         let game_state = GameStateBuilder::new()
             .num_players_with_stack(2, 100.0)
@@ -1130,6 +1163,7 @@ mod tests {
                     fallback: 1,
                 }])),
             },
+            hand_estimator: EstimatorConfig::default(),
         };
         let game_state = GameStateBuilder::new()
             .num_players_with_stack(3, 100.0)
@@ -1263,6 +1297,7 @@ mod tests {
         let mut none_cfg = AgentConfig::CfrBasic {
             name: None,
             exploration: CfrExploration::default(),
+            hand_estimator: EstimatorConfig::default(),
         };
         let custom = BudgetConfig(vec![BudgetItem::IterationCount { max: 7 }]);
         none_cfg.fill_default_budget(&custom);
@@ -1279,6 +1314,7 @@ mod tests {
             exploration: CfrExploration {
                 budget: Some(explicit.clone()),
             },
+            hand_estimator: EstimatorConfig::default(),
         };
         some_cfg.fill_default_budget(&custom);
         match &some_cfg {
@@ -1309,13 +1345,72 @@ mod tests {
     }
 
     #[test]
-    fn hand_estimator_config_defaults_to_known() {
+    fn estimator_config_defaults_to_known() {
         assert_eq!(EstimatorConfig::default(), EstimatorConfig::Known);
     }
 
     #[test]
-    fn hand_estimator_config_round_trips_json() {
+    fn estimator_config_round_trips_json() {
         let parsed: EstimatorConfig = serde_json::from_str("\"uniform\"").unwrap();
         assert_eq!(parsed, EstimatorConfig::Uniform);
+    }
+
+    #[tokio::test]
+    async fn estimator_config_builds_estimator() {
+        use crate::arena::hand_estimator::HandDistribution;
+        use crate::core::{Card, Hand};
+
+        let mut game_state = GameStateBuilder::new()
+            .num_players_with_stack(2, 100.0)
+            .blinds(10.0, 5.0)
+            .build()
+            .unwrap();
+        game_state.hands[0] = Hand::new_with_cards(vec![Card::from(0), Card::from(1)]);
+        game_state.hands[1] = Hand::new_with_cards(vec![Card::from(2), Card::from(3)]);
+        game_state.round_data.to_act_idx = 0;
+
+        // Known maps to the point-mass estimator; Uniform to the weighted one.
+        let known = EstimatorConfig::Known
+            .build()
+            .estimate(&game_state, None)
+            .await;
+        assert!(matches!(known.get(1), Some(HandDistribution::PointMass(_))));
+
+        let uniform = EstimatorConfig::Uniform
+            .build()
+            .estimate(&game_state, None)
+            .await;
+        assert!(matches!(
+            uniform.get(1),
+            Some(HandDistribution::Weighted(_))
+        ));
+    }
+
+    #[test]
+    fn cfr_configurable_parses_hand_estimator() {
+        let json = r#"{
+            "type": "cfr_configurable",
+            "hand_estimator": "uniform",
+            "action_config": {}
+        }"#;
+        let cfg: AgentConfig = serde_json::from_str(json).unwrap();
+        match cfg {
+            AgentConfig::CfrConfigurable { hand_estimator, .. } => {
+                assert_eq!(hand_estimator, EstimatorConfig::Uniform);
+            }
+            other => panic!("expected CfrConfigurable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cfr_configurable_defaults_hand_estimator_to_known() {
+        let json = r#"{ "type": "cfr_configurable", "action_config": {} }"#;
+        let cfg: AgentConfig = serde_json::from_str(json).unwrap();
+        match cfg {
+            AgentConfig::CfrConfigurable { hand_estimator, .. } => {
+                assert_eq!(hand_estimator, EstimatorConfig::Known);
+            }
+            other => panic!("expected CfrConfigurable, got {other:?}"),
+        }
     }
 }

--- a/src/arena/agent/config.rs
+++ b/src/arena/agent/config.rs
@@ -153,6 +153,8 @@
 //! 2. **Update `ConfigAgentBuilder::build()`** to handle new CFR types
 //! 3. **Add appropriate tests and examples**
 
+use std::sync::Arc;
+
 use crate::arena::agent::{
     AllInAgent, CallingAgent, FoldingAgent, RandomAgent, RandomPotControlAgent,
 };
@@ -161,6 +163,9 @@ use crate::arena::cfr::{
     ConfigurableActionConfigError, ConfigurableActionGenerator, PreflopChartActionConfig,
     PreflopChartActionGenerator, PreflopChartConfig, PreflopChartConfigError,
     SimpleActionGenerator, TraversalSet,
+};
+use crate::arena::hand_estimator::{
+    HandDistributionEstimator, KnownHandsEstimator, UniformRandomEstimator,
 };
 use crate::arena::{Agent, GameState};
 use serde::{Deserialize, Serialize};
@@ -349,6 +354,30 @@ pub struct CfrExploration {
     /// one comparison.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget: Option<BudgetConfig>,
+}
+
+/// Which opponent hand-distribution estimator a CFR agent uses.
+// Task 12 will wire this into AgentConfig variants; suppress dead_code until then.
+#[expect(dead_code, reason = "wired into AgentConfig variants in Task 12")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EstimatorConfig {
+    /// Use the real opponent hands (today's behavior). Default.
+    #[default]
+    Known,
+    /// Sample opponents uniformly from the remaining deck.
+    Uniform,
+}
+
+impl EstimatorConfig {
+    /// Construct the configured estimator.
+    #[expect(dead_code, reason = "called from AgentConfig variants in Task 12")]
+    pub fn build(&self) -> Arc<dyn HandDistributionEstimator> {
+        match self {
+            EstimatorConfig::Known => Arc::new(KnownHandsEstimator),
+            EstimatorConfig::Uniform => Arc::new(UniformRandomEstimator),
+        }
+    }
 }
 
 /// Errors that can occur during agent configuration
@@ -1277,5 +1306,16 @@ mod tests {
         // Test that resolve_agent_name uses provided name when Some
         let name = resolve_agent_name(&Some("CustomName".to_string()), "TestKind", 3);
         assert_eq!(name, "CustomName", "Should use provided name");
+    }
+
+    #[test]
+    fn hand_estimator_config_defaults_to_known() {
+        assert_eq!(EstimatorConfig::default(), EstimatorConfig::Known);
+    }
+
+    #[test]
+    fn hand_estimator_config_round_trips_json() {
+        let parsed: EstimatorConfig = serde_json::from_str("\"uniform\"").unwrap();
+        assert_eq!(parsed, EstimatorConfig::Uniform);
     }
 }

--- a/src/arena/cfr/agent/builder.rs
+++ b/src/arena/cfr/agent/builder.rs
@@ -9,10 +9,7 @@
 
 use std::borrow::Cow;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
-
-use crate::arena::historian::SharedHistoryStorage;
 
 use crate::arena::action::AgentAction;
 use crate::arena::{HandDistributionEstimator, hand_estimator::KnownHandsEstimator};
@@ -23,6 +20,7 @@ use super::super::{
 };
 
 use super::engine::CFRAgent;
+use super::hand_log::HandLog;
 
 pub struct CFRAgentBuilder<T>
 where
@@ -41,6 +39,7 @@ where
     budget: Option<Arc<dyn Budget>>,
     stop: Option<Arc<AtomicBool>>,
     estimator: Option<Arc<dyn HandDistributionEstimator>>,
+    hand_log: Option<HandLog>,
 }
 
 impl<T> Default for CFRAgentBuilder<T>
@@ -62,6 +61,7 @@ where
             budget: None,
             stop: None,
             estimator: None,
+            hand_log: None,
         }
     }
 }
@@ -148,7 +148,14 @@ where
             .estimator
             .unwrap_or_else(|| Arc::new(KnownHandsEstimator) as Arc<dyn HandDistributionEstimator>);
 
-        let log_storage: SharedHistoryStorage = Arc::new(Mutex::new(Vec::new()));
+        // Only agents whose estimator needs history carry a log. Sub-agents are
+        // handed one via `hand_log()`; a depth-0 agent that needs history but
+        // wasn't handed one gets a fresh log (it self-provides the historian).
+        let hand_log = if estimator.needs_history() {
+            Some(self.hand_log.unwrap_or_default())
+        } else {
+            None
+        };
 
         CFRAgent {
             name,
@@ -165,7 +172,7 @@ where
             budget,
             stop,
             estimator,
-            log_storage,
+            hand_log,
         }
     }
 
@@ -198,6 +205,14 @@ where
     /// flag.
     pub(super) fn stop_flag(mut self, stop: Arc<AtomicBool>) -> Self {
         self.stop = Some(stop);
+        self
+    }
+
+    /// Provide the per-sim copy-on-write action log. Used by
+    /// `compute_reward_recursive` to seed sub-agents (depth >= 1). Depth-0
+    /// agents normally leave this unset and get a fresh log in `build`.
+    pub(super) fn hand_log(mut self, log: HandLog) -> Self {
+        self.hand_log = Some(log);
         self
     }
 

--- a/src/arena/cfr/agent/builder.rs
+++ b/src/arena/cfr/agent/builder.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use crate::arena::action::AgentAction;
+use crate::arena::{HandDistributionEstimator, hand_estimator::KnownHandsEstimator};
 
 use super::super::{
     ActionIndexMapper, ActionIndexMapperConfig, Budget, BudgetConfig, CFRState, InFlightLimiter,
@@ -36,6 +37,7 @@ where
     limiter: Option<InFlightLimiter>,
     budget: Option<Arc<dyn Budget>>,
     stop: Option<Arc<AtomicBool>>,
+    estimator: Option<Arc<dyn HandDistributionEstimator>>,
 }
 
 impl<T> Default for CFRAgentBuilder<T>
@@ -56,6 +58,7 @@ where
             limiter: None,
             budget: None,
             stop: None,
+            estimator: None,
         }
     }
 }
@@ -138,6 +141,9 @@ where
         let stop = self
             .stop
             .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+        let estimator = self
+            .estimator
+            .unwrap_or_else(|| Arc::new(KnownHandsEstimator) as Arc<dyn HandDistributionEstimator>);
 
         CFRAgent {
             name,
@@ -153,6 +159,7 @@ where
             limiter,
             budget,
             stop,
+            estimator,
         }
     }
 
@@ -185,6 +192,13 @@ where
     /// flag.
     pub(super) fn stop_flag(mut self, stop: Arc<AtomicBool>) -> Self {
         self.stop = Some(stop);
+        self
+    }
+
+    /// Set the opponent hand-distribution estimator. Defaults to
+    /// [`KnownHandsEstimator`], which reproduces the pre-estimator behavior.
+    pub fn estimator(mut self, estimator: Arc<dyn HandDistributionEstimator>) -> Self {
+        self.estimator = Some(estimator);
         self
     }
 }

--- a/src/arena/cfr/agent/builder.rs
+++ b/src/arena/cfr/agent/builder.rs
@@ -9,7 +9,10 @@
 
 use std::borrow::Cow;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+
+use crate::arena::historian::SharedHistoryStorage;
 
 use crate::arena::action::AgentAction;
 use crate::arena::{HandDistributionEstimator, hand_estimator::KnownHandsEstimator};
@@ -145,6 +148,8 @@ where
             .estimator
             .unwrap_or_else(|| Arc::new(KnownHandsEstimator) as Arc<dyn HandDistributionEstimator>);
 
+        let log_storage: SharedHistoryStorage = Arc::new(Mutex::new(Vec::new()));
+
         CFRAgent {
             name,
             traversal_set,
@@ -160,6 +165,7 @@ where
             budget,
             stop,
             estimator,
+            log_storage,
         }
     }
 

--- a/src/arena/cfr/agent/engine.rs
+++ b/src/arena/cfr/agent/engine.rs
@@ -147,6 +147,9 @@ where
     pub(super) limiter: InFlightLimiter,
     pub(super) budget: Arc<dyn Budget>,
     pub(super) stop: Arc<AtomicBool>,
+    // Wired up in Task 10; field exists now so the builder and type are in place.
+    #[expect(dead_code)]
+    pub(super) estimator: std::sync::Arc<dyn crate::arena::HandDistributionEstimator>,
 }
 
 /// Spawn a tokio task that flips `stop` to `true` after `duration`. The

--- a/src/arena/cfr/agent/engine.rs
+++ b/src/arena/cfr/agent/engine.rs
@@ -36,6 +36,7 @@ use rand::rngs::StdRng;
 use smallvec::SmallVec;
 use tracing::event;
 
+use crate::arena::hand_estimator::{HandDistributionEstimator as _, sample_world};
 use crate::arena::{
     Agent, GameState, HoldemSimulationBuilder, action::AgentAction, game_state::Round,
 };
@@ -543,6 +544,12 @@ where
 
         let target_node_idx = self.target_node_idx().unwrap();
 
+        // ── Opponent-hand range estimate (decision 2): once per act, from
+        // this agent's own seat. Sampled per wave below. On error, warn and
+        // fall back to a uniform range so the solve never stalls (decision 6).
+        let estimator = self.estimator.clone();
+        let ranges = estimator.estimate(game_state, None).await;
+
         // Per-slot wave accumulators, reused across waves to avoid repeated Vec
         // allocations. Each wave sums every sample landing in a slot and counts
         // them; `wave_mean` then averages (slots with zero samples — pruned or
@@ -757,6 +764,21 @@ where
                 estimator: self.estimator.clone(),
             };
 
+            // ── Per-wave world (decision 2 + 9) ──
+            // Recursive waves play against a freshly sampled world (acting seat
+            // + board fixed). Fast-forward waves are leaves: never re-sample.
+            // With KnownHandsEstimator the sample reproduces the real hands and
+            // never touches the RNG, so behavior is byte-for-byte unchanged.
+            // The ThreadRng lives only inside this sync block, never crossing an
+            // await (keeps the explore future Send).
+            let wave_state: Option<GameState> = if fast_forward {
+                None
+            } else {
+                let mut rng = rand::rng();
+                Some(sample_world(&ranges, game_state, &mut rng))
+            };
+            let effective_gs: &GameState = wave_state.as_ref().unwrap_or(game_state);
+
             // Decide whether to prune this wave. On reprobe waves (every
             // REPROBE_INTERVAL-th), explore all actions. Computed ONCE per wave
             // so all `wave_width` samples make the same prune decision and the
@@ -820,7 +842,7 @@ where
             // shared `Arc<GameState>` snapshot once (cloned once, then cheap Arc
             // clones per spawned task) and only when we may actually spawn.
             let spawn_here = self.depth < SPAWN_FRONTIER_DEPTH;
-            let gs_arc = spawn_here.then(|| std::sync::Arc::new(game_state.clone()));
+            let gs_arc = spawn_here.then(|| std::sync::Arc::new(effective_gs.clone()));
 
             // `wave_width` samples × each active action.
             for _sample in 0..wave_width {
@@ -882,7 +904,7 @@ where
                         });
                         continue;
                     }
-                    let r = Self::compute_reward(game_state, &action, &ctx).await;
+                    let r = Self::compute_reward(effective_gs, &action, &ctx).await;
                     inline.push((reward_idx, r));
                 }
             }

--- a/src/arena/cfr/agent/engine.rs
+++ b/src/arena/cfr/agent/engine.rs
@@ -111,6 +111,7 @@ use super::fast_forward::{
     fast_forward_enumerate_showdowns, fast_forward_run_to_showdown,
     fast_forward_sample_flop_enumerate_runout,
 };
+use super::hand_log::{HandLog, HandLogHistorian};
 use super::reward_context::ComputeRewardContext;
 
 /// Write the per-slot mean over the samples a wave produced into `out`. Slots
@@ -149,10 +150,10 @@ where
     pub(super) budget: Arc<dyn Budget>,
     pub(super) stop: Arc<AtomicBool>,
     pub(super) estimator: std::sync::Arc<dyn crate::arena::HandDistributionEstimator>,
-    /// Shared action log for this agent's current hand, populated by the
-    /// historian returned from `Agent::historian` when the estimator needs
-    /// history. Read at `act()` time to build the `GameLog`.
-    pub(super) log_storage: crate::arena::historian::SharedHistoryStorage,
+    /// Per-line copy-on-write action log; `Some` only when the estimator needs
+    /// history. Read at `act()` to build the `GameLog`; frozen at depth 0 so the
+    /// real hand is copied once and shared by reference through the recursion.
+    pub(super) hand_log: Option<HandLog>,
 }
 
 /// Spawn a tokio task that flips `stop` to `true` after `duration`. The
@@ -266,6 +267,11 @@ where
         // All sub-agents share the same CFR state (single shared tree).
         let shared_cfr_state = ctx.cfr_state.clone();
 
+        // Per-sub-sim action log: same shared real-hand prefix, fresh tail
+        // seeded with this line's accumulated actions (copy-on-descend → full
+        // path). `None` when the estimator doesn't need history.
+        let child_log: Option<HandLog> = ctx.hand_log.as_ref().map(|l| l.spawn_child());
+
         let mut agents: Vec<Box<dyn Agent>> = Vec::with_capacity(num_agents);
         for i in 0..num_agents {
             let mut builder = CFRAgentBuilder::<T>::new()
@@ -280,6 +286,10 @@ where
                 .budget(ctx.budget.clone())
                 .stop_flag(ctx.stop.clone())
                 .estimator(ctx.estimator.clone());
+
+            if let Some(ref cl) = child_log {
+                builder = builder.hand_log(cl.clone());
+            }
 
             // Sub-agents share the SAME in-flight limiter, budget, and stop
             // flag as the root, so adaptive `try_acquire`-or-inline spawning
@@ -296,16 +306,23 @@ where
 
         // Seed the sub-simulation's RNG from the thread-local generator.
         let sub_sim_rng = StdRng::from_rng(&mut rand::rng());
-        let mut sim = HoldemSimulationBuilder::default()
+        let mut sim_builder = HoldemSimulationBuilder::default()
             .game_state(game_state.clone())
             .agents(agents)
             .cfr_context(
                 shared_cfr_state,
                 forked_traversal_set,
                 ctx.allow_node_mutation,
-            )
-            .build_with_rng(sub_sim_rng)
-            .unwrap();
+            );
+        // Install exactly one writer for this sub-sim's tail. Sub-agents are at
+        // depth >= 1, so their `Agent::historian` returns `None` (no duplicate
+        // writers).
+        if let Some(cl) = child_log {
+            sim_builder = sim_builder.historians(vec![
+                Box::new(HandLogHistorian::new(cl)) as Box<dyn crate::arena::Historian>
+            ]);
+        }
+        let mut sim = sim_builder.build_with_rng(sub_sim_rng).unwrap();
 
         sim.run().await;
 
@@ -553,20 +570,27 @@ where
         // below.
         let estimator = self.estimator.clone();
 
-        // Assemble the current-hand action log only when the estimator needs it.
-        // Scope to the most recent GameStart so multi-hand sims don't leak prior
-        // hands. The MutexGuard is confined to this block (dropped before await).
-        let history_actions: Option<Vec<crate::arena::action::Action>> =
-            if estimator.needs_history() {
-                let guard = self.log_storage.lock().expect("log storage poisoned");
-                let start = guard
-                    .iter()
-                    .rposition(|r| matches!(r.action, crate::arena::action::Action::GameStart(_)))
-                    .unwrap_or(0);
-                Some(guard[start..].iter().map(|r| r.action.clone()).collect())
+        // Build (once) the exploration log this act uses. At depth 0 we freeze
+        // the real-hand log into a shared immutable prefix; deeper agents
+        // already hold a frozen-prefix log and reuse it directly. `None` on the
+        // default fast path (estimator doesn't need history) — unchanged.
+        let exploration_log: Option<HandLog> = if estimator.needs_history() {
+            let log = self
+                .hand_log
+                .as_ref()
+                .expect("needs_history agent must have a hand_log");
+            Some(if self.depth == 0 {
+                log.freeze()
             } else {
-                None
-            };
+                log.clone()
+            })
+        } else {
+            None
+        };
+
+        // Owned snapshot backing the GameLog across the async estimate boundary.
+        let history_actions: Option<Vec<crate::arena::action::Action>> =
+            exploration_log.as_ref().map(|l| l.to_actions());
         let game_log = history_actions
             .as_ref()
             .map(|a| crate::arena::GameLog { actions: a });
@@ -785,6 +809,7 @@ where
                 fast_forward,
                 allow_node_mutation: self.allow_node_mutation,
                 estimator: self.estimator.clone(),
+                hand_log: exploration_log.clone(),
             };
 
             // ── Per-wave world (decision 2 + 9) ──

--- a/src/arena/cfr/agent/engine.rs
+++ b/src/arena/cfr/agent/engine.rs
@@ -36,7 +36,7 @@ use rand::rngs::StdRng;
 use smallvec::SmallVec;
 use tracing::event;
 
-use crate::arena::hand_estimator::{HandDistributionEstimator as _, sample_world};
+use crate::arena::hand_estimator::sample_world;
 use crate::arena::{
     Agent, GameState, HoldemSimulationBuilder, action::AgentAction, game_state::Round,
 };
@@ -549,10 +549,29 @@ where
         let target_node_idx = self.target_node_idx().unwrap();
 
         // ── Opponent-hand range estimate (decision 2): once per act, from
-        // this agent's own seat. Sampled per wave below. On error, warn and
-        // fall back to a uniform range so the solve never stalls (decision 6).
+        // this agent's own seat (`game_state.to_act_idx()`). Sampled per wave
+        // below.
         let estimator = self.estimator.clone();
-        let ranges = estimator.estimate(game_state, None).await;
+
+        // Assemble the current-hand action log only when the estimator needs it.
+        // Scope to the most recent GameStart so multi-hand sims don't leak prior
+        // hands. The MutexGuard is confined to this block (dropped before await).
+        let history_actions: Option<Vec<crate::arena::action::Action>> =
+            if estimator.needs_history() {
+                let guard = self.log_storage.lock().expect("log storage poisoned");
+                let start = guard
+                    .iter()
+                    .rposition(|r| matches!(r.action, crate::arena::action::Action::GameStart(_)))
+                    .unwrap_or(0);
+                Some(guard[start..].iter().map(|r| r.action.clone()).collect())
+            } else {
+                None
+            };
+        let game_log = history_actions
+            .as_ref()
+            .map(|a| crate::arena::GameLog { actions: a });
+
+        let ranges = estimator.estimate(game_state, game_log.as_ref()).await;
 
         // Per-slot wave accumulators, reused across waves to avoid repeated Vec
         // allocations. Each wave sums every sample landing in a slot and counts

--- a/src/arena/cfr/agent/engine.rs
+++ b/src/arena/cfr/agent/engine.rs
@@ -149,6 +149,10 @@ where
     pub(super) budget: Arc<dyn Budget>,
     pub(super) stop: Arc<AtomicBool>,
     pub(super) estimator: std::sync::Arc<dyn crate::arena::HandDistributionEstimator>,
+    /// Shared action log for this agent's current hand, populated by the
+    /// historian returned from `Agent::historian` when the estimator needs
+    /// history. Read at `act()` time to build the `GameLog`.
+    pub(super) log_storage: crate::arena::historian::SharedHistoryStorage,
 }
 
 /// Spawn a tokio task that flips `stop` to `true` after `duration`. The

--- a/src/arena/cfr/agent/engine.rs
+++ b/src/arena/cfr/agent/engine.rs
@@ -147,8 +147,6 @@ where
     pub(super) limiter: InFlightLimiter,
     pub(super) budget: Arc<dyn Budget>,
     pub(super) stop: Arc<AtomicBool>,
-    // Wired up in Task 10; field exists now so the builder and type are in place.
-    #[expect(dead_code)]
     pub(super) estimator: std::sync::Arc<dyn crate::arena::HandDistributionEstimator>,
 }
 
@@ -275,7 +273,8 @@ where
                 .depth(sub_depth)
                 .limiter(ctx.limiter.clone())
                 .budget(ctx.budget.clone())
-                .stop_flag(ctx.stop.clone());
+                .stop_flag(ctx.stop.clone())
+                .estimator(ctx.estimator.clone());
 
             // Sub-agents share the SAME in-flight limiter, budget, and stop
             // flag as the root, so adaptive `try_acquire`-or-inline spawning
@@ -755,6 +754,7 @@ where
                 depth: self.depth,
                 fast_forward,
                 allow_node_mutation: self.allow_node_mutation,
+                estimator: self.estimator.clone(),
             };
 
             // Decide whether to prune this wave. On reprobe waves (every

--- a/src/arena/cfr/agent/engine.rs
+++ b/src/arena/cfr/agent/engine.rs
@@ -777,7 +777,13 @@ where
                 let mut rng = rand::rng();
                 Some(sample_world(&ranges, game_state, &mut rng))
             };
-            let effective_gs: &GameState = wave_state.as_ref().unwrap_or(game_state);
+            // Wrap the sampled world in an Arc once so the inline borrow and the
+            // spawn snapshot share a single allocation (no second clone). For
+            // fast-forward waves (wave_state == None) there is no sampled world;
+            // effective_gs borrows the base game_state.
+            let sampled_arc: Option<std::sync::Arc<GameState>> =
+                wave_state.map(std::sync::Arc::new);
+            let effective_gs: &GameState = sampled_arc.as_deref().unwrap_or(game_state);
 
             // Decide whether to prune this wave. On reprobe waves (every
             // REPROBE_INTERVAL-th), explore all actions. Computed ONCE per wave
@@ -842,7 +848,13 @@ where
             // shared `Arc<GameState>` snapshot once (cloned once, then cheap Arc
             // clones per spawned task) and only when we may actually spawn.
             let spawn_here = self.depth < SPAWN_FRONTIER_DEPTH;
-            let gs_arc = spawn_here.then(|| std::sync::Arc::new(effective_gs.clone()));
+            // Reuse the sampled-world Arc when present (cheap refcount bump);
+            // only clone the base game_state when there was no sampled world
+            // (fast-forward waves) and we still need a spawn snapshot.
+            let gs_arc = spawn_here.then(|| match &sampled_arc {
+                Some(arc) => arc.clone(),
+                None => std::sync::Arc::new(game_state.clone()),
+            });
 
             // `wave_width` samples × each active action.
             for _sample in 0..wave_width {

--- a/src/arena/cfr/agent/hand_log.rs
+++ b/src/arena/cfr/agent/hand_log.rs
@@ -33,7 +33,6 @@ pub struct HandLog {
     tail: Arc<Mutex<SmallVec<[Action; INLINE]>>>,
 }
 
-#[allow(dead_code)]
 impl HandLog {
     /// Empty prefix, empty tail. Used for a depth-0 top-level simulation before
     /// its real hand has been recorded.
@@ -46,6 +45,10 @@ impl HandLog {
 
     /// Append one action to this line's tail. Stores the `Action` only — no
     /// `GameState` clone. Panics on a poisoned lock (callers are single-sim).
+    ///
+    /// Production writes go through `HandLogHistorian`; this direct setter is
+    /// only used by tests to seed a log, so it's gated to test builds.
+    #[cfg(test)]
     pub fn record(&self, action: Action) {
         self.tail
             .lock()
@@ -94,12 +97,10 @@ impl Default for HandLog {
 
 /// The single per-simulation writer appending each recorded action into a
 /// shared [`HandLog`]. Lightweight: holds one `HandLog` (two Arcs).
-#[allow(dead_code)]
 pub struct HandLogHistorian {
     log: HandLog,
 }
 
-#[allow(dead_code)]
 impl HandLogHistorian {
     pub fn new(log: HandLog) -> Self {
         Self { log }
@@ -219,9 +220,7 @@ mod tests {
         hist.record_action(0, &game_state, &ra(Round::Preflop))
             .await
             .unwrap();
-        hist.record_action(0, &game_state, &deal(7))
-            .await
-            .unwrap();
+        hist.record_action(0, &game_state, &deal(7)).await.unwrap();
 
         // The historian's clone shares the tail with `log`, so the appends are
         // visible through the original handle.

--- a/src/arena/cfr/agent/hand_log.rs
+++ b/src/arena/cfr/agent/hand_log.rs
@@ -1,0 +1,230 @@
+//! Copy-on-write action log for CFR hand-history estimation.
+//!
+//! The real hand is frozen ONCE at depth 0 into a shared immutable `prefix`;
+//! each simulation's own actions are an owned `tail`, copied on descent so a
+//! child sees the full betting path that produced its state. No mutable buffer
+//! is ever shared across concurrent tasks: the `prefix` is read-only and each
+//! simulation owns its `tail`.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use smallvec::SmallVec;
+
+use crate::arena::GameState;
+use crate::arena::action::Action;
+use crate::arena::historian::{Historian, HistorianError, HistorianLock};
+
+/// Inline capacity for one line's appended actions. The real hand lives in the
+/// shared `prefix`, so a tail only holds a single recursion line's continuation
+/// (short in practice). Longer lines spill to the heap.
+const INLINE: usize = 16;
+
+/// One line of play's action log: a shared immutable prefix plus an owned tail.
+///
+/// `Clone` is a shallow Arc clone: a clone SHARES the same `tail` as the
+/// original — both observe each other's `record`s. This is how the per-sim
+/// `HandLogHistorian` (the writer) and the agents (readers) share one tail.
+/// To start a *new, independent* line of play (a child sub-simulation), use
+/// [`HandLog::spawn_child`], which forks a fresh tail.
+#[derive(Clone)]
+pub struct HandLog {
+    prefix: Arc<[Action]>,
+    tail: Arc<Mutex<SmallVec<[Action; INLINE]>>>,
+}
+
+#[allow(dead_code)]
+impl HandLog {
+    /// Empty prefix, empty tail. Used for a depth-0 top-level simulation before
+    /// its real hand has been recorded.
+    pub fn new() -> Self {
+        Self {
+            prefix: Arc::from([] as [Action; 0]),
+            tail: Arc::new(Mutex::new(SmallVec::new())),
+        }
+    }
+
+    /// Append one action to this line's tail. Stores the `Action` only — no
+    /// `GameState` clone. Panics on a poisoned lock (callers are single-sim).
+    pub fn record(&self, action: Action) {
+        self.tail
+            .lock()
+            .expect("HandLog tail poisoned")
+            .push(action);
+    }
+
+    /// The full ordered action sequence: shared prefix then this line's tail.
+    /// Materialized into an owned `Vec` so it can back a `GameLog` across the
+    /// async `estimate` boundary without holding the lock.
+    pub fn to_actions(&self) -> Vec<Action> {
+        let tail = self.tail.lock().expect("HandLog tail poisoned");
+        let mut out = Vec::with_capacity(self.prefix.len() + tail.len());
+        out.extend_from_slice(&self.prefix);
+        out.extend(tail.iter().cloned());
+        out
+    }
+
+    /// Collapse `prefix + tail` into a single shared immutable prefix with an
+    /// empty tail. Called ONCE at depth 0 to absorb the real hand so
+    /// descendants never re-copy it.
+    pub fn freeze(&self) -> HandLog {
+        HandLog {
+            prefix: Arc::from(self.to_actions()),
+            tail: Arc::new(Mutex::new(SmallVec::new())),
+        }
+    }
+
+    /// A child log for a spawned sub-simulation: the same shared `prefix`, and a
+    /// fresh tail seeded with a copy of this line's accumulated tail. Only the
+    /// short simulated tail is copied; the real-hand prefix is shared by Arc.
+    pub fn spawn_child(&self) -> HandLog {
+        let seed = self.tail.lock().expect("HandLog tail poisoned").clone();
+        HandLog {
+            prefix: self.prefix.clone(),
+            tail: Arc::new(Mutex::new(seed)),
+        }
+    }
+}
+
+impl Default for HandLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The single per-simulation writer appending each recorded action into a
+/// shared [`HandLog`]. Lightweight: holds one `HandLog` (two Arcs).
+#[allow(dead_code)]
+pub struct HandLogHistorian {
+    log: HandLog,
+}
+
+#[allow(dead_code)]
+impl HandLogHistorian {
+    pub fn new(log: HandLog) -> Self {
+        Self { log }
+    }
+}
+
+#[async_trait]
+impl Historian for HandLogHistorian {
+    async fn record_action(
+        &mut self,
+        _id: u128,
+        _game_state: &GameState,
+        action: &Action,
+    ) -> Result<(), HistorianError> {
+        let mut tail = self
+            .log
+            .tail
+            .lock()
+            .map_err(|_| HistorianError::LockPoisoned {
+                lock: HistorianLock::HandLog,
+            })?;
+        tail.push(action.clone());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arena::game_state::Round;
+    use crate::core::Card;
+
+    fn ra(r: Round) -> Action {
+        Action::RoundAdvance(r)
+    }
+    fn deal(n: u8) -> Action {
+        Action::DealCommunity(Card::from(n))
+    }
+
+    #[test]
+    fn new_is_empty() {
+        assert!(HandLog::new().to_actions().is_empty());
+    }
+
+    #[test]
+    fn record_appends_in_order() {
+        let log = HandLog::new();
+        log.record(ra(Round::Preflop));
+        log.record(deal(10));
+        assert_eq!(log.to_actions(), vec![ra(Round::Preflop), deal(10)]);
+    }
+
+    #[test]
+    fn freeze_collapses_into_prefix_and_empties_tail() {
+        let log = HandLog::new();
+        log.record(ra(Round::Preflop));
+        log.record(deal(10));
+        let frozen = log.freeze();
+        // Frozen sees the same sequence...
+        assert_eq!(frozen.to_actions(), vec![ra(Round::Preflop), deal(10)]);
+        // ...but its tail is empty: new records on the frozen log start fresh,
+        // and the original is unaffected.
+        frozen.record(deal(20));
+        assert_eq!(
+            frozen.to_actions(),
+            vec![ra(Round::Preflop), deal(10), deal(20)]
+        );
+        assert_eq!(log.to_actions(), vec![ra(Round::Preflop), deal(10)]);
+    }
+
+    #[test]
+    fn spawn_child_copies_tail_and_is_independent() {
+        let parent = HandLog::new();
+        parent.record(ra(Round::Flop));
+        let child = parent.spawn_child();
+        // Child starts from the parent's accumulated tail.
+        assert_eq!(child.to_actions(), vec![ra(Round::Flop)]);
+        // Appends to each are independent (no shared mutable tail).
+        child.record(deal(30));
+        parent.record(deal(40));
+        assert_eq!(child.to_actions(), vec![ra(Round::Flop), deal(30)]);
+        assert_eq!(parent.to_actions(), vec![ra(Round::Flop), deal(40)]);
+    }
+
+    #[test]
+    fn full_path_through_freeze_then_two_descents() {
+        // Depth 0: real hand recorded, then frozen.
+        let root = HandLog::new();
+        root.record(ra(Round::Preflop));
+        let d0 = root.freeze(); // prefix = [Preflop], tail = []
+
+        // Depth 1: child starts empty, accumulates its line.
+        let d1 = d0.spawn_child();
+        d1.record(deal(1));
+
+        // Depth 2: child copies d1's tail, then accumulates.
+        let d2 = d1.spawn_child();
+        d2.record(deal(2));
+
+        // Full path = real hand + depth-1 line + depth-2 line.
+        assert_eq!(d2.to_actions(), vec![ra(Round::Preflop), deal(1), deal(2)]);
+    }
+
+    #[tokio::test]
+    async fn historian_records_into_shared_log() {
+        use crate::arena::Historian;
+
+        let log = HandLog::new();
+        let mut hist = HandLogHistorian::new(log.clone());
+
+        let game_state = crate::arena::GameStateBuilder::default()
+            .num_players_with_stack(2, 100.0)
+            .big_blind(2.0)
+            .build()
+            .unwrap();
+
+        hist.record_action(0, &game_state, &ra(Round::Preflop))
+            .await
+            .unwrap();
+        hist.record_action(0, &game_state, &deal(7))
+            .await
+            .unwrap();
+
+        // The historian's clone shares the tail with `log`, so the appends are
+        // visible through the original handle.
+        assert_eq!(log.to_actions(), vec![ra(Round::Preflop), deal(7)]);
+    }
+}

--- a/src/arena/cfr/agent/mod.rs
+++ b/src/arena/cfr/agent/mod.rs
@@ -168,6 +168,47 @@ where
     fn name(&self) -> &str {
         self.name.as_ref()
     }
+
+    fn historian(&self) -> Option<Box<dyn crate::arena::Historian>> {
+        if self.estimator.needs_history() {
+            Some(Box::new(
+                crate::arena::historian::VecHistorian::new_with_actions(self.log_storage.clone()),
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+/// Test-only estimator that requires history and records, into shared state,
+/// how many actions the `GameLog` it received contained. It defers the actual
+/// ranges to `KnownHandsEstimator` so sampling still works.
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct HistoryNeedingStub {
+    pub last_seen_actions: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl crate::arena::HandDistributionEstimator for HistoryNeedingStub {
+    async fn estimate(
+        &self,
+        game_state: &GameState,
+        history: Option<&crate::arena::GameLog<'_>>,
+    ) -> crate::arena::OpponentRanges {
+        let n = history.map(|h| h.actions.len()).unwrap_or(0);
+        self.last_seen_actions
+            .store(n, std::sync::atomic::Ordering::SeqCst);
+        crate::arena::hand_estimator::KnownHandsEstimator
+            .estimate(game_state, None)
+            .await
+    }
+
+    fn needs_history(&self) -> bool {
+        true
+    }
+
 }
 
 #[cfg(test)]
@@ -2238,5 +2279,40 @@ mod tests {
         agent.ensure_regret_matcher();
         agent.explore_all_actions(&game_state).await;
         // Test passes if no panic occurs.
+    }
+
+    #[tokio::test]
+    async fn historian_present_only_when_estimator_needs_history() {
+        use crate::arena::Agent;
+        use std::sync::Arc;
+
+        let game_state = crate::arena::GameStateBuilder::default()
+            .num_players_with_stack(2, 100.0)
+            .big_blind(2.0)
+            .build()
+            .unwrap();
+        let cfr_state = make_cfr_state(&game_state);
+        let traversal_set = TraversalSet::new(game_state.num_players);
+
+        // Default (KnownHands) does not need history → no historian.
+        let agent = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
+            .name("no-hist")
+            .player_idx(0)
+            .cfr_state(cfr_state.clone())
+            .traversal_set(traversal_set.clone())
+            .action_gen_config(())
+            .build();
+        assert!(agent.historian().is_none());
+
+        // A needs_history estimator → historian present.
+        let agent2 = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
+            .name("hist")
+            .player_idx(0)
+            .cfr_state(cfr_state)
+            .traversal_set(traversal_set)
+            .action_gen_config(())
+            .estimator(Arc::new(HistoryNeedingStub::default()))
+            .build();
+        assert!(agent2.historian().is_some());
     }
 }

--- a/src/arena/cfr/agent/mod.rs
+++ b/src/arena/cfr/agent/mod.rs
@@ -2281,6 +2281,59 @@ mod tests {
         // Test passes if no panic occurs.
     }
 
+    /// End-to-end test proving that agent historians are collected even when a
+    /// CFR context is set on the simulation. Builds a real `HoldemSimulation`
+    /// with `cfr_context` set and a `CFRAgent` whose estimator is
+    /// `HistoryNeedingStub` (needs_history == true), runs it, and asserts the
+    /// agent's shared `log_storage` got populated.
+    #[tokio::test]
+    async fn historian_populates_log_in_real_cfr_sim() {
+        use std::sync::Arc;
+
+        let game_state = crate::arena::GameStateBuilder::default()
+            .num_players_with_stack(2, 100.0)
+            .blinds(10.0, 5.0)
+            .build()
+            .unwrap();
+        let cfr_state = make_cfr_state(&game_state);
+        let traversal_set = TraversalSet::new(game_state.num_players);
+
+        let stub_agent = CFRAgentBuilder::<ConfigurableActionGenerator>::new()
+            .name("hist")
+            .player_idx(0)
+            .cfr_state(cfr_state.clone())
+            .traversal_set(traversal_set.clone())
+            .action_gen_config(ConfigurableActionConfig::default())
+            .budget(budget_for_schedule(&[1]))
+            .estimator(Arc::new(HistoryNeedingStub::default()))
+            .build();
+        // Grab the shared log handle before the agent is moved into the sim.
+        let log = stub_agent.log_storage.clone();
+
+        let other = CFRAgentBuilder::<ConfigurableActionGenerator>::new()
+            .name("p1")
+            .player_idx(1)
+            .cfr_state(cfr_state.clone())
+            .traversal_set(traversal_set.clone())
+            .action_gen_config(ConfigurableActionConfig::default())
+            .budget(budget_for_schedule(&[1]))
+            .build();
+
+        let agents: Vec<Box<dyn Agent>> = vec![Box::new(stub_agent), Box::new(other)];
+        let mut sim = HoldemSimulationBuilder::default()
+            .game_state(game_state)
+            .agents(agents)
+            .cfr_context(cfr_state, traversal_set, true)
+            .build()
+            .unwrap();
+        sim.run().await;
+
+        assert!(
+            !log.lock().unwrap().is_empty(),
+            "agent historian must be collected and populate the log even when cfr_context is set"
+        );
+    }
+
     #[tokio::test]
     async fn historian_present_only_when_estimator_needs_history() {
         use crate::arena::Agent;

--- a/src/arena/cfr/agent/mod.rs
+++ b/src/arena/cfr/agent/mod.rs
@@ -171,10 +171,14 @@ where
     }
 
     fn historian(&self) -> Option<Box<dyn crate::arena::Historian>> {
-        if self.estimator.needs_history() {
-            Some(Box::new(
-                crate::arena::historian::VecHistorian::new_with_actions(self.log_storage.clone()),
-            ))
+        // The real hand is recorded only at depth 0 (the actual game). Deeper
+        // sub-sims get one explicit writer installed by `compute_reward_recursive`,
+        // so they must NOT self-provide one here.
+        if self.depth == 0 && self.estimator.needs_history() {
+            self.hand_log.as_ref().map(|log| {
+                Box::new(hand_log::HandLogHistorian::new(log.clone()))
+                    as Box<dyn crate::arena::Historian>
+            })
         } else {
             None
         }
@@ -2288,7 +2292,7 @@ mod tests {
     /// CFR context is set on the simulation. Builds a real `HoldemSimulation`
     /// with `cfr_context` set and a `CFRAgent` whose estimator is
     /// `HistoryNeedingStub` (needs_history == true), runs it, and asserts the
-    /// agent's shared `log_storage` got populated.
+    /// agent's shared `hand_log` got populated.
     #[tokio::test]
     async fn historian_populates_log_in_real_cfr_sim() {
         use std::sync::Arc;
@@ -2311,7 +2315,10 @@ mod tests {
             .estimator(Arc::new(HistoryNeedingStub::default()))
             .build();
         // Grab the shared log handle before the agent is moved into the sim.
-        let log = stub_agent.log_storage.clone();
+        let log = stub_agent
+            .hand_log
+            .clone()
+            .expect("needs_history agent has a hand_log");
 
         let other = CFRAgentBuilder::<ConfigurableActionGenerator>::new()
             .name("p1")
@@ -2332,7 +2339,7 @@ mod tests {
         sim.run().await;
 
         assert!(
-            !log.lock().unwrap().is_empty(),
+            !log.to_actions().is_empty(),
             "agent historian must be collected and populate the log even when cfr_context is set"
         );
     }
@@ -2376,7 +2383,6 @@ mod tests {
     async fn estimate_receives_current_hand_log() {
         use crate::arena::action::{Action, GameStartPayload};
         use crate::arena::game_state::Round;
-        use crate::arena::historian::HistoryRecord;
         use std::sync::Arc;
 
         // Build a 2-player preflop game state with explicit hole cards,
@@ -2397,48 +2403,36 @@ mod tests {
             .estimator(Arc::new(stub))
             .build();
 
-        // Pre-populate the ROOT agent's shared log with exactly three records:
-        // 1) a GameStart (scope anchor), 2) a RoundAdvance, 3) a DealCommunity.
-        // The GameLog assembled in explore_all_actions is scoped from the
-        // most-recent GameStart, so the root estimate should see all 3 actions.
+        // Pre-populate the ROOT agent's log with exactly three actions:
+        // GameStart (scope anchor), RoundAdvance, DealCommunity. The depth-0
+        // freeze turns these into the immutable prefix, so the root estimate
+        // sees all 3.
         {
-            let mut g = agent.log_storage.lock().unwrap();
-            g.clear();
-            // 1) GameStart
-            g.push(HistoryRecord {
-                before_game_state: None,
-                action: Action::GameStart(GameStartPayload {
-                    ante: 0.0,
-                    small_blind: 5.0,
-                    big_blind: 10.0,
-                }),
-                after_game_state: game_state.clone(),
-            });
-            // 2) RoundAdvance
-            g.push(HistoryRecord {
-                before_game_state: None,
-                action: Action::RoundAdvance(Round::Preflop),
-                after_game_state: game_state.clone(),
-            });
-            // 3) DealCommunity
-            g.push(HistoryRecord {
-                before_game_state: None,
-                action: Action::DealCommunity(crate::core::Card::from(10u8)),
-                after_game_state: game_state.clone(),
-            });
+            let log = agent
+                .hand_log
+                .as_ref()
+                .expect("needs_history agent has a hand_log");
+            log.record(Action::GameStart(GameStartPayload {
+                ante: 0.0,
+                small_blind: 5.0,
+                big_blind: 10.0,
+            }));
+            log.record(Action::RoundAdvance(Round::Preflop));
+            log.record(Action::DealCommunity(crate::core::Card::from(10u8)));
         }
 
         agent.ensure_target_node();
         agent.ensure_regret_matcher();
         agent.explore_all_actions(&game_state).await;
 
-        // The root's estimate saw a GameLog scoped from GameStart → 3 actions.
-        // Sub-agents (sharing the stub) observe their own (empty) logs; we only
-        // require that the root's observation (3) is among the recorded counts.
         let counts = observed.lock().unwrap();
         assert!(
             counts.contains(&3),
             "expected the root estimate to receive a 3-action GameLog; saw {counts:?}"
+        );
+        assert!(
+            counts.iter().all(|&c| c >= 3),
+            "every estimate must see at least the real-hand prefix (full path); saw {counts:?}"
         );
     }
 }

--- a/src/arena/cfr/agent/mod.rs
+++ b/src/arena/cfr/agent/mod.rs
@@ -181,12 +181,13 @@ where
 }
 
 /// Test-only estimator that requires history and records, into shared state,
-/// how many actions the `GameLog` it received contained. It defers the actual
-/// ranges to `KnownHandsEstimator` so sampling still works.
+/// the action count of every `GameLog` it is handed (one entry per estimate
+/// call — note recursive sub-agents share this same instance). It defers the
+/// actual ranges to `KnownHandsEstimator` so sampling still works.
 #[cfg(test)]
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct HistoryNeedingStub {
-    pub last_seen_actions: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    pub observed_counts: std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
 }
 
 #[cfg(test)]
@@ -198,8 +199,10 @@ impl crate::arena::HandDistributionEstimator for HistoryNeedingStub {
         history: Option<&crate::arena::GameLog<'_>>,
     ) -> crate::arena::OpponentRanges {
         let n = history.map(|h| h.actions.len()).unwrap_or(0);
-        self.last_seen_actions
-            .store(n, std::sync::atomic::Ordering::SeqCst);
+        self.observed_counts
+            .lock()
+            .expect("observed_counts poisoned")
+            .push(n);
         crate::arena::hand_estimator::KnownHandsEstimator
             .estimate(game_state, None)
             .await
@@ -208,7 +211,6 @@ impl crate::arena::HandDistributionEstimator for HistoryNeedingStub {
     fn needs_history(&self) -> bool {
         true
     }
-
 }
 
 #[cfg(test)]
@@ -2367,5 +2369,75 @@ mod tests {
             .estimator(Arc::new(HistoryNeedingStub::default()))
             .build();
         assert!(agent2.historian().is_some());
+    }
+
+    #[tokio::test]
+    async fn estimate_receives_current_hand_log() {
+        use crate::arena::action::{Action, GameStartPayload};
+        use crate::arena::game_state::Round;
+        use crate::arena::historian::HistoryRecord;
+        use std::sync::Arc;
+
+        // Build a 2-player preflop game state with explicit hole cards,
+        // mirroring setup_tiny_heads_up so explore_all_actions has a valid
+        // acting seat.
+        let (game_state, cfr_state, traversal_set) = setup_tiny_heads_up();
+
+        let stub = HistoryNeedingStub::default();
+        let observed = stub.observed_counts.clone();
+
+        let mut agent = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
+            .name("hist-feed")
+            .player_idx(game_state.to_act_idx())
+            .cfr_state(cfr_state)
+            .traversal_set(traversal_set)
+            .budget(budget_for_schedule(&[2, 1]))
+            .action_gen_config(())
+            .estimator(Arc::new(stub))
+            .build();
+
+        // Pre-populate the ROOT agent's shared log with exactly three records:
+        // 1) a GameStart (scope anchor), 2) a RoundAdvance, 3) a DealCommunity.
+        // The GameLog assembled in explore_all_actions is scoped from the
+        // most-recent GameStart, so the root estimate should see all 3 actions.
+        {
+            let mut g = agent.log_storage.lock().unwrap();
+            g.clear();
+            // 1) GameStart
+            g.push(HistoryRecord {
+                before_game_state: None,
+                action: Action::GameStart(GameStartPayload {
+                    ante: 0.0,
+                    small_blind: 5.0,
+                    big_blind: 10.0,
+                }),
+                after_game_state: game_state.clone(),
+            });
+            // 2) RoundAdvance
+            g.push(HistoryRecord {
+                before_game_state: None,
+                action: Action::RoundAdvance(Round::Preflop),
+                after_game_state: game_state.clone(),
+            });
+            // 3) DealCommunity
+            g.push(HistoryRecord {
+                before_game_state: None,
+                action: Action::DealCommunity(crate::core::Card::from(10u8)),
+                after_game_state: game_state.clone(),
+            });
+        }
+
+        agent.ensure_target_node();
+        agent.ensure_regret_matcher();
+        agent.explore_all_actions(&game_state).await;
+
+        // The root's estimate saw a GameLog scoped from GameStart → 3 actions.
+        // Sub-agents (sharing the stub) observe their own (empty) logs; we only
+        // require that the root's observation (3) is among the recorded counts.
+        let counts = observed.lock().unwrap();
+        assert!(
+            counts.contains(&3),
+            "expected the root estimate to receive a 3-action GameLog; saw {counts:?}"
+        );
     }
 }

--- a/src/arena/cfr/agent/mod.rs
+++ b/src/arena/cfr/agent/mod.rs
@@ -16,6 +16,7 @@
 mod builder;
 mod engine;
 mod fast_forward;
+mod hand_log;
 mod reward_context;
 
 use std::sync::Arc;

--- a/src/arena/cfr/agent/mod.rs
+++ b/src/arena/cfr/agent/mod.rs
@@ -2435,4 +2435,123 @@ mod tests {
             "every estimate must see at least the real-hand prefix (full path); saw {counts:?}"
         );
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sub_sim_continues_prefix_without_relogging_setup() {
+        use crate::arena::action::Action;
+        use std::sync::Arc;
+
+        let (game_state, cfr_state, traversal_set) = setup_tiny_heads_up();
+
+        let stub = HistoryNeedingStub::default();
+        let observed = stub.observed_counts.clone();
+
+        let mut agent = CFRAgentBuilder::<ConfigurableActionGenerator>::new()
+            .name("cont")
+            .player_idx(game_state.to_act_idx())
+            .cfr_state(cfr_state)
+            .traversal_set(traversal_set)
+            .budget(budget_for_schedule(&[2, 1]))
+            .action_gen_config(ConfigurableActionConfig::default())
+            .estimator(Arc::new(stub))
+            .build();
+
+        // Seed a 2-action real-hand prefix.
+        {
+            let log = agent.hand_log.as_ref().unwrap();
+            log.record(Action::RoundAdvance(crate::arena::game_state::Round::River));
+            log.record(Action::DealCommunity(crate::core::Card::from(5u8)));
+        }
+
+        agent.ensure_target_node();
+        agent.ensure_regret_matcher();
+        agent.explore_all_actions(&game_state).await;
+
+        let counts = observed.lock().unwrap();
+        // Root estimate saw exactly the 2-action prefix (no setup re-logged).
+        assert!(
+            counts.contains(&2),
+            "root estimate should see the 2-action prefix; saw {counts:?}"
+        );
+        // At least one sub-agent estimate saw the prefix PLUS appended actions.
+        // This holds because the sub-sim's HandLogHistorian records round/deal
+        // events (and the forced opening action) into the child tail before any
+        // non-forced depth-1 agent reaches `estimate`, so that agent observes
+        // prefix(2) + tail(>=1) > 2. If the game-state geometry ever changed so
+        // every depth-1 path hit the single-action shortcut, this would need a
+        // deterministic scenario rather than a weakened assertion.
+        assert!(
+            counts.iter().any(|&c| c > 2),
+            "a sub-sim estimate should see the prefix plus its own line; saw {counts:?}"
+        );
+        // Every estimate sees at least the full prefix (full-path property).
+        assert!(
+            counts.iter().all(|&c| c >= 2),
+            "every estimate must include the real-hand prefix; saw {counts:?}"
+        );
+    }
+
+    /// Independence is structural (each `spawn_child` allocates its own
+    /// `Arc<Mutex>` tail), so a sequential test proves the property that keeps
+    /// the *concurrent* sub-sim fan-out in `compute_reward_recursive` safe.
+    #[test]
+    fn concurrent_children_have_independent_tails() {
+        use crate::arena::action::Action;
+        use crate::arena::game_state::Round;
+
+        let root = super::hand_log::HandLog::new();
+        root.record(Action::RoundAdvance(Round::Flop));
+        let frozen = root.freeze();
+
+        // Two siblings spawned from the same parent must not interleave.
+        let a = frozen.spawn_child();
+        let b = frozen.spawn_child();
+        a.record(Action::DealCommunity(crate::core::Card::from(1u8)));
+        b.record(Action::DealCommunity(crate::core::Card::from(2u8)));
+
+        assert_eq!(
+            a.to_actions(),
+            vec![
+                Action::RoundAdvance(Round::Flop),
+                Action::DealCommunity(crate::core::Card::from(1u8))
+            ]
+        );
+        assert_eq!(
+            b.to_actions(),
+            vec![
+                Action::RoundAdvance(Round::Flop),
+                Action::DealCommunity(crate::core::Card::from(2u8))
+            ]
+        );
+    }
+
+    #[test]
+    fn default_estimator_has_no_hand_log_and_no_historian() {
+        use crate::arena::Agent;
+
+        let game_state = crate::arena::GameStateBuilder::default()
+            .num_players_with_stack(2, 100.0)
+            .big_blind(2.0)
+            .build()
+            .unwrap();
+        let cfr_state = make_cfr_state(&game_state);
+        let traversal_set = TraversalSet::new(game_state.num_players);
+
+        let agent = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
+            .name("default")
+            .player_idx(0)
+            .cfr_state(cfr_state)
+            .traversal_set(traversal_set)
+            .action_gen_config(())
+            .build();
+
+        assert!(
+            agent.hand_log.is_none(),
+            "default estimator must carry no log"
+        );
+        assert!(
+            agent.historian().is_none(),
+            "no historian on the default fast path"
+        );
+    }
 }

--- a/src/arena/cfr/agent/mod.rs
+++ b/src/arena/cfr/agent/mod.rs
@@ -2212,4 +2212,31 @@ mod tests {
              all five budgeted waves complete and apply their updates"
         );
     }
+
+    /// Smoke test: `explore_all_actions` completes without panicking when the
+    /// agent is built with `UniformRandomEstimator`. This exercises the
+    /// per-act estimate + per-wave world-sampling paths introduced in Task 10.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explore_runs_with_uniform_estimator() {
+        use crate::arena::hand_estimator::UniformRandomEstimator;
+
+        let (game_state, cfr_state, traversal_set) = setup_tiny_heads_up();
+
+        let budget = budget_for_schedule(&[4, 2, 1]);
+
+        let mut agent = CFRAgentBuilder::<BasicCFRActionGenerator>::new()
+            .name("uniform-test")
+            .player_idx(game_state.to_act_idx())
+            .cfr_state(cfr_state)
+            .traversal_set(traversal_set)
+            .budget(budget)
+            .action_gen_config(())
+            .estimator(Arc::new(UniformRandomEstimator))
+            .build();
+
+        agent.ensure_target_node();
+        agent.ensure_regret_matcher();
+        agent.explore_all_actions(&game_state).await;
+        // Test passes if no panic occurs.
+    }
 }

--- a/src/arena/cfr/agent/reward_context.rs
+++ b/src/arena/cfr/agent/reward_context.rs
@@ -16,6 +16,7 @@ use super::super::{
     ActionIndexMapper, Budget, CFRState, InFlightLimiter, TraversalSet, TraversalState,
     action_generator::ActionGenerator,
 };
+use super::hand_log::HandLog;
 use crate::arena::HandDistributionEstimator;
 
 pub(super) struct ComputeRewardContext<T: ActionGenerator> {
@@ -37,6 +38,9 @@ pub(super) struct ComputeRewardContext<T: ActionGenerator> {
     pub(super) fast_forward: bool,
     pub(super) allow_node_mutation: bool,
     pub(super) estimator: Arc<dyn HandDistributionEstimator>,
+    /// Frozen-at-depth-0 action log for this exploration; `None` when the
+    /// estimator doesn't need history. Children spawn from it via `spawn_child`.
+    pub(super) hand_log: Option<HandLog>,
 }
 
 // Manual `Clone` so the bound is only on the `Arc`-backed handles, not on `T`.
@@ -55,6 +59,7 @@ impl<T: ActionGenerator> Clone for ComputeRewardContext<T> {
             fast_forward: self.fast_forward,
             allow_node_mutation: self.allow_node_mutation,
             estimator: self.estimator.clone(),
+            hand_log: self.hand_log.clone(),
         }
     }
 }

--- a/src/arena/cfr/agent/reward_context.rs
+++ b/src/arena/cfr/agent/reward_context.rs
@@ -16,6 +16,7 @@ use super::super::{
     ActionIndexMapper, Budget, CFRState, InFlightLimiter, TraversalSet, TraversalState,
     action_generator::ActionGenerator,
 };
+use crate::arena::HandDistributionEstimator;
 
 pub(super) struct ComputeRewardContext<T: ActionGenerator> {
     pub(super) traversal_set: TraversalSet,
@@ -35,6 +36,7 @@ pub(super) struct ComputeRewardContext<T: ActionGenerator> {
     pub(super) depth: usize,
     pub(super) fast_forward: bool,
     pub(super) allow_node_mutation: bool,
+    pub(super) estimator: Arc<dyn HandDistributionEstimator>,
 }
 
 // Manual `Clone` so the bound is only on the `Arc`-backed handles, not on `T`.
@@ -52,6 +54,7 @@ impl<T: ActionGenerator> Clone for ComputeRewardContext<T> {
             depth: self.depth,
             fast_forward: self.fast_forward,
             allow_node_mutation: self.allow_node_mutation,
+            estimator: self.estimator.clone(),
         }
     }
 }

--- a/src/arena/hand_estimator/distribution.rs
+++ b/src/arena/hand_estimator/distribution.rs
@@ -1,6 +1,8 @@
 //! The hole-card distribution type and its synchronous sampler.
 
 use crate::core::Card;
+use crate::core::CardBitSet;
+use rand::RngExt;
 
 /// A canonical, unordered pair of hole cards. `lo` is always the card with the
 /// smaller `u8` index, so `HoleCombo::new(a, b) == HoleCombo::new(b, a)`.
@@ -25,18 +27,79 @@ impl HoleCombo {
 
 /// All 1326 canonical two-card combinations from a 52-card deck.
 pub fn all_hole_combos() -> Vec<HoleCombo> {
-    let mut combos = Vec::with_capacity(1326);
-    for a in 0u8..52 {
-        for b in (a + 1)..52 {
-            combos.push(HoleCombo::new(Card::from(a), Card::from(b)));
+    (0u8..52)
+        .flat_map(|a| (a + 1..52).map(move |b| HoleCombo::new(Card::from(a), Card::from(b))))
+        .collect()
+}
+
+/// Weights over hole-card combos. Stored sparsely as `(combo, weight)` pairs;
+/// weights need not be normalized — [`HandDistribution::sample`] normalizes
+/// over the surviving (non-dead) combos.
+#[derive(Debug, Clone)]
+pub struct WeightedCombos {
+    /// `(combo, weight)` pairs. Zero/negative weights are ignored.
+    pub weights: Vec<(HoleCombo, f32)>,
+}
+
+/// A synchronous sampler over one opponent's possible hole cards.
+#[derive(Debug, Clone)]
+pub enum HandDistribution {
+    /// Degenerate point mass at a single known combo (used by KnownHands).
+    PointMass(HoleCombo),
+    /// A weighted distribution over combos (used by UniformRandom and the
+    /// future ML estimator).
+    Weighted(WeightedCombos),
+}
+
+impl HandDistribution {
+    /// Draw one hole-card combo, avoiding every card in `dead`. Returns `None`
+    /// if no legal combo remains.
+    pub fn sample<R: RngExt>(&self, rng: &mut R, dead: &CardBitSet) -> Option<HoleCombo> {
+        match self {
+            HandDistribution::PointMass(combo) => {
+                if dead.contains(combo.lo) || dead.contains(combo.hi) {
+                    None
+                } else {
+                    Some(*combo)
+                }
+            }
+            HandDistribution::Weighted(w) => {
+                let alive = |c: &HoleCombo| !dead.contains(c.lo) && !dead.contains(c.hi);
+                let total: f32 = w
+                    .weights
+                    .iter()
+                    .filter(|(c, wt)| *wt > 0.0 && alive(c))
+                    .map(|(_, wt)| *wt)
+                    .sum();
+                if total <= 0.0 {
+                    return None;
+                }
+                let mut target = rng.random::<f32>() * total;
+                for (combo, wt) in &w.weights {
+                    if *wt > 0.0 && alive(combo) {
+                        target -= *wt;
+                        if target <= 0.0 {
+                            return Some(*combo);
+                        }
+                    }
+                }
+                // Floating-point guard: return the last surviving combo.
+                w.weights
+                    .iter()
+                    .rev()
+                    .find(|(c, wt)| *wt > 0.0 && alive(c))
+                    .map(|(c, _)| *c)
+            }
         }
     }
-    combos
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::CardBitSet;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     #[test]
     fn canonicalizes_regardless_of_order() {
@@ -52,5 +115,51 @@ mod tests {
         assert_eq!(combos.len(), 1326);
         let unique: std::collections::HashSet<_> = combos.iter().copied().collect();
         assert_eq!(unique.len(), 1326);
+    }
+
+    #[test]
+    fn point_mass_returns_its_combo_when_alive() {
+        let combo = HoleCombo::new(Card::from(3), Card::from(9));
+        let dist = HandDistribution::PointMass(combo);
+        let mut rng = StdRng::seed_from_u64(1);
+        assert_eq!(dist.sample(&mut rng, &CardBitSet::new()), Some(combo));
+    }
+
+    #[test]
+    fn point_mass_returns_none_when_dead() {
+        let combo = HoleCombo::new(Card::from(3), Card::from(9));
+        let dist = HandDistribution::PointMass(combo);
+        let mut dead = CardBitSet::new();
+        dead.insert(Card::from(9));
+        let mut rng = StdRng::seed_from_u64(1);
+        assert_eq!(dist.sample(&mut rng, &dead), None);
+    }
+
+    #[test]
+    fn weighted_never_returns_a_dead_card() {
+        let dist = HandDistribution::Weighted(WeightedCombos {
+            weights: all_hole_combos().into_iter().map(|c| (c, 1.0)).collect(),
+        });
+        let mut dead = CardBitSet::new();
+        for i in 0u8..50 {
+            dead.insert(Card::from(i));
+        }
+        // Only cards 50 and 51 remain alive → the only legal combo.
+        let mut rng = StdRng::seed_from_u64(7);
+        let drawn = dist.sample(&mut rng, &dead).unwrap();
+        assert_eq!(drawn, HoleCombo::new(Card::from(50), Card::from(51)));
+    }
+
+    #[test]
+    fn weighted_returns_none_when_all_dead() {
+        let dist = HandDistribution::Weighted(WeightedCombos {
+            weights: all_hole_combos().into_iter().map(|c| (c, 1.0)).collect(),
+        });
+        let mut dead = CardBitSet::new();
+        for i in 0u8..52 {
+            dead.insert(Card::from(i));
+        }
+        let mut rng = StdRng::seed_from_u64(7);
+        assert_eq!(dist.sample(&mut rng, &dead), None);
     }
 }

--- a/src/arena/hand_estimator/distribution.rs
+++ b/src/arena/hand_estimator/distribution.rs
@@ -1,0 +1,56 @@
+//! The hole-card distribution type and its synchronous sampler.
+
+use crate::core::Card;
+
+/// A canonical, unordered pair of hole cards. `lo` is always the card with the
+/// smaller `u8` index, so `HoleCombo::new(a, b) == HoleCombo::new(b, a)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HoleCombo {
+    /// The card with the smaller `u8` index.
+    pub lo: Card,
+    /// The card with the larger `u8` index.
+    pub hi: Card,
+}
+
+impl HoleCombo {
+    /// Build a canonical combo from two distinct cards.
+    pub fn new(a: Card, b: Card) -> Self {
+        if u8::from(a) <= u8::from(b) {
+            Self { lo: a, hi: b }
+        } else {
+            Self { lo: b, hi: a }
+        }
+    }
+}
+
+/// All 1326 canonical two-card combinations from a 52-card deck.
+pub fn all_hole_combos() -> Vec<HoleCombo> {
+    let mut combos = Vec::with_capacity(1326);
+    for a in 0u8..52 {
+        for b in (a + 1)..52 {
+            combos.push(HoleCombo::new(Card::from(a), Card::from(b)));
+        }
+    }
+    combos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_regardless_of_order() {
+        let a = Card::from(40);
+        let b = Card::from(7);
+        assert_eq!(HoleCombo::new(a, b), HoleCombo::new(b, a));
+        assert_eq!(HoleCombo::new(a, b).lo, b);
+    }
+
+    #[test]
+    fn enumerates_exactly_1326_unique_combos() {
+        let combos = all_hole_combos();
+        assert_eq!(combos.len(), 1326);
+        let unique: std::collections::HashSet<_> = combos.iter().copied().collect();
+        assert_eq!(unique.len(), 1326);
+    }
+}

--- a/src/arena/hand_estimator/estimators.rs
+++ b/src/arena/hand_estimator/estimators.rs
@@ -1,0 +1,90 @@
+//! Built-in estimators: known hands (default) and uniform-random.
+
+use async_trait::async_trait;
+
+use crate::arena::GameState;
+use crate::core::{Card, CardBitSet};
+
+use super::{
+    GameLog, HandDistribution, HandDistributionEstimator, HoleCombo, OpponentRanges,
+};
+
+/// True when `seat` still holds hidden cards in the hand (active or all-in).
+fn seat_in_hand(game_state: &GameState, seat: usize) -> bool {
+    game_state.player_active.get(seat) || game_state.player_all_in.get(seat)
+}
+
+/// The two hole cards for `seat`: the seat's hand minus the shared board.
+fn hole_cards(game_state: &GameState, seat: usize, board: &CardBitSet) -> Option<HoleCombo> {
+    let hole: Vec<Card> = game_state.hands[seat]
+        .iter()
+        .filter(|c| !board.contains(*c))
+        .collect();
+    if hole.len() == 2 {
+        Some(HoleCombo::new(hole[0], hole[1]))
+    } else {
+        None
+    }
+}
+
+/// Estimator that returns each opponent's true hand as a point mass. This is
+/// the default; with it, `sample_world` reproduces the real hands exactly, so
+/// CFR behavior is identical to the pre-estimator engine.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct KnownHandsEstimator;
+
+#[async_trait]
+impl HandDistributionEstimator for KnownHandsEstimator {
+    async fn estimate(
+        &self,
+        game_state: &GameState,
+        _history: Option<&GameLog<'_>>,
+    ) -> OpponentRanges {
+        let perspective_idx = game_state.to_act_idx();
+        let board: CardBitSet = game_state.board.iter().copied().collect();
+        let mut per_seat = Vec::with_capacity(game_state.num_players);
+        for seat in 0..game_state.num_players {
+            if seat == perspective_idx || !seat_in_hand(game_state, seat) {
+                per_seat.push(None);
+                continue;
+            }
+            per_seat.push(hole_cards(game_state, seat, &board).map(HandDistribution::PointMass));
+        }
+        OpponentRanges::new(per_seat)
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arena::GameStateBuilder;
+    use crate::core::Hand;
+
+    fn two_player_state() -> GameState {
+        // Two players, each dealt distinct hole cards, no board.
+        let mut gs = GameStateBuilder::default()
+            .num_players_with_stack(2, 100.0)
+            .big_blind(2.0)
+            .build()
+            .unwrap();
+        gs.hands[0] = Hand::new_with_cards(vec![Card::from(0), Card::from(1)]);
+        gs.hands[1] = Hand::new_with_cards(vec![Card::from(2), Card::from(3)]);
+        gs.round_data.to_act_idx = 0;
+        gs
+    }
+
+    #[tokio::test]
+    async fn returns_point_mass_for_opponent_only() {
+        let mut gs = two_player_state();
+        gs.round_data.to_act_idx = 0;
+        let ranges = KnownHandsEstimator.estimate(&gs, None).await;
+        assert!(ranges.get(0).is_none(), "acting seat must be None");
+        match ranges.get(1) {
+            Some(HandDistribution::PointMass(c)) => {
+                assert_eq!(*c, HoleCombo::new(Card::from(2), Card::from(3)));
+            }
+            other => panic!("expected point mass, got {other:?}"),
+        }
+    }
+}

--- a/src/arena/hand_estimator/estimators.rs
+++ b/src/arena/hand_estimator/estimators.rs
@@ -7,6 +7,7 @@ use crate::core::{Card, CardBitSet};
 
 use super::{
     GameLog, HandDistribution, HandDistributionEstimator, HoleCombo, OpponentRanges,
+    WeightedCombos, all_hole_combos,
 };
 
 /// True when `seat` still holds hidden cards in the hand (active or all-in).
@@ -42,17 +43,48 @@ impl HandDistributionEstimator for KnownHandsEstimator {
     ) -> OpponentRanges {
         let perspective_idx = game_state.to_act_idx();
         let board: CardBitSet = game_state.board.iter().copied().collect();
-        let mut per_seat = Vec::with_capacity(game_state.num_players);
-        for seat in 0..game_state.num_players {
-            if seat == perspective_idx || !seat_in_hand(game_state, seat) {
-                per_seat.push(None);
-                continue;
-            }
-            per_seat.push(hole_cards(game_state, seat, &board).map(HandDistribution::PointMass));
-        }
+        let per_seat = (0..game_state.num_players)
+            .map(|seat| {
+                if seat == perspective_idx || !seat_in_hand(game_state, seat) {
+                    None
+                } else {
+                    hole_cards(game_state, seat, &board).map(HandDistribution::PointMass)
+                }
+            })
+            .collect();
         OpponentRanges::new(per_seat)
     }
+}
 
+/// Estimator that assigns each opponent a uniform distribution over all combos
+/// (dead-card filtering happens at sample time). The no-ML "play against a
+/// range" baseline and the plumbing's test fixture.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UniformRandomEstimator;
+
+#[async_trait]
+impl HandDistributionEstimator for UniformRandomEstimator {
+    async fn estimate(
+        &self,
+        game_state: &GameState,
+        _history: Option<&GameLog<'_>>,
+    ) -> OpponentRanges {
+        let perspective_idx = game_state.to_act_idx();
+        let weights: Vec<(HoleCombo, f32)> =
+            all_hole_combos().into_iter().map(|c| (c, 1.0)).collect();
+        let per_seat = (0..game_state.num_players)
+            .map(|seat| {
+                if seat == perspective_idx || !seat_in_hand(game_state, seat) {
+                    None
+                } else {
+                    Some(HandDistribution::Weighted(WeightedCombos {
+                        weights: weights.clone(),
+                    }))
+                }
+            })
+            .collect();
+        OpponentRanges::new(per_seat)
+    }
 }
 
 #[cfg(test)]
@@ -70,7 +102,6 @@ mod tests {
             .unwrap();
         gs.hands[0] = Hand::new_with_cards(vec![Card::from(0), Card::from(1)]);
         gs.hands[1] = Hand::new_with_cards(vec![Card::from(2), Card::from(3)]);
-        gs.round_data.to_act_idx = 0;
         gs
     }
 
@@ -85,6 +116,18 @@ mod tests {
                 assert_eq!(*c, HoleCombo::new(Card::from(2), Card::from(3)));
             }
             other => panic!("expected point mass, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn uniform_returns_weighted_for_opponent_only() {
+        let mut gs = two_player_state();
+        gs.round_data.to_act_idx = 1;
+        let ranges = UniformRandomEstimator.estimate(&gs, None).await;
+        assert!(ranges.get(1).is_none(), "acting seat must be None");
+        match ranges.get(0) {
+            Some(HandDistribution::Weighted(w)) => assert_eq!(w.weights.len(), 1326),
+            other => panic!("expected weighted, got {other:?}"),
         }
     }
 }

--- a/src/arena/hand_estimator/mod.rs
+++ b/src/arena/hand_estimator/mod.rs
@@ -1,0 +1,8 @@
+//! Opponent hand-distribution estimation for CFR.
+//!
+//! A `HandDistributionEstimator` guesses, from the perspective of the seat
+//! that is about to act, the hole-card distribution of every *other* live
+//! player. The CFR engine calls it once per `act()` and then samples concrete
+//! worlds from the result (see `world::sample_world`). This lets the solver
+//! play against ranges instead of the pinned, fully-known hands.
+

--- a/src/arena/hand_estimator/mod.rs
+++ b/src/arena/hand_estimator/mod.rs
@@ -6,3 +6,7 @@
 //! worlds from the result (see `world::sample_world`). This lets the solver
 //! play against ranges instead of the pinned, fully-known hands.
 
+mod distribution;
+
+pub use distribution::{HoleCombo, all_hole_combos};
+

--- a/src/arena/hand_estimator/mod.rs
+++ b/src/arena/hand_estimator/mod.rs
@@ -6,7 +6,77 @@
 //! worlds from the result (see `world::sample_world`). This lets the solver
 //! play against ranges instead of the pinned, fully-known hands.
 
+use async_trait::async_trait;
+
+use crate::arena::GameState;
+use crate::arena::action::Action;
+
 mod distribution;
 
 pub use distribution::{HandDistribution, HoleCombo, WeightedCombos, all_hole_combos};
 
+/// A read-only view over the actions recorded so far in the current hand,
+/// passed to estimators that need history. Wraps the raw `Action` stream; kept
+/// as a struct so fields can be added later without changing the trait.
+pub struct GameLog<'a> {
+    /// The actions of the current hand, in order.
+    pub actions: &'a [Action],
+}
+
+/// One hole-card distribution per seat, from the acting agent's perspective.
+/// `None` for the acting seat, folded seats, and any seat with no hidden cards.
+#[derive(Debug, Clone, Default)]
+pub struct OpponentRanges {
+    per_seat: Vec<Option<HandDistribution>>,
+}
+
+impl OpponentRanges {
+    /// Build ranges from a per-seat vector indexed by seat number.
+    pub fn new(per_seat: Vec<Option<HandDistribution>>) -> Self {
+        Self { per_seat }
+    }
+
+    /// The distribution for `seat`, or `None` if that seat is not re-sampled.
+    pub fn get(&self, seat: usize) -> Option<&HandDistribution> {
+        self.per_seat.get(seat).and_then(|o| o.as_ref())
+    }
+}
+
+/// Estimates opponents' hole-card distributions. The ML model implements this.
+#[async_trait]
+pub trait HandDistributionEstimator: Send + Sync {
+    /// Estimate the hole-card distribution of every *other* live player from
+    /// the perspective of `perspective_idx` (the seat about to act). `history`
+    /// is `None` unless the agent assembled a log for a `needs_history()`
+    /// estimator.
+    async fn estimate(
+        &self,
+        game_state: &GameState,
+        history: Option<&GameLog<'_>>,
+    ) -> OpponentRanges;
+
+    /// Whether this estimator needs the game log. Default `false`, so the CFR
+    /// agent attaches no historian and passes `history: None`.
+    fn needs_history(&self) -> bool {
+        false
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opponent_ranges_get_is_bounds_safe() {
+        let ranges = OpponentRanges::new(vec![None, None]);
+        assert!(ranges.get(0).is_none());
+        assert!(ranges.get(99).is_none());
+    }
+
+    #[test]
+    fn estimator_is_object_safe() {
+        // Compile-time proof that the trait can be boxed as a trait object.
+        fn _assert(_: std::sync::Arc<dyn HandDistributionEstimator>) {}
+    }
+}

--- a/src/arena/hand_estimator/mod.rs
+++ b/src/arena/hand_estimator/mod.rs
@@ -8,5 +8,5 @@
 
 mod distribution;
 
-pub use distribution::{HoleCombo, all_hole_combos};
+pub use distribution::{HandDistribution, HoleCombo, WeightedCombos, all_hole_combos};
 

--- a/src/arena/hand_estimator/mod.rs
+++ b/src/arena/hand_estimator/mod.rs
@@ -15,7 +15,7 @@ mod distribution;
 mod estimators;
 
 pub use distribution::{HandDistribution, HoleCombo, WeightedCombos, all_hole_combos};
-pub use estimators::KnownHandsEstimator;
+pub use estimators::{KnownHandsEstimator, UniformRandomEstimator};
 
 /// A read-only view over the actions recorded so far in the current hand,
 /// passed to estimators that need history. Wraps the raw `Action` stream; kept

--- a/src/arena/hand_estimator/mod.rs
+++ b/src/arena/hand_estimator/mod.rs
@@ -13,9 +13,11 @@ use crate::arena::action::Action;
 
 mod distribution;
 mod estimators;
+mod world;
 
 pub use distribution::{HandDistribution, HoleCombo, WeightedCombos, all_hole_combos};
 pub use estimators::{KnownHandsEstimator, UniformRandomEstimator};
+pub use world::sample_world;
 
 /// A read-only view over the actions recorded so far in the current hand,
 /// passed to estimators that need history. Wraps the raw `Action` stream; kept
@@ -48,9 +50,9 @@ impl OpponentRanges {
 #[async_trait]
 pub trait HandDistributionEstimator: Send + Sync {
     /// Estimate the hole-card distribution of every *other* live player from
-    /// the perspective of `perspective_idx` (the seat about to act). `history`
-    /// is `None` unless the agent assembled a log for a `needs_history()`
-    /// estimator.
+    /// the perspective of the seat about to act (`game_state.to_act_idx()`).
+    /// `history` is `None` unless the agent assembled a log for a
+    /// `needs_history()` estimator.
     async fn estimate(
         &self,
         game_state: &GameState,
@@ -62,7 +64,6 @@ pub trait HandDistributionEstimator: Send + Sync {
     fn needs_history(&self) -> bool {
         false
     }
-
 }
 
 #[cfg(test)]

--- a/src/arena/hand_estimator/mod.rs
+++ b/src/arena/hand_estimator/mod.rs
@@ -12,8 +12,10 @@ use crate::arena::GameState;
 use crate::arena::action::Action;
 
 mod distribution;
+mod estimators;
 
 pub use distribution::{HandDistribution, HoleCombo, WeightedCombos, all_hole_combos};
+pub use estimators::KnownHandsEstimator;
 
 /// A read-only view over the actions recorded so far in the current hand,
 /// passed to estimators that need history. Wraps the raw `Action` stream; kept

--- a/src/arena/hand_estimator/world.rs
+++ b/src/arena/hand_estimator/world.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use crate::arena::GameState;
 use crate::core::{Card, CardBitSet, Hand};
 
-use super::{OpponentRanges};
+use super::OpponentRanges;
 
 /// How many times to retry a colliding draw before falling back to a uniform
 /// draw from the remaining deck.
@@ -15,11 +15,8 @@ const MAX_RESAMPLE_RETRIES: usize = 16;
 /// `ranges`, keeping the acting agent's own cards and the board fixed. Each
 /// re-dealt seat's hand is rebuilt as its new hole cards plus the shared board,
 /// preserving the engine invariant that a player's `Hand` contains the board.
-pub fn sample_world<R: Rng>(
-    ranges: &OpponentRanges,
-    base: &GameState,
-    rng: &mut R,
-) -> GameState {
+pub fn sample_world<R: Rng>(ranges: &OpponentRanges, base: &GameState, rng: &mut R) -> GameState {
+    let acting_idx = base.to_act_idx();
     let mut gs = base.clone();
     let board: Vec<Card> = base.board.iter().copied().collect();
 
@@ -31,7 +28,7 @@ pub fn sample_world<R: Rng>(
         dead.insert(*c);
     }
     for seat in 0..base.num_players {
-        if ranges.get(seat).is_none() {
+        if seat == acting_idx || ranges.get(seat).is_none() {
             for c in base.hands[seat].iter() {
                 dead.insert(c);
             }
@@ -39,6 +36,9 @@ pub fn sample_world<R: Rng>(
     }
 
     for seat in 0..base.num_players {
+        if seat == acting_idx {
+            continue;
+        }
         let Some(dist) = ranges.get(seat) else {
             continue;
         };
@@ -52,10 +52,16 @@ pub fn sample_world<R: Rng>(
                 break;
             }
         }
-        let (lo, hi) = match combo {
+        let (lo, hi) = match combo.or_else(|| uniform_pair_from_deck(&dead, rng)) {
             Some(pair) => pair,
             None => {
-                match uniform_pair_from_deck(&dead, rng) { Some(pair) => pair, None => continue }
+                // The deck is exhausted (cannot happen in a valid game): keep
+                // the seat's original hand and mark its cards dead so later
+                // seats don't collide with it.
+                for c in base.hands[seat].iter() {
+                    dead.insert(c);
+                }
+                continue;
             }
         };
 
@@ -76,13 +82,10 @@ pub fn sample_world<R: Rng>(
 
 /// Draw two distinct cards uniformly from the cards not in `dead`.
 fn uniform_pair_from_deck<R: Rng>(dead: &CardBitSet, rng: &mut R) -> Option<(Card, Card)> {
-    let mut live = CardBitSet::default(); // full 52-card deck
-    for i in 0u8..52 {
-        let card = Card::from(i);
-        if dead.contains(card) {
-            live.remove(card);
-        }
-    }
+    let mut live: CardBitSet = (0u8..52)
+        .map(Card::from)
+        .filter(|c| !dead.contains(*c))
+        .collect();
     let first = live.sample_one(rng)?;
     live.remove(first);
     let second = live.sample_one(rng)?;
@@ -111,8 +114,7 @@ mod tests {
 
     #[tokio::test]
     async fn known_hands_round_trips_every_hand() {
-        let mut gs = two_player_state();
-        gs.round_data.to_act_idx = 0;
+        let gs = two_player_state();
         let ranges = KnownHandsEstimator.estimate(&gs, None).await;
         let mut rng = StdRng::seed_from_u64(42);
         let world = sample_world(&ranges, &gs, &mut rng);

--- a/src/arena/hand_estimator/world.rs
+++ b/src/arena/hand_estimator/world.rs
@@ -1,0 +1,139 @@
+//! Synchronous per-wave world sampling.
+
+use rand::Rng;
+
+use crate::arena::GameState;
+use crate::core::{Card, CardBitSet, Hand};
+
+use super::{OpponentRanges};
+
+/// How many times to retry a colliding draw before falling back to a uniform
+/// draw from the remaining deck.
+const MAX_RESAMPLE_RETRIES: usize = 16;
+
+/// Clone `base` and re-deal every *other* live player's hole cards from
+/// `ranges`, keeping the acting agent's own cards and the board fixed. Each
+/// re-dealt seat's hand is rebuilt as its new hole cards plus the shared board,
+/// preserving the engine invariant that a player's `Hand` contains the board.
+pub fn sample_world<R: Rng>(
+    ranges: &OpponentRanges,
+    base: &GameState,
+    rng: &mut R,
+) -> GameState {
+    let mut gs = base.clone();
+    let board: Vec<Card> = base.board.iter().copied().collect();
+
+    // Dead = board + every card held by a seat we are NOT re-sampling (the
+    // acting seat, folded seats, and any seat with no range). This removes
+    // folded/known cards from the live deck just like the real dealer.
+    let mut dead = CardBitSet::new();
+    for c in &board {
+        dead.insert(*c);
+    }
+    for seat in 0..base.num_players {
+        if ranges.get(seat).is_none() {
+            for c in base.hands[seat].iter() {
+                dead.insert(c);
+            }
+        }
+    }
+
+    for seat in 0..base.num_players {
+        let Some(dist) = ranges.get(seat) else {
+            continue;
+        };
+
+        // Try the distribution, retrying on collision, then fall back to a
+        // uniform draw from the live deck.
+        let mut combo = None;
+        for _ in 0..MAX_RESAMPLE_RETRIES {
+            if let Some(c) = dist.sample(rng, &dead) {
+                combo = Some((c.lo, c.hi));
+                break;
+            }
+        }
+        let (lo, hi) = match combo {
+            Some(pair) => pair,
+            None => {
+                match uniform_pair_from_deck(&dead, rng) { Some(pair) => pair, None => continue }
+            }
+        };
+
+        dead.insert(lo);
+        dead.insert(hi);
+
+        let mut hand = Hand::new();
+        hand.insert(lo);
+        hand.insert(hi);
+        for c in &board {
+            hand.insert(*c);
+        }
+        gs.hands[seat] = hand;
+    }
+
+    gs
+}
+
+/// Draw two distinct cards uniformly from the cards not in `dead`.
+fn uniform_pair_from_deck<R: Rng>(dead: &CardBitSet, rng: &mut R) -> Option<(Card, Card)> {
+    let mut live = CardBitSet::default(); // full 52-card deck
+    for i in 0u8..52 {
+        let card = Card::from(i);
+        if dead.contains(card) {
+            live.remove(card);
+        }
+    }
+    let first = live.sample_one(rng)?;
+    live.remove(first);
+    let second = live.sample_one(rng)?;
+    Some((first, second))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arena::GameStateBuilder;
+    use crate::arena::hand_estimator::{HandDistributionEstimator, KnownHandsEstimator};
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    fn two_player_state() -> GameState {
+        let mut gs = GameStateBuilder::default()
+            .num_players_with_stack(2, 100.0)
+            .big_blind(2.0)
+            .build()
+            .unwrap();
+        gs.hands[0] = Hand::new_with_cards(vec![Card::from(0), Card::from(1)]);
+        gs.hands[1] = Hand::new_with_cards(vec![Card::from(2), Card::from(3)]);
+        gs.round_data.to_act_idx = 0;
+        gs
+    }
+
+    #[tokio::test]
+    async fn known_hands_round_trips_every_hand() {
+        let mut gs = two_player_state();
+        gs.round_data.to_act_idx = 0;
+        let ranges = KnownHandsEstimator.estimate(&gs, None).await;
+        let mut rng = StdRng::seed_from_u64(42);
+        let world = sample_world(&ranges, &gs, &mut rng);
+        assert_eq!(world.hands[0], gs.hands[0]);
+        assert_eq!(world.hands[1], gs.hands[1]);
+    }
+
+    #[tokio::test]
+    async fn sampled_world_has_no_duplicate_cards() {
+        use crate::arena::hand_estimator::UniformRandomEstimator;
+        let gs = two_player_state();
+        let ranges = UniformRandomEstimator.estimate(&gs, None).await;
+        let mut rng = StdRng::seed_from_u64(99);
+        let world = sample_world(&ranges, &gs, &mut rng);
+        // Acting seat unchanged.
+        assert_eq!(world.hands[0], gs.hands[0]);
+        // Opponent's two cards must not collide with the acting seat's cards.
+        let mut seen = CardBitSet::new();
+        for c in world.hands[0].iter().chain(world.hands[1].iter()) {
+            assert!(!seen.contains(c), "duplicate card {c:?} across seats");
+            seen.insert(c);
+        }
+    }
+}

--- a/src/arena/historian/mod.rs
+++ b/src/arena/historian/mod.rs
@@ -14,6 +14,8 @@ pub enum HistorianLock {
     StatsStorageWrite,
     /// Lock on the shared `VecHistorian` records storage.
     VecRecords,
+    /// Lock on a CFR `HandLog` tail buffer.
+    HandLog,
 }
 
 impl std::fmt::Display for HistorianLock {
@@ -22,6 +24,7 @@ impl std::fmt::Display for HistorianLock {
             Self::StatsStorageRead => write!(f, "StatsStorage read"),
             Self::StatsStorageWrite => write!(f, "StatsStorage write"),
             Self::VecRecords => write!(f, "VecHistorian records"),
+            Self::HandLog => write!(f, "HandLog tail"),
         }
     }
 }

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -140,6 +140,7 @@ pub mod cfr;
 pub mod competition;
 pub mod errors;
 pub mod game_state;
+pub mod hand_estimator;
 pub mod historian;
 pub mod rng;
 pub mod sim_builder;

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -157,6 +157,7 @@ pub use game_state::{
     CloneGameStateGenerator, GameState, GameStateBuilder, GameStateGenerator,
     RandomGameStateGenerator,
 };
+pub use hand_estimator::{GameLog, HandDistributionEstimator, OpponentRanges};
 pub use historian::{CloneHistorianGenerator, Historian, HistorianError, HistorianGenerator};
 pub use rng::seeded_rng;
 pub use sim_builder::HoldemSimulationBuilder;

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -201,20 +201,18 @@ impl HoldemSimulationBuilder {
             .agents
             .unwrap_or_else(|| build_agents(game_state.hands.len()));
 
-        let has_cfr_context = self.cfr_state.is_some();
-
-        // Skip agent historian collection when CFR context is set,
-        // since CFR agents don't provide historians — the CFRHistorian
-        // is provided via cfr_context() instead.
-        let mut historians: Vec<_> = if has_cfr_context {
-            self.historians.into_iter().collect()
-        } else {
-            let agent_historians = agents.iter().filter_map(|a| a.historian());
-            self.historians
-                .into_iter()
-                .chain(agent_historians)
-                .collect()
-        };
+        // Collect historians from explicit registration plus any provided by
+        // agents. CFR agents only provide a historian when their estimator
+        // needs the game log (HandDistributionEstimator::needs_history); the
+        // default returns None, so this is a no-op for ordinary CFR sims. The
+        // CFRHistorian (CFR tree traversal) is added separately below when a
+        // CFR context is present.
+        let agent_historians = agents.iter().filter_map(|a| a.historian());
+        let mut historians: Vec<_> = self
+            .historians
+            .into_iter()
+            .chain(agent_historians)
+            .collect();
 
         // If CFR context was provided, create and add a CFRHistorian.
         if let (Some(cfr_state), Some(traversal_set)) = (self.cfr_state, self.cfr_traversal_set) {

--- a/src/arena/sim_builder.rs
+++ b/src/arena/sim_builder.rs
@@ -202,11 +202,10 @@ impl HoldemSimulationBuilder {
             .unwrap_or_else(|| build_agents(game_state.hands.len()));
 
         // Collect historians from explicit registration plus any provided by
-        // agents. CFR agents only provide a historian when their estimator
-        // needs the game log (HandDistributionEstimator::needs_history); the
-        // default returns None, so this is a no-op for ordinary CFR sims. The
-        // CFRHistorian (CFR tree traversal) is added separately below when a
-        // CFR context is present.
+        // agents. CFR agents self-provide a `HandLogHistorian` ONLY at depth 0
+        // and only when their estimator needs the game log; sub-agents and the
+        // default estimator return `None`, so this is a no-op for ordinary CFR
+        // sims. The CFRHistorian (tree traversal) is added separately below.
         let agent_historians = agents.iter().filter_map(|a| a.historian());
         let mut historians: Vec<_> = self
             .historians


### PR DESCRIPTION
This branch teaches the CFR solver to play against **estimated opponent ranges**
instead of the pinned, fully-known opponent hands it currently sees. It lays the
trait, sampling, and hand-history plumbing needed for a future ML range model,
while keeping today's behavior **byte-for-byte identical** by default.

Today, when a CFR agent explores, every sub-simulation knows its opponents'
exact hole cards. That is unrealistic and makes the solver clairvoyant. This
change introduces a `HandDistributionEstimator` abstraction: once per `act()`,
the agent asks the estimator for each opponent's hole-card distribution, and
each exploration wave samples a fresh "world" (concrete opponent hands) from
those distributions — keeping the acting seat's own cards and the board fixed.

The default estimator (`KnownHandsEstimator`) returns each opponent's true hand
as a point mass, so `sample_world` reproduces the real hands and **never touches
the RNG**. With it, the engine is identical to the pre-estimator solver. Opting
into ranges is a one-line config change.

## What's new

### `arena::hand_estimator` module

- **`HandDistributionEstimator` trait** — `async estimate(game_state, history) ->
  OpponentRanges`, from the perspective of the seat about to act. Object-safe
  (`Arc<dyn ...>`), `Send + Sync`. This is the seam the ML model will implement.
- **`HandDistribution`** — a synchronous sampler: `PointMass(HoleCombo)` for
  known hands, or `Weighted(WeightedCombos)` for a sparse `(combo, weight)`
  distribution. `sample()` performs dead-card filtering and weight normalization
  over surviving combos.
- **`HoleCombo` / `all_hole_combos()`** — a canonical unordered card pair and an
  enumeration of all 1326 two-card combinations.
- **`OpponentRanges`** — one distribution per seat (`None` for the acting seat,
  folded seats, and seats with no hidden cards).
- **`sample_world()`** — clones the base `GameState` and re-deals every *other*
  live player's hole cards from their range, tracking dead cards (board + known/
  folded hands) like the real dealer. Retries on collision, then falls back to a
  uniform draw from the live deck; preserves the engine invariant that a
  player's `Hand` contains the board.
- **Built-in estimators**: `KnownHandsEstimator` (default; true hands as point
  masses) and `UniformRandomEstimator` (uniform over the remaining deck — the
  no-ML "play against a range" baseline and a test fixture).

### CFR engine integration

- Each `act()` calls the estimator once, then samples a per-wave world for
  recursive (non-fast-forward) waves. Fast-forward waves are leaves and never
  re-sample.
- The sampled world is wrapped in an `Arc` once and shared between the inline
  borrow and the spawn snapshot, avoiding a second `GameState` clone.
- `CFRAgent` / `CFRAgentBuilder` gain an `estimator` field, defaulting to
  `KnownHandsEstimator`.

### Copy-on-write hand history (`HandLog`)

History-aware estimators need the betting path that led to the current state.
`HandLog` provides it without per-agent cloning:

- The real hand is frozen **once** at depth 0 into a shared immutable `prefix`
  (`Arc<[Action]>`); each simulation owns a short `tail` of its own simulated
  actions, copied on descent (`spawn_child`) so a child sees the full path.
- No mutable buffer is shared across concurrent tasks — the prefix is read-only
  and each sim owns its tail (`SmallVec` with 16-action inline capacity).
- `HandLogHistorian` is the single per-sim writer. CFR agents now self-provide
  it via `Agent::historian()` — **only at depth 0 and only when the estimator
  needs history** — so the default path attaches no historian at all.
- This replaces the previous per-agent `VecHistorian` + `GameState`-clone
  approach for hand history, dropping those clones from the hot path.

### Config surface

- New `EstimatorConfig` enum (`"known"` / `"uniform"`, default `known`) and a
  `hand_estimator` field on all CFR agent configs (`cfr_basic`, `cfr_simple`,
  `cfr_configurable`, `cfr_preflop_chart`). Existing configs parse unchanged.
- `examples/configs/cfr_configurable.json` documents the new field.

### Supporting changes

- `sim_builder` now collects agent-provided historians **even when a CFR context
  is set** (previously skipped). Safe because CFR agents only return a historian
  at depth 0 with a history-needing estimator; the default and sub-agents return
  `None`.
- `HistorianLock::HandLog` variant for poisoned-lock error reporting.
- Public re-exports: `GameLog`, `HandDistributionEstimator`, `OpponentRanges`.

## Behavior & compatibility

- **Default behavior is unchanged.** `KnownHandsEstimator` reproduces the real
  hands and never draws from the RNG, so the solver is byte-for-byte identical
  to master. Existing configs and saved experiments are unaffected.
- Opting into ranges is `"hand_estimator": "uniform"` (or a future ML estimator).

## Testing

- Unit tests for combo canonicalization/enumeration (exactly 1326), weighted and
  point-mass sampling with dead-card filtering, and `sample_world` round-tripping
  known hands / producing no duplicate cards.
- `HandLog` tests for freeze/spawn-child independence, full-path-through-descent
  ordering, and concurrent writes via `HandLogHistorian`.
- Config tests: `EstimatorConfig` defaults to `known`, JSON round-trips, builds
  the right estimator, and all CFR variants parse `hand_estimator`.
- Engine-level tests: exploration runs cleanly under `UniformRandomEstimator`,
  and an end-to-end CFR sim proves the agent historian is collected and its
  shared log populated even with a CFR context set.
- New benchmark group (`build_sim_with_history`) isolates the `HandLog`
  recording overhead by using a `needs_history` estimator with sampling
  semantics identical to `KnownHandsEstimator`.

## Why this matters

This is the groundwork for replacing the solver's clairvoyance with a learned
opponent model. The trait boundary, world sampling, and zero-copy hand history
are all in place; dropping in an ML `HandDistributionEstimator` is now a
localized change rather than an engine rewrite — and it ships behind a default
that changes nothing until explicitly enabled.
