### PR TITLE
build: pin x86-64 to v3 baseline and trim published crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,12 @@
+# x86-64: pin to the v3 micro-arch level — AVX2, FMA, BMI1/2, and the bit ops we
+# lean on (popcnt, lzcnt, tzcnt). Floor is Intel Haswell (2013) / AMD Excavator
+# (2015), which covers every currently-supported Intel Mac. x86-ONLY: keep this
+# out of any global [build] table or the aarch64 build will fail on unknown CPU.
+# Stack size of 40MB for the deep CFR recursion.
 [target.x86_64-unknown-linux-gnu]
-# Use Native CPU
-# and a stack size of: 40MB
 rustflags = [
   "-C",
-  "target-cpu=native",
+  "target-cpu=x86-64-v3",
   "-C",
   "link-args=-Wl,-zstack-size=47185920",
   "-C",
@@ -11,7 +14,9 @@ rustflags = [
 ]
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "target-cpu=native", "-C", "force-frame-pointers=yes"]
+rustflags = ["-C", "target-cpu=x86-64-v3", "-C", "force-frame-pointers=yes"]
 
+# Apple Silicon is aarch64 — the x86-64-v* levels don't apply. apple-m1 is the
+# correct floor (M1 was the first Apple Silicon Mac).
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "target-cpu=native", "-C", "force-frame-pointers=yes"]
+rustflags = ["-C", "target-cpu=apple-m1", "-C", "force-frame-pointers=yes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,18 @@ description = "A library to help with any Rust code dealing with poker. This inc
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2024"
+# Dev-only files that have no business in the published crate. `.cargo/` build
+# config only applies to in-tree builds (cargo invocation dir, not the package),
+# so consumers ignore it anyway; the rest is tooling, CI, agent notes, and
+# generated demo artifacts. docs/arena_tui.png is kept — the README embeds it.
+exclude = [
+  ".cargo/",
+  ".github/",
+  "CLAUDE.md",
+  "mise.toml",
+  "mise.lock",
+  "examples/exports/",
+]
 
 [dependencies]
 rand = { version = "~0.10.1" }


### PR DESCRIPTION
Summary:
Replace target-cpu=native with portable per-arch baselines so release builds
are fast yet reproducible across machines. x86-64 (Linux + Intel Mac) pins to
x86-64-v3, which enables the hardware popcnt/lzcnt/bmi1/bmi2 instructions our
bitset code relies on plus AVX2/FMA, with a floor of Haswell-2013 / every
currently-supported Intel Mac. Apple Silicon pins to apple-m1 (x86-64-v* is an
x86-only concept and would fail on aarch64). These rustflags only affect
in-tree builds; crates.io consumers still compile at their own default
baseline, so cargo install stays portable.

Also add a Cargo.toml exclude list to keep dev-only files out of the published
crate: .cargo/ (build config, ignored by consumers anyway), .github/ CI,
CLAUDE.md agent notes, mise tooling, and generated examples/exports artifacts.
Trims the package from 200 to 191 files. docs/arena_tui.png is kept because the
README embeds it.

Test Plan:
- cargo build --release --features rsp (compiles clean under x86-64-v3)
- cargo package --list --allow-dirty (excluded paths gone, screenshot retained,
  191 files)
